### PR TITLE
Add ATLAS tables

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -34,6 +34,7 @@ export default defineConfig({
         tabContentAutoImport,
         "@components/Callout.astro",
         "@components/Accordion.astro",
+        "@components/ListTable.astro",
       ],
     }),
     // Enable Preact to support Preact JSX components.

--- a/src/components/ListTable.astro
+++ b/src/components/ListTable.astro
@@ -1,0 +1,22 @@
+---
+import BuildListTable from "@components/atlas/BuildListTable.tsx";
+
+export interface Props {
+  search: boolean
+  resizable: boolean
+  bordered: boolean
+}
+
+const { search = false, resizable = false, bordered = false } = Astro.props as Props;
+
+// Store the content contained within the Accordion as a string.
+// This string is converted to HTML inside the atlas/BuildAccordion.jsx file.
+
+let content = "";
+
+if (Astro.slots.has("default")) {
+  content = await Astro.slots.render("default");
+}
+---
+
+<BuildListTable client:only="react" resizable={resizable} bordered={bordered} search={search} content={content} />

--- a/src/components/atlas/BuildListTable.tsx
+++ b/src/components/atlas/BuildListTable.tsx
@@ -1,0 +1,116 @@
+/** @jsxImportSource react */
+import { TableV2, Input } from "@adjust/components";
+import type { FC } from "react";
+import type { TableColumnTypes } from "@adjust/components";
+import { useState } from "react";
+
+// Create an interface for the cells. These can be string pairs of any accessor and value.
+
+interface ColumnCell {
+  [key: string]: string;
+}
+
+const BuildListTable: FC<{
+  content: string;
+  search: boolean;
+  resizable: boolean;
+  bordered: boolean;
+}> = (props) => {
+  // Set up a blank string for the search term
+
+  const [searchTerm, setSearchTerm] = useState("");
+
+  // The Atlas component passes the body content as a string of HTML.
+  // We convert this to HTML using the `dangerouslySetInnerHTML` function.
+
+  const content = <div dangerouslySetInnerHTML={{ __html: props.content }} />;
+
+  // In order to iterate through the list items, we create a new HTML document
+
+  var el = document.createElement("html");
+
+  // Add the HTML string to the newly made document
+
+  el.innerHTML = content.props.dangerouslySetInnerHTML.__html;
+
+  // Select any list item that is a child of a top-level list
+
+  const listItems = el.querySelectorAll("body > ul > li > ul");
+
+  // Initialize blank arrays to hold our data
+
+  let columns: TableColumnTypes[] = [];
+  let data: ColumnCell[] = [];
+
+  const visualPropertiesBordered = {
+    areColumnsBordered: props.bordered,
+  };
+
+  // Loop through each selector
+  listItems.forEach((value, key) => {
+    // The first row is always the header, so we create the columns array with these values
+    if (key === 0) {
+      for (let i = 0; i < value.children.length; i++) {
+        columns.push({
+          // Take the written title as a header
+          Header: value.children[i].innerHTML,
+          // Use a snake case version of the header as an accessor
+          accessor: value.children[i]
+            .textContent!.toLowerCase()
+            .replace(" ", "_"),
+          // We need to tell the Tables component to render this information as
+          // HTML so that we can do advanced formatting
+          Cell: ({ value }) => (
+            <span dangerouslySetInnerHTML={{ __html: value }} />
+          ),
+          // Make the columns resizable
+          isResizable: props.resizable,
+          isAutoWidth: !props.resizable,
+        });
+      }
+    }
+    // Loop through each list after the first one to fill out the table
+    if (key > 0) {
+      // Initialize an empty object
+      var row: ColumnCell = {};
+      for (let i = 0; i < value.children.length; i++) {
+        // Add the accessor at the same position as the list item
+        let accessor: string = columns[i].accessor.toString();
+        // Create a new value pair and add it to the object
+        row[accessor] = value.children[i].innerHTML;
+      }
+      // Add the object to the array
+      data.push(row);
+    }
+  });
+
+  return (
+    <div style={{ overflow: "auto" }}>
+      {props.search && (
+        <div style={{ padding: "25px 15px 35px 15px" }}>
+          <Input
+            label="Search"
+            type="search"
+            value={searchTerm}
+            onClear={() => {
+              setSearchTerm("");
+            }}
+            onChange={(e) => {
+              setSearchTerm(e.target.value);
+            }}
+          />
+        </div>
+      )}
+      <TableV2
+        data={data}
+        columns={columns}
+        autoRowsHeight
+        searchTerm={searchTerm}
+        visualProperties={visualPropertiesBordered}
+        getFilteredData={(filteredValues) => console.log({ filteredValues })}
+      />
+    </div>
+  );
+};
+
+export default BuildListTable;

--- a/src/components/atlas/BuildListTable.tsx
+++ b/src/components/atlas/BuildListTable.tsx
@@ -107,7 +107,6 @@ const BuildListTable: FC<{
         autoRowsHeight
         searchTerm={searchTerm}
         visualProperties={visualPropertiesBordered}
-        getFilteredData={(filteredValues) => console.log({ filteredValues })}
       />
     </div>
   );

--- a/src/components/atlas/BuildListTable.tsx
+++ b/src/components/atlas/BuildListTable.tsx
@@ -85,9 +85,9 @@ const BuildListTable: FC<{
   });
 
   return (
-    <div style={{ overflow: "auto" }}>
+    <div className="overflow-auto">
       {props.search && (
-        <div style={{ padding: "25px 15px 35px 15px" }}>
+        <div className="px-[15px] pt-[25px] pb-[35px]">
           <Input
             label="Search"
             type="search"

--- a/src/content/docs/en/kitchen-sink/index.mdx
+++ b/src/content/docs/en/kitchen-sink/index.mdx
@@ -9,14 +9,31 @@ This page includes documentation for this site's custom authoring components and
 
 ## Callouts
 
-Callouts are components which display additional information in visually distinct ways.
+Callouts are components which display additional information in visually distinct ways. Callouts implement the ATLAS [Banner component](https://atlas.adeven.com/docs/components/Banner).
 
 ### Props
 
-| Prop    | Data type | Values                                                                                                                                                                          | Required               |
-| ------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
-| `type`  | String    | <ul><li><code>info</code></li><li><code>note</code></li><li><code>tip</code></li><li><code>warning</code></li><li><code>important</code></li><li><code>seealso</code></li></ul> | No. Defaults to `info` |
-| `title` | String    | The title of the callout                                                                                                                                                        | No. Defaults to `type` |
+<ListTable>
+
+-  -  Prop
+   -  Data type
+   -  Values
+   -  Required
+-  -  `type`
+   -  String
+   -  -  `info`
+      -  `note`
+      -  `tip`
+      -  `warning`
+      -  `important`
+      -  `seealso`
+   -  No. Defaults to `info`
+-  -  `title`
+   -  String
+   -  The title of the callout
+   -  No. Defaults to `type`
+
+</ListTable>
 
 ### Examples
 
@@ -146,14 +163,26 @@ A seealso callout contains links to additional or supplemental documentation or 
 
 ## Accordions
 
-Accordions are components which visually hide additional information to make a page less busy.
+Accordions are components which visually hide additional information to make a page less busy. Accordions implement the ATLAS [Accordion component](https://atlas.adeven.com/docs/components/Accordion).
 
 ### Props
 
-| Prop    | Data type | Required | Description                                                  |
-| ------- | --------- | -------- | ------------------------------------------------------------ |
-| `title` | String    | Yes      | The title that appears on the accordion                      |
-| `badge` | String    | No       | An optional badge that appears on the right of the accordion |
+<ListTable>
+
+-  -  Prop
+   -  Data type
+   -  Required
+   -  Description
+-  -  `title`
+   -  String
+   -  Yes
+   -  The title that appears on the accordion
+-  -  `badge`
+   -  String
+   -  No
+   -  An optional badge that appears on the right of the accordion
+
+</ListTable>
 
 ### Examples
 
@@ -188,3 +217,222 @@ An optional `badge` can be specified to add more context to an Accordion compone
    This is an Accordion element. It **contains**
    [Markdown](https://www.markdownguide.org/).
 </Accordion>
+
+## List tables
+
+List tables are a special table syntax that mimic Sphinx's [`list-table` syntax](https://docutils.sourceforge.io/docs/ref/rst/directives.html#list-table). List tables implement the ATLAS [Table V2 component](https://atlas.adeven.com/docs/components/TableV2).
+
+### Props
+
+<ListTable>
+
+-  -  Prop
+   -  Data type
+   -  Required
+   -  Description
+-  -  `search`
+   -  Boolean
+   -  No
+   -  Whether to include a search input. Defaults to `false`.
+-  -  `resizable`
+   -  Boolean
+   -  No
+   -  Whether readers should be able to resize columns. If not set, columns are sized automatically.
+-  -  `bordered`
+   -  Boolean
+   -  No
+   -  Whether the table should be bordered. Defaults to `true`.
+
+</ListTable>
+
+### Examples
+
+#### Standard list table
+
+By default, list tables are automatically sized and can't be searched. All standard Markdown is available in each list item.
+
+```mdx
+<ListTable>
+
+-  -  Header 1
+   -  Header 2
+   -  Header 3
+-  -  Column 1
+   -  Column 2
+   -  Column 3
+-  -  **Markdown** _Syntax_
+   -  [is available](https://markdownguide.org)
+   -  -  Including
+      -  List
+      -  Items
+
+</ListTable>
+```
+
+<ListTable>
+
+-  -  Header 1
+   -  Header 2
+   -  Header 3
+-  -  Column 1
+   -  Column 2
+   -  Column 3
+-  -  **Markdown** _Syntax_
+   -  [is available](https://markdownguide.org)
+   -  -  Including
+      -  List
+      -  Items
+
+</ListTable>
+
+#### Resizable list table
+
+If a table is resizable, users can resize columns to make content more readable.
+
+```mdx
+<ListTable resizable>
+
+-  -  Header 1
+   -  Header 2
+   -  Header 3
+-  -  Column 1
+   -  Column 2
+   -  Column 3
+-  -  **Markdown** _Syntax_
+   -  [is available](https://markdownguide.org)
+   -  -  Including
+      -  List
+      -  Items
+
+</ListTable>
+```
+
+<ListTable resizable>
+
+-  -  Header 1
+   -  Header 2
+   -  Header 3
+-  -  Column 1
+   -  Column 2
+   -  Column 3
+-  -  **Markdown** _Syntax_
+   -  [is available](https://markdownguide.org)
+   -  -  Including
+      -  List
+      -  Items
+
+</ListTable>
+
+#### Searchable list table
+
+If a table is searchable, a text input appears above the table. All columns are filtered by the search input.
+
+```mdx
+<ListTable search>
+
+-  -  Header 1
+   -  Header 2
+   -  Header 3
+-  -  Column 1
+   -  Column 2
+   -  Column 3
+-  -  **Markdown** _Syntax_
+   -  [is available](https://markdownguide.org)
+   -  -  Including
+      -  List
+      -  Items
+
+</ListTable>
+```
+
+<ListTable search>
+
+-  -  Header 1
+   -  Header 2
+   -  Header 3
+-  -  Column 1
+   -  Column 2
+   -  Column 3
+-  -  **Markdown** _Syntax_
+   -  [is available](https://markdownguide.org)
+   -  -  Including
+      -  List
+      -  Items
+
+</ListTable>
+
+#### Bordered list table
+
+List tables don't have a border by default. To add a border, pass a `bordered` prop.
+
+```mdx
+<ListTable bordered>
+
+-  -  Header 1
+   -  Header 2
+   -  Header 3
+-  -  Column 1
+   -  Column 2
+   -  Column 3
+-  -  **Markdown** _Syntax_
+   -  [is available](https://markdownguide.org)
+   -  -  Including
+      -  List
+      -  Items
+
+</ListTable>
+```
+
+<ListTable bordered>
+
+-  -  Header 1
+   -  Header 2
+   -  Header 3
+-  -  Column 1
+   -  Column 2
+   -  Column 3
+-  -  **Markdown** _Syntax_
+   -  [is available](https://markdownguide.org)
+   -  -  Including
+      -  List
+      -  Items
+
+</ListTable>
+
+#### Combined Props
+
+All table props can be combined at once.
+
+```mdx
+<ListTable bordered search resizable>
+
+-  -  Header 1
+   -  Header 2
+   -  Header 3
+-  -  Column 1
+   -  Column 2
+   -  Column 3
+-  -  **Markdown** _Syntax_
+   -  [is available](https://markdownguide.org)
+   -  -  Including
+      -  List
+      -  Items
+
+</ListTable>
+```
+
+<ListTable bordered search resizable>
+
+-  -  Header 1
+   -  Header 2
+   -  Header 3
+-  -  Column 1
+   -  Column 2
+   -  Column 3
+-  -  **Markdown** _Syntax_
+   -  [is available](https://markdownguide.org)
+   -  -  Including
+      -  List
+      -  Items
+
+</ListTable>


### PR DESCRIPTION
Per https://adjustcom.atlassian.net/browse/THC-810, this change adds support for a list-table feature that mimics the syntax of Sphinx and renders a Table V2 table from ATLAS.

This approach might not be the best one. I've tried to render the component list as HTML then iterate through the elements to create the headers and columns, but I'm sure there's a much easier way so I'd appreciate any pointers.