### PR TITLE
Use headers as prop content for ATLAS

### DIFF
--- a/src/components/Accordion.astro
+++ b/src/components/Accordion.astro
@@ -4,16 +4,6 @@ import BuildAccordion from "@components/atlas/BuildAccordion.tsx";
 // Creates a standard "headline" Accordion with an optional neutral badge
 // https://atlas.adeven.com/docs/components/Accordion
 
-// There are two information props for this component. Title is mandatory.
-// If a badge is provided, it is interpolated as a neutral badge on the accordion
-
-export interface Props {
-  title: string;
-  badge?: string;
-}
-
-const { title, badge } = Astro.props as Props;
-
 // Store the content contained within the Accordion as a string.
 // This string is converted to HTML inside the atlas/BuildAccordion.jsx file.
 
@@ -27,7 +17,5 @@ if (Astro.slots.has("default")) {
 <!-- Pass the assigned information to the BuildAccordion React component -->
 <BuildAccordion
   client:only="react"
-  title={title}
-  badge={badge}
   content={content}
 />

--- a/src/components/Callout.astro
+++ b/src/components/Callout.astro
@@ -9,7 +9,6 @@ import { toSentenceCase } from "@components/utils/convertCase";
 
 export interface Props {
   type?: string;
-  title?: string;
 }
 
 // This map iterates through the different banner types the author might specify and maps them to a `BannerKind`
@@ -28,7 +27,7 @@ let typeMap = new Map<String, BannerKind>([
 // The type is declared as "neutral" in case no type is provided.
 // If the author provides a type, it overrides this default.
 
-const { type = "neutral", title } = Astro.props as Props;
+const { type = "neutral" } = Astro.props as Props;
 
 // Iterate through the map and assign the type provided by the author to a BannerKind
 // If no type is found, default to "neutral"
@@ -39,7 +38,7 @@ let bannerType: BannerKind = typeMap.get(type) || "neutral";
 // This takes the value of the type and capitalizes the first letter.
 // If no type has been specified, default to "Info".
 
-let placeholderTitle =
+let typeTitle =
   type === "neutral" ? "Info" : toSentenceCase(type);
 
 // Store the content contained within the Callout as a string.
@@ -55,7 +54,7 @@ if (Astro.slots.has("default")) {
 <!-- Pass the assigned information to the BuildBanner React component -->
 <BuildBanner
   client:only="react"
-  title={title ?? placeholderTitle}
+  typeTitle={typeTitle}
   kind={bannerType}
   description={description}
 />

--- a/src/components/Tile.astro
+++ b/src/components/Tile.astro
@@ -1,14 +1,18 @@
 ---
-import { Tile as AtlasTile, IconName } from "@adjust/components";
+import BuildTile from "@components/atlas/BuildTile";
+import type { IconName } from "@adjust/components";
 
 export interface Props {
-  title?: string;
   icon?: IconName;
 }
 
-const { title, icon } = Astro.props as Props;
+const { icon } = Astro.props as Props;
+
+let content = "";
+
+if (Astro.slots.has("default")) {
+  content = await Astro.slots.render("default");
+}
 ---
 
-<AtlasTile title={title} iconName={icon} client:only="react">
-  <slot />
-</AtlasTile>
+<BuildTile icon={icon} content={content} client:only="react" />

--- a/src/components/atlas/BuildAccordion.tsx
+++ b/src/components/atlas/BuildAccordion.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource react */
 import { Accordion } from "@adjust/components";
+import { htmlWithTitles } from "@components/utils/htmlWithTitles";
 import type { FC } from "react";
 
 // We only need one type of Accordion currently.
@@ -7,13 +8,11 @@ import type { FC } from "react";
 
 const BuildAccordion: FC<{
   content: string;
-  title: string;
-  badge?: string;
 }> = (props) => {
   // The Atlas component passes the body content as a string of HTML.
   // We convert this to HTML using the `dangerouslySetInnerHTML` function.
 
-  const content = <div dangerouslySetInnerHTML={{ __html: props.content }} />;
+  const content = htmlWithTitles(props.content);
 
   // Each accordion exists in its own list, so we can hardcode the value of `id` to 1.
   // If we want to create multi-accordion lists in future we will need to iterate the `id`.
@@ -21,16 +20,16 @@ const BuildAccordion: FC<{
   const data = [
     {
       id: 1,
-      title: props.title,
-      content: content,
+      title: content.title || "",
+      content: content.body,
       badge: {},
     },
   ];
 
   // Only add a badge if `props.badge` contains a value
 
-  if (props.badge) {
-    data[0].badge = { label: props.badge, color: "neutral" };
+  if (content.badge) {
+    data[0].badge = { label: content.badge, color: "neutral" };
   }
 
   return <Accordion data={data} type="headline" />;

--- a/src/components/atlas/BuildBanner.tsx
+++ b/src/components/atlas/BuildBanner.tsx
@@ -1,21 +1,24 @@
 /** @jsxImportSource react */
 import type { FC } from "react";
+import { htmlWithTitles } from "@components/utils/htmlWithTitles";
 import { Banner } from "@adjust/components";
 
 const BuildBanner: FC<{
   description: string;
-  title: string;
+  typeTitle: string;
   kind: BannerKind;
 }> = (props) => {
-  // The Atlas component passes the body content as a string of HTML.
-  // We convert this to HTML using the `dangerouslySetInnerHTML` function.
+  /* The Astro component passes the body content as a string of HTML.
+  We use a helper function to convert this into usable HTML content*/
 
-  const description = (
-    <div dangerouslySetInnerHTML={{ __html: props.description }} />
-  );
+  let content = htmlWithTitles(props.description);
 
   return (
-    <Banner title={props.title} kind={props.kind} description={description} />
+    <Banner
+      title={content.title ? content.title : props.typeTitle}
+      kind={props.kind}
+      description={content.body}
+    />
   );
 };
 

--- a/src/components/atlas/BuildTile.tsx
+++ b/src/components/atlas/BuildTile.tsx
@@ -1,22 +1,25 @@
 /** @jsxImportSource react */
-import { IconName, Tile } from "@adjust/components";
 import type { FC } from "react";
+import { htmlWithTitles } from "@components/utils/htmlWithTitles";
+import { Tile } from "@adjust/components";
+import type { IconName } from "@adjust/components";
 
-const BuildTile: FC<{
+const BuildBanner: FC<{
   content: string;
   icon?: IconName;
-  title?: string;
 }> = (props) => {
-  // The Atlas component passes the body content as a string of HTML.
-  // We convert this to HTML using the `dangerouslySetInnerHTML` function.
+  /* The Astro component passes the body content as a string of HTML.
+  We use a helper function to convert this into usable HTML content*/
 
-  const content = <div dangerouslySetInnerHTML={{ __html: props.content }} />;
+  let content = htmlWithTitles(props.content);
 
   return (
-    <Tile title={props.title} iconName={props.icon}>
-      {content}
-    </Tile>
+    <Tile
+      title={content.title ? content.title : ""}
+      iconName={props.icon}
+      children={content.body}
+    />
   );
 };
 
-export default BuildTile;
+export default BuildBanner;

--- a/src/components/utils/htmlWithTitles.tsx
+++ b/src/components/utils/htmlWithTitles.tsx
@@ -1,0 +1,49 @@
+/** @jsxImportSource react */
+
+function stringToHtml(content: string) {
+  return <div dangerouslySetInnerHTML={{ __html: content }} />;
+}
+
+export function htmlWithTitles(content: string) {
+  let itemBody = stringToHtml(content);
+
+  // We hold this content in a faux document element
+
+  let el = document.createElement("html");
+
+  el.innerHTML = itemBody.props.dangerouslySetInnerHTML.__html;
+
+  /* To ensure we can translate content, we write it all in Markdown.
+   We need to extract the first header 3 and use it as the label */
+
+  let title = el.querySelector("body > h3");
+
+  let label = title?.textContent?.toString();
+
+  // If the next sibling of the header is a header 4, we need to store this.
+
+  let badgeCheck = title?.nextSibling;
+
+  let badge: string | undefined;
+
+  // Store the header 4 and remove it if
+
+  if (badgeCheck?.nodeName === "H4") {
+    badge = badgeCheck?.textContent?.toString();
+    badgeCheck?.remove();
+  }
+
+  // Remove the title
+
+  title?.remove();
+
+  // Next we convert the stringified HTML back to a React element
+
+  let body = stringToHtml(el.innerHTML.toString());
+
+  return {
+    title: label,
+    body: body,
+    badge: badge,
+  };
+}

--- a/src/content/docs/en/kitchen-sink/accordions.mdx
+++ b/src/content/docs/en/kitchen-sink/accordions.mdx
@@ -6,55 +6,46 @@ slug: "en/kitchen-sink/accordions"
 
 Accordions are components which visually hide additional information to make a page less busy. Accordions implement the ATLAS [Accordion component](https://atlas.adeven.com/docs/components/Accordion).
 
-## Props
-
-<ListTable>
-
--  -  Prop
-   -  Data type
-   -  Required
-   -  Description
--  -  `title`
-   -  String
-   -  Yes
-   -  The title that appears on the accordion
--  -  `badge`
-   -  String
-   -  No
-   -  An optional badge that appears on the right of the accordion
-
-</ListTable>
-
 ## Examples
 
 ### Standard Accordion
 
-Accordions require a title and can contain any markdown content.
+Accordions should have a title. The first `<h3>` element (`###`) is taken as the title.
 
 ```mdx
-<Accordion title="Example accordion">
-   This is an Accordion element. It **contains**
-   [Markdown](https://www.markdownguide.org/).
+<Accordion>
+### Example accordion
+
+This is an Accordion element. It **contains** [Markdown](https://www.markdownguide.org/).
+
 </Accordion>
 ```
 
-<Accordion title="Example accordion">
-   This is an Accordion element. It **contains**
-   [Markdown](https://www.markdownguide.org/).
+<Accordion>
+### Example accordion
+
+This is an Accordion element. It **contains** [Markdown](https://www.markdownguide.org/).
+
 </Accordion>
 
 ### Accordion with badge
 
-An optional `badge` can be specified to add more context to an Accordion component.
+Optionally, a badge can be added to the side of the accordion. The first `<h4>` element (`####`) is taken as the badge content.
 
 ```mdx
-<Accordion title="Example accordion" badge="iOS">
-   This is an Accordion element. It **contains**
-   [Markdown](https://www.markdownguide.org/).
+<Accordion>
+### Example accordion
+#### iOS
+
+This is an Accordion element. It **contains** [Markdown](https://www.markdownguide.org/).
+
 </Accordion>
 ```
 
-<Accordion title="Example dropdown" badge="iOS">
-   This is an Accordion element. It **contains**
-   [Markdown](https://www.markdownguide.org/).
+<Accordion>
+### Example accordion
+#### iOS
+
+This is an Accordion element. It **contains** [Markdown](https://www.markdownguide.org/).
+
 </Accordion>

--- a/src/content/docs/en/kitchen-sink/callouts.mdx
+++ b/src/content/docs/en/kitchen-sink/callouts.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Callouts"
+label: "Callouts"
 description: "Reference for the callout component"
 slug: "en/kitchen-sink/callouts"
 ---
@@ -23,10 +23,6 @@ Callouts are components which display additional information in visually distinc
       -  `important`
       -  `seealso`
    -  No. Defaults to `info`
--  -  `title`
-   -  String
-   -  The title of the callout
-   -  No. Defaults to `type`
 
 </ListTable>
 
@@ -34,40 +30,52 @@ Callouts are components which display additional information in visually distinc
 
 ### Default values
 
-If no `type` or `title` is specified, a neutral "info" callout with the title "Info" as a placeholder.
+Callouts should have a title. The first `<h3>` element (`###`) is taken as the title.
+
+If no `type` or label is specified, a neutral "info" callout with the label "Info" as a placeholder.
 
 ```mdx
 <Callout>
-This is a default callout. It **renders** [Markdown](https://markdownguide.org/).
+   This is a default callout. It **renders**
+   [Markdown](https://markdownguide.org/).
 </Callout>
 ```
 
 <Callout>
-This is a default callout. It **renders** [Markdown](https://markdownguide.org/).
+   This is a default callout. It **renders**
+   [Markdown](https://markdownguide.org/).
 </Callout>
 
 If no `type` is specified, the component defaults to a neutral "info" callout.
 
 ```mdx
-<Callout title="Default callout with custom title">
+<Callout>
+### Default callout with custom label
+
 This is a default callout. It **renders** [Markdown](https://markdownguide.org/).
+
 </Callout>
 ```
 
-<Callout title="Default callout with custom title">
+<Callout>
+### Default callout with custom label
+
 This is a default callout. It **renders** [Markdown](https://markdownguide.org/).
+
 </Callout>
 
-If no `title` is specified, a sentence-cased version of the `type` is rendered as the title.
+If no label is specified, a sentence-cased version of the `type` is rendered as the label.
 
 ```mdx
 <Callout type="warning">
-This is a callout with no title. It **renders** [Markdown](https://markdownguide.org/).
+   This is a callout with no label. It **renders**
+   [Markdown](https://markdownguide.org/).
 </Callout>
 ```
 
 <Callout type="warning">
-This is a callout with no title. It **renders** [Markdown](https://markdownguide.org/).
+   This is a callout with no label. It **renders**
+   [Markdown](https://markdownguide.org/).
 </Callout>
 
 ### Note callout
@@ -75,13 +83,19 @@ This is a callout with no title. It **renders** [Markdown](https://markdownguide
 A note callout is used to highlight additional information to the user.
 
 ```mdx
-<Callout type="note" title="A note callout">
-This is a *note* callout. It **renders** [Markdown](https://www.markdownguide.org/).
+<Callout type="note">
+### A note callout
+
+This is a _note_ callout. It **renders** [Markdown](https://www.markdownguide.org/).
+
 </Callout>
 ```
 
-<Callout type="note" title="A note callout">
-This is a *note* callout. It **renders** [Markdown](https://www.markdownguide.org/).
+<Callout type="note">
+### A note callout
+
+This is a _note_ callout. It **renders** [Markdown](https://www.markdownguide.org/).
+
 </Callout>
 
 ### Tip callout
@@ -89,13 +103,19 @@ This is a *note* callout. It **renders** [Markdown](https://www.markdownguide.or
 A tip callout highlights suggestions or tips that are recommended but not required.
 
 ```mdx
-<Callout type="tip" title="A tip callout">
-This is a *tip* callout. It **renders** [Markdown](https://www.markdownguide.org/).
+<Callout type="tip">
+### A tip callout
+
+This is a _tip_ callout. It **renders** [Markdown](https://www.markdownguide.org/).
+
 </Callout>
 ```
 
-<Callout type="tip" title="A tip callout">
-This is a *tip* callout. It **renders** [Markdown](https://www.markdownguide.org/).
+<Callout type="tip">
+### A tip callout
+
+This is a _tip_ callout. It **renders** [Markdown](https://www.markdownguide.org/).
+
 </Callout>
 
 #### Warning callout
@@ -103,13 +123,19 @@ This is a *tip* callout. It **renders** [Markdown](https://www.markdownguide.org
 A warning callout contains information that highlights negative consequences.
 
 ```mdx
-<Callout type="warning" title="A warning callout">
-This is a *warning* callout. It **renders** [Markdown](https://www.markdownguide.org/).
+<Callout type="warning">
+### A warning callout
+
+This is a _warning_ callout. It **renders** [Markdown](https://www.markdownguide.org/).
+
 </Callout>
 ```
 
-<Callout type="warning" title="A warning callout">
-This is a *warning* callout. It **renders** [Markdown](https://www.markdownguide.org/).
+<Callout type="warning">
+### A warning callout
+
+This is a _warning_ callout. It **renders** [Markdown](https://www.markdownguide.org/).
+
 </Callout>
 
 ### Important callout
@@ -117,13 +143,19 @@ This is a *warning* callout. It **renders** [Markdown](https://www.markdownguide
 An important callout contains information that the user shouldn't ignore.
 
 ```mdx
-<Callout type="important" title="An important callout">
-This is an *important* callout. It **renders** [Markdown](https://www.markdownguide.org/).
+<Callout type="important">
+### An important callout
+
+This is an _important_ callout. It **renders** [Markdown](https://www.markdownguide.org/).
+
 </Callout>
 ```
 
-<Callout type="important" title="An important callout">
-This is an *important* callout. It **renders** [Markdown](https://www.markdownguide.org/).
+<Callout type="important">
+### An important callout
+
+This is an _important_ callout. It **renders** [Markdown](https://www.markdownguide.org/).
+
 </Callout>
 
 ### Seealso callout
@@ -131,11 +163,17 @@ This is an *important* callout. It **renders** [Markdown](https://www.markdowngu
 A seealso callout contains links to additional or supplemental documentation or context.
 
 ```mdx
-<Callout type="seealso" title="A seealso callout">
-This is a *seealso* callout. It **renders** [Markdown](https://www.markdownguide.org/).
+<Callout type="seealso">
+### A seealso callout
+
+This is a _seealso_ callout. It **renders** [Markdown](https://www.markdownguide.org/).
+
 </Callout>
 ```
 
-<Callout type="seealso" title="A seealso callout">
-This is a *seealso* callout. It **renders** [Markdown](https://www.markdownguide.org/).
+<Callout type="seealso">
+### A seealso callout
+
+This is a _seealso_ callout. It **renders** [Markdown](https://www.markdownguide.org/).
+
 </Callout>

--- a/src/content/docs/en/kitchen-sink/tiles.mdx
+++ b/src/content/docs/en/kitchen-sink/tiles.mdx
@@ -14,10 +14,6 @@ Tiles are components that help to visually compartmentalize content. Tiles rende
    -  Data type
    -  Required
    -  Description
--  -  `title`
-   -  String
-   -  No
-   -  An optional title for the tile.
 -  -  `icon`
    -  IconName
    -  No
@@ -27,23 +23,26 @@ Tiles are components that help to visually compartmentalize content. Tiles rende
 
 ## Examples
 
-Tiles can be customized with a title and an icon. These are optional and may be left out.
+Tiles can be customized with a title and an `icon`. These are optional and may be left out. The first `<h3>` element (`###`) is taken as the title.
 
 <Callout type="important">
 `Tile` components can contain only **Markdown** and [inline typography](/en/kitchen-sink/typography). Structural components such as `Callout` and `Accordion` elements won't render in a Tile.
 </Callout>
 
 ```mdx
-<Tile title="Documentation goals" icon="Kpi">
+<Tile icon="Kpi">
+### Documentation goals
+
 This is a tile that contains documentation goals.
 
 _It_ **contains** [Markdown](https://www.markdownguide.org/).
 </Tile>
 ```
 
-<Tile title="Documentation goals" icon="Kpi">
+<Tile icon="Kpi">
+### Documentation goals
+
 This is a tile that contains documentation goals.
 
 _It_ **contains** [Markdown](https://www.markdownguide.org/).
 </Tile>
-


### PR DESCRIPTION
To facilitate translations, we need to ensure that any translatable content inside a component is parsed as Markdown. This means that Smartling will be able to receive and return conent in different languages for Astro to build into proper components.

To facilitate this, content is passed to a helper function (`htmlWithTitles`) which strips the first `h3` and `h4` from a body of Markdown and returns the results as properties to be used in React components.