### PR TITLE
Reduce accordion usage

### DIFF
--- a/src/content/docs/en/sdk/ios/configuration/deep-links/data-points.mdx
+++ b/src/content/docs/en/sdk/ios/configuration/deep-links/data-points.mdx
@@ -18,8 +18,6 @@ You need to retrieve the following data points before you can set up deep links 
 
 Follow these instructions to retrieve your data points.
 
-<Accordion>
-
 ### App ID Prefix and Release Bundle ID
 
 Your App ID is found on the Apple Developer portal. It contains two parts:
@@ -37,10 +35,6 @@ To find your App ID Prefix and Bundle ID, follow these steps:
 4. Find your app and select it to open the edit page.
 5. Your App ID Prefix and Bundle ID are displayed at the top of the page. Copy the relevant information and store it somewhere for later use.
 
-</Accordion>
-
-<Accordion>
-
 ### Debug Bundle ID
 
 If you're using a different bundle ID for your debug build, you can find its ID in Xcode.
@@ -52,11 +46,7 @@ If you're using a different bundle ID for your debug build, you can find its ID 
 5. Select <GuiLabel>Debug</GuiLabel> from the sub menu that appears.
 6. Your Bundle ID is shown. Copy this information and store it somewhere for later use.
 
-</Accordion>
-
-<Accordion>
-
-### Release Custom URL Scheme and Debug Custom URL Scheme
+### Custom URL schemes
 
 <Callout type="tip">
 
@@ -81,17 +71,13 @@ If your iOS app doesn't have a custom URL scheme yet, follow these steps to set 
 3. Select your app under <GuiLabel>Targets</GuiLabel>. 
 4. Select <GuiLabel>Info</GuiLabel> from the top menu.
 5. Expand the <GuiLabel>URL Types</GuiLabel> section.
-6. Select the Add option (<GuiLabel>+</GuiLabel>) to add a new URL type.
+6. Select the Add option (<Icon name="Plus" />) to add a new URL type.
 7. Fill in the following information to create a URL scheme:
    * <GuiLabel>Identifier</GuiLabel>: `$(PRODUCT_BUNDLE_IDENTIFIER)`
    * <GuiLabel>URL Schemes</GuiLabel>: your custom URL scheme. This must be unique. Don't use protected schemes such as `http`, `https`, or `mailto`
    * <GuiLabel>Role</GuiLabel>: Editor
 
 This scheme will work for your production **and** debug builds.
-
-</Accordion>
-
-<Accordion>
 
 ### Link Resolution domains
 
@@ -102,5 +88,3 @@ A link resolution domain is required for deep linking via email, SMS, QR codes, 
 </Callout>
 
 Your marketing team may already be using a link resolution domain for their email marketing platform. Get this domain from them and store it somewhere for later use.
-
-</Accordion>

--- a/src/content/docs/en/sdk/ios/configuration/deep-links/deferred.mdx
+++ b/src/content/docs/en/sdk/ios/configuration/deep-links/deferred.mdx
@@ -6,6 +6,7 @@ sidebar-position: 4
 ---
 
 import SetLinkMeEnabled from "@ios-examples/ADJConfig/setLinkMeEnabled.mdx"
+import SetLinkMeEnabledSig from "@ios-signatures/ADJConfig/setLinkMeEnabled.mdx"
 
 A deferred deep link sends a user to a place in your app after routing them via the App Store to install the app first.
 
@@ -43,102 +44,102 @@ There are 2 approaches to set up deferred deep linking in your app:
 
 1. Set up a delegate callback for deferred deep linking. If you have already configured attribution callbacks, you can skip this step.
 
-   <Tabs>
-   <Tab sync="swift">
-   
-   ### Swift
+<Tabs>
+<Tab sync="swift">
 
-   ```swift title="AppDelegate.swift"
-   class AppDelegate: UIResponder, UIApplicationDelegate, AdjustDelegate {
-   }
-   ```
+### Swift
 
-   </Tab>
-   <Tab sync="objc">
+```swift title="AppDelegate.swift"
+class AppDelegate: UIResponder, UIApplicationDelegate, AdjustDelegate {
+}
+```
 
-   ### Objective-C
+</Tab>
+<Tab sync="objc">
 
-   ```objective-c title="AppDelegate.h"
-   @interface AppDelegate : UIResponder <UIApplicationDelegate, AdjustDelegate>
-   ```
+### Objective-C
 
-   </Tab>
-   </Tabs>
+```objective-c title="AppDelegate.h"
+@interface AppDelegate : UIResponder <UIApplicationDelegate, AdjustDelegate>
+```
+
+</Tab>
+</Tabs>
 
 2. If you haven’t already done so, create an instance of the `ADJConfig` class and set a delegate on the `ADJConfig` object in your app delegate. You need to set the delegate in `ADJConfig` before initializing the SDK.
 
-   <Tabs>
-   <Tab sync="swift">
-   
-   ### Swift
+<Tabs>
+<Tab sync="swift">
 
-   ```swift
-   let yourAppToken = "{YourAppToken}"
-   let environment = ADJEnvironmentSandbox as? String
-   let adjustConfig = ADJConfig(
-      appToken: yourAppToken,
-      environment: environment)
-   adjustConfig?.delegate = self
+### Swift
 
-   // ...
+```swift
+let yourAppToken = "{YourAppToken}"
+let environment = ADJEnvironmentSandbox as? String
+let adjustConfig = ADJConfig(
+   appToken: yourAppToken,
+   environment: environment)
+adjustConfig?.delegate = self
 
-   Adjust.appDidLaunch(adjustConfig)
-   ```
+// ...
 
-   </Tab>
-   <Tab sync="objc">
+Adjust.appDidLaunch(adjustConfig)
+```
 
-   ### Objective-C
+</Tab>
+<Tab sync="objc">
 
-   ```objective-c
-   *adjustConfig = [ADJConfig configWithAppToken:@"{YourAppToken}"
-                                  environment:ADJEnvironmentSandbox];
-   [adjustConfig setDelegate:self];
+### Objective-C
 
-   // ...
+```objective-c
+*adjustConfig = [ADJConfig configWithAppToken:@"{YourAppToken}"
+                                 environment:ADJEnvironmentSandbox];
+[adjustConfig setDelegate:self];
 
-   [Adjust appDidLaunch:adjustConfig];
-   ```
+// ...
 
-   </Tab>
-   </Tabs>
+[Adjust appDidLaunch:adjustConfig];
+```
+
+</Tab>
+</Tabs>
 
 3. Add the `adjustDeeplinkResponse` deferred deep link callback method to the delegate. The Adjust SDK calls this method after receiving a deferred deep link.
    1. Set your deep link handling code.
    2. Set the return value of the `adjustDeeplinkResponse` method to true or false. This indicates whether you want the Adjust SDK to call the `open(_:options:completionHandler:)` method to open the deep link after your deep link handling code runs.
 
-   <Tabs>
-   <Tab sync="swift">
-   
-   ### Swift
+<Tabs>
+<Tab sync="swift">
 
-   ```swift
-   func adjustDeeplinkResponse(_ deeplink: URL?) -> Bool {
+### Swift
+
+```swift
+func adjustDeeplinkResponse(_ deeplink: URL?) -> Bool {
+   // add your code below to handle deep link
+   // (for example, show onboarding screens, then open deep link content)
+   // deeplink object contains the deep link
+
+   return false
+}
+```
+
+</Tab>
+<Tab sync="objc">
+
+### Objective-C
+
+```objective-c
+- (BOOL)adjustDeeplinkResponse:(NSURL *)deeplink {
       // add your code below to handle deep link
       // (for example, show onboarding screens, then open deep link content)
       // deeplink object contains the deep link
+      
+      return NO;
+}
+```
 
-      return false
-   }
-   ```
-
-   </Tab>
-   <Tab sync="objc">
-
-   ### Objective-C
-
-   ```objective-c
-   - (BOOL)adjustDeeplinkResponse:(NSURL *)deeplink {
-       // add your code below to handle deep link
-       // (for example, show onboarding screens, then open deep link content)
-       // deeplink object contains the deep link
-       
-       return NO;
-   }
-   ```
-
-   </Tab>
-   </Tabs>
+</Tab>
+</Tabs>
 
 ## Set up Adjust LinkMe
 
@@ -158,6 +159,6 @@ The Adjust SDK checks the pasteboard when a user opens the app for the first tim
 
 When a user clicks on a LinkMe URL they have the option to copy the link information to their system pasteboard. You can use the Adjust SDK to read the system pasteboard for deep link information. If deep link information is present, the Adjust SDK forwards the user to the correct page in your app.
 
-To enable pasteboard checking in your app, pass a **true** value to the `setLinkMeEnabled` method on your `ADJConfig` object:
+To enable pasteboard checking in your app, pass a **true** value to the <Tooltip>`setLinkMeEnabled` method || <SetLinkMeEnabledSig /></Tooltip> on your `ADJConfig` object:
 
 <SetLinkMeEnabled />

--- a/src/content/docs/en/sdk/ios/configuration/deep-links/direct.mdx
+++ b/src/content/docs/en/sdk/ios/configuration/deep-links/direct.mdx
@@ -27,8 +27,6 @@ To get started, you need to enable Associated Domains in your Apple Developer ac
 
 Follow these steps to add your deep link configuration to your Xcode project.
 
-<Accordion>
-
 ### Adjust universal links domain
 
 1. Open your app project in Xcode.
@@ -40,10 +38,6 @@ Follow these steps to add your deep link configuration to your Xcode project.
 7. Select <GuiLabel>Associated Domains</GuiLabel>.
 8. Enter the Adjust Universal Link domain with the prefix `applinks:`
    -  Here is an example using the `example.adj.st` domain: `applinks:example.adj.st`.
-
-</Accordion>
-
-<Accordion>
 
 ### Custom URL scheme
 
@@ -67,13 +61,9 @@ Check with your marketing team to see if a custom URL scheme is needed for the a
 
 This scheme will work for your production **and** debug builds.
 
-</Accordion>
-
 ## Modify your iOS app
 
 You need to update your iOS app to set up different deep linking scenarios. How you update your app depends on whether your app uses [scenes](https://developer.apple.com/documentation/uikit/app_and_environment/scenes).
-
-<Accordion>
 
 ### App doesn't use scenes
 
@@ -219,10 +209,6 @@ func application(
 
 </Tab>
 </Tabs>
-
-</Accordion>
-
-<Accordion>
 
 ### App uses scenes
 
@@ -412,5 +398,3 @@ func scene(
 
 </Tab>
 </Tabs>
-
-</Accordion>

--- a/src/content/docs/en/sdk/ios/configuration/deep-links/resolution.mdx
+++ b/src/content/docs/en/sdk/ios/configuration/deep-links/resolution.mdx
@@ -107,9 +107,7 @@ To use link resolution, your email partner needs to let you to set up the redire
 -  Iterable: Iterable provides the URL redirection service that supports custom domains.
 -  Mailchimp: Link resolution isn't available because Mailchimp doesn't allow you to configure their redirect domain as a universal link.
 
-<Accordion>
-
-### Example
+#### Example
 
 1. The email marketer builds their email using a template. This template contains a link or an image with a universal link.
 
@@ -129,8 +127,6 @@ To use link resolution, your email partner needs to let you to set up the redire
 7. The link resolution method returns the resolved URL.
 8. Your app handles the returned URL. In this case, your app would display the `summer-clothes` page in your app with a `beach promo` modal to the user.
 9. Your app calls the <Tooltip>`appWillOpenUrl` method || <AppWillOpenUrl /></Tooltip> in the Adjust SDK with the returned URL.
-
-</Accordion>
 
 ### URL shorteners
 
@@ -154,9 +150,7 @@ When marketers run certain types of campaigns, sometimes a short URL is required
 6. Configure your URL shortener domain as a custom domain on the URL shortener service. You need to configure the DNS for your URL shortener domain to point to the URL shortener service’s servers. ([Reference documentation to add a custom domain in short.io](https://help.short.io/en/articles/4065811-how-can-i-add-a-domain)).
 7. Configure universal links on the URL shortener service. ([Reference documentation to configure universal links in short.io](https://help.short.io/en/articles/4065870-how-to-set-up-deep-links-for-ios)).
 
-<Accordion>
-
-### Example
+#### Example
 
 1. The marketer creates a universal link.
 
@@ -177,5 +171,3 @@ When marketers run certain types of campaigns, sometimes a short URL is required
 8. The link resolution method returns the resolved URL.
 9. Your app handles the returned URL. In this case, your app would display the `summer-clothes` page in your app with a `beach promo` modal to the user.
 10.   Your app calls the <Tooltip>`appWillOpenUrl` method || <AppWillOpenUrl /></Tooltip> in the Adjust SDK with the returned URL.
-
-</Accordion>

--- a/src/content/docs/en/sdk/ios/configuration/deep-links/testing.mdx
+++ b/src/content/docs/en/sdk/ios/configuration/deep-links/testing.mdx
@@ -66,8 +66,6 @@ To check your universal link domain configuration, follow these steps.
 
 If this option doesn't appear, check the following issues.
 
-<Accordion>
-
 ### Adjust universal links
 
 * Check your marketing team has enabled Adjust universal links in the Adjust dashboard.
@@ -79,10 +77,6 @@ If this option doesn't appear, check the following issues.
    * <GuiLabel>Bundle ID</GuiLabel>: Verify whether you are using the bundle ID of the debug build or release build.
    * <GuiLabel>Universal link domain</GuiLabel>: Verify whether you are using the universal link domain of the debug build or release build. The universal link domain in the app needs to match with the branded link in the Adjust dashboard.
 
-</Accordion>
-
-<Accordion>
-
 ### Email redirect and URL shortener universal links
 
 * Check the Associated Domains configuration in Xcode.
@@ -92,8 +86,6 @@ If this option doesn't appear, check the following issues.
   * <GuiLabel>App ID prefix</GuiLabel>
    * <GuiLabel>Bundle ID</GuiLabel>: Verify whether you are using the bundle ID of the debug build or release build.
    * Email redirect domain / URL shortener domain - Verify whether you have configured the domain as a custom domain in the email partner's system.
-
-</Accordion>
 
 ### Test direct deep linking in the app
 

--- a/src/content/docs/en/sdk/ios/configuration/skad.mdx
+++ b/src/content/docs/en/sdk/ios/configuration/skad.mdx
@@ -43,8 +43,6 @@ If you manage your conversion values with Adjust, the servers update this value 
 
 <UpdateConversionValue />
 
-<Accordion>
-
 ### Example
 
 This example demonstrates how to update a conversion value to `10` in response to a user triggering an event.
@@ -74,9 +72,7 @@ func onButtonClick() {
 </Tab>
 </Tabs>
 
-</Accordion>
-
-### Set up completion handlers
+## Set up completion handlers
 
 The Adjust SDK contains wrappers for Apple's `updatePostbackConversionValue` methods. These methods provide more options for handling SKAdNetwork postbacks, including the option to handle failures.
 
@@ -109,8 +105,6 @@ updatePostbackConversionValue
    - An optional completion handler you provide to catch and handle any errors this method encounters when you update a conversion value. Set this value to `nil` if you don’t provide a handler.
 
 </Table>
-
-<Accordion>
 
 ### Example
 
@@ -151,13 +145,9 @@ if (@available(iOS 16.1, *)) {
 </Tab>
 </Tabs>
 
-</Accordion>
-
 ## Listen for changes to conversion values
 
 If you use Adjust to manage conversion values, the Adjust's servers send conversion value updates to the SDK. You can set up a delegate function to listen for these changes using the `adjustConversionValueUpdated` method.
-
-<Accordion>
 
 ### Example
 
@@ -191,8 +181,6 @@ func adjustConversionValueUpdated(_ conversionValue: NSNumber?) {
 </Tab>
 </Tabs>
 
-</Accordion>
-
 ## SKAdNetwork 4.0 callbacks
 
 SKAdNetwork 4.0 postbacks contain some additional information to give advertisers more insight into their users. When Adjust's servers update conversion values, this additional information is sent in a payload. You can access this information with the `adjustConversionValueUpdated` callback method.
@@ -216,8 +204,6 @@ SKAdNetwork 4.0 postbacks contain some additional information to give advertiser
    - Whether to send the postback before the conversion window ends. `1` indicates the postback will be sent before the conversion window ends. Defaults to `0` in SKAdNetwork 4.0 postbacks and `nil` in older SKAdNetwork versions
 
 </Table>
-
-<Accordion>
 
 ### Example
 
@@ -251,8 +237,6 @@ func adjustConversionValueUpdated(_ fineValue: NSNumber?, coarseValue: String?, 
 
 </Tab>
 </Tabs>
-
-</Accordion>
 
 ## Set up direct install postbacks
 

--- a/src/content/docs/en/sdk/ios/features/ad-revenue.mdx
+++ b/src/content/docs/en/sdk/ios/features/ad-revenue.mdx
@@ -38,7 +38,7 @@ To send ad revenue to Adjust:
 
 ## Sources
 
-<Table>
+<Table height="full-height">
 
 | Parameter                            | Source            |
 | ------------------------------------ | ----------------- |
@@ -77,17 +77,11 @@ Check the [guide to tracking purchases in different currencies](https://help.adj
 
 The ad revenue object contains properties you can use to report on your ad campaigns.
 
-<Accordion>
-
 ### Ad impressions
 
 Record the number of ad impressions by passing an **integer** value to the <Tooltip>`setAdImpressionsCount` method || <SetAdImpressionsCountSig /></Tooltip>.
 
 <SetAdImpressionsCount />
-
-</Accordion>
-
-<Accordion>
 
 ### Ad revenue network
 
@@ -95,27 +89,17 @@ Record which network generated the revenue by passing a **string** value to the 
 
 <SetAdRevenueNetwork />
 
-</Accordion>
-
-<Accordion>
-
 ### Ad revenue unit
 
 Record which ad revenue unit generated the revenue by passing a **string** value to the <Tooltip>`setAdRevenueUnit` method || <SetAdRevenueUnitSig /></Tooltip>.
 
 <SetAdRevenueUnit />
 
-</Accordion>
-
-<Accordion>
-
 ### Ad revenue placement
 
 Record the placement of your ad by passing a **string** value to the <Tooltip>`setAdRevenuePlacement` method || <SetAdRevenuePlacementSig /></Tooltip>.
 
 <SetAdRevenuePlacement />
-
-</Accordion>
 
 ## Add callback parameters
 

--- a/src/content/docs/en/sdk/ios/features/events.mdx
+++ b/src/content/docs/en/sdk/ios/features/events.mdx
@@ -24,10 +24,6 @@ You can associate your [Adjust event tokens](https://help.adjust.com/en/article/
 
 <TrackEvent />
 
-<Accordion>
-
-### Example
-
 This example demonstrates how to record an event with the token `g3mfiw` whenever a user interacts with a button.
 
 <Tabs>
@@ -111,8 +107,6 @@ class ViewControllerSwift: UIViewController {
 </Tab>
 </Tabs>
 
-</Accordion>
-
 ## Record event revenue
 
 You can record revenue associated with an event by setting the revenue and currency properties on your event instance. Use this feature to record revenue-generating actions in your app.
@@ -132,8 +126,6 @@ Check the guide to [tracking purchases in different currencies](https://help.adj
 </Callout>
 
 <SetRevenue />
-
-<Accordion>
 
 ### Example
 
@@ -220,8 +212,6 @@ class ViewControllerSwift: UIViewController {
 </Tab>
 </Tabs>
 
-</Accordion>
-
 ## Unique events
 
 You can pass an optional identifier to avoid recording duplicate events. The SDK stores the last ten identifiers and skips revenue events with duplicate transaction IDs.
@@ -229,8 +219,6 @@ You can pass an optional identifier to avoid recording duplicate events. The SDK
 To set the identifier, call the <Tooltip>`setTransactionId` method || <SetTransactionIdSig /></Tooltip> and pass your transaction ID as a **string** argument.
 
 <SetTransactionId />
-
-<Accordion>
 
 ### Example
 
@@ -321,8 +309,6 @@ class ViewControllerSwift: UIViewController {
 </Tab>
 </Tabs>
 
-</Accordion>
-
 ## Add callback parameters
 
 If you [register a callback URL](https://help.adjust.com/en/article/set-up-callbacks) in the Adjust dashboard, the SDK sends a GET request to your callback URL when it records an event.
@@ -354,8 +340,6 @@ Adjust supports many placeholders which you can use to pass information from the
 You can read more about using URL callbacks, including a full list of available values, in the [callbacks guide](https://help.adjust.com/en/article/callbacks).
 
 </Callout>
-
-<Accordion>
 
 ### Example
 
@@ -457,8 +441,6 @@ class ViewControllerSwift: UIViewController {
 </Tab>
 </Tabs>
 
-</Accordion>
-
 ## Add partner parameters
 
 You can send extra information to your network partners by adding [partner parameters](https://help.adjust.com/en/article/advanced-event-setup#receive-custom-data-with-partner-parameters).
@@ -474,8 +456,6 @@ Partner parameters don't appear in raw data by default. You can add the `{partne
 Add partner parameters to your event by calling the <Tooltip>`addPartnerParameter` method || <AddPartnerParameterSig /></Tooltip> with **string** key-value arguments. You can add multiple parameters by calling this method multiple times.
 
 <AddPartnerParameter />
-
-<Accordion>
 
 ### Example
 
@@ -570,8 +550,6 @@ class ViewControllerSwift: UIViewController {
 </Tab>
 </Tabs>
 
-</Accordion>
-
 ## Add a callback identifier
 
 You can add a custom string identifier to each event you want to measure. Adjust's servers can report on this identifier in event callbacks. This enables you to keep track of which events have been successfully measured.
@@ -579,8 +557,6 @@ You can add a custom string identifier to each event you want to measure. Adjust
 Set up this identifier by calling the <Tooltip>`setCallbackId` method || <SetCallbackIdSig /></Tooltip> with your ID as a **string** argument.
 
 <SetCallbackId />
-
-<Accordion>
 
 ### Example
 
@@ -668,5 +644,3 @@ class ViewControllerSwift: UIViewController {
 
 </Tab>
 </Tabs>
-
-</Accordion>

--- a/src/content/docs/en/sdk/ios/index.mdx
+++ b/src/content/docs/en/sdk/ios/index.mdx
@@ -20,7 +20,7 @@ To add the SDK using Swift's package manager:
 ### Alternative installation methods
 
 <Tabs>
-<Tab>
+<Tab sync="cocoapods">
 
 ### Cocoapods
 
@@ -41,7 +41,7 @@ pod 'Adjust/WebBridge', '~> v4.35.0'
 ```
 
 </Tab>
-<Tab>
+<Tab sync="carthage">
 
 ### Carthage
 
@@ -52,7 +52,7 @@ github "adjust/ios_sdk"
 ```
 
 </Tab>
-<Tab>
+<Tab sync="framework">
 
 ### Add as framework
 
@@ -78,7 +78,8 @@ Choose the frameworks you need and add them to your `Xcode` project:
 
 Once you've added the Adjust SDK to your `Xcode` project, you need to integrate it in your app.
 
-<Accordion>
+<Tabs>
+<Tab sync="cocoapods">
 
 ### Cocoapods
 
@@ -121,11 +122,10 @@ If you use the Adjust Web Bridge, add the following to your `AppDelegate.h` file
 </Tab>
 </Tabs>
 
-</Accordion>
+</Tab>
+<Tab sync="carthage">
 
-<Accordion>
-
-### Carthage and framework import
+### Carthage
 
 Add the relevant import statements in your project files:
 
@@ -190,7 +190,76 @@ If you use the Adjust SDK in your iMessage app, add the following to your `AppDe
 </Tab>
 </Tabs>
 
-</Accordion>
+</Tab>
+<Tab sync="framework">
+
+### Framework import
+
+Add the relevant import statements in your project files:
+
+<Tabs>
+<Tab sync="swift">
+
+### Swift
+
+To import the Adjust SDK, add the following to your bridging header file:
+
+```objc
+#import <Adjust/Adjust.h>
+```
+
+If you use the Adjust Web Bridge, add the following to your bridging header file:
+
+```objc
+#import <AdjustSdkWebBridge/AdjustBridge.h>
+```
+
+If you use the Adjust SDK in a tvOS app, add the following to your bridging header file:
+
+```objc
+#import <AdjustSdkTv/Adjust.h>
+```
+
+If you use the Adjust SDK in a iMessage app, add the following to your bridging header file:
+
+```objc
+#import <AdjustSdkIm/Adjust.h>
+```
+
+</Tab>
+<Tab sync="objc">
+
+### Objective-C
+
+To import the Adjust SDK, add the following to your `AppDelegate.h` file:
+
+```objc
+#import <AdjustSdk/Adjust.h>
+```
+
+If you use the Adjust Web Bridge, add the following to your `AppDelegate.h` file:
+
+```objc
+#import <AdjustSdkWebBridge/AdjustBridge.h>
+```
+
+If you use the Adjust SDK in your tvOS app, add the following to your `AppDelegate.h` file:
+
+```objc
+#import <AdjustSdkTv/Adjust.h>
+```
+
+If you use the Adjust SDK in your iMessage app, add the following to your `AppDelegate.h` file:
+
+```objc
+#import <AdjustSdkIm/Adjust.h>
+```
+
+</Tab>
+</Tabs>
+
+</Tab>
+</Tabs>
 
 ## 3. Add iOS frameworks
 

--- a/src/content/docs/en/sdk/unity/configuration/att.mdx
+++ b/src/content/docs/en/sdk/unity/configuration/att.mdx
@@ -47,8 +47,6 @@ The Adjust SDK also records the consent status if you use a custom prompt. If yo
 
 <RequestTrackingAuthorization />
 
-<Accordion>
-
 ### Example
 
 This example demonstrates how to log a human-readable description of the user's authorization status when they interact with a prompt.
@@ -74,15 +72,11 @@ Adjust.requestTrackingAuthorizationWithCompletionHandler((status) =>
 });
 ```
 
-</Accordion>
-
 ## Get current authorization status
 
 You can retrieve a user's current authorization status at any time. Call the <Tooltip>`appTrackingAuthorizationStatus` method || <AppTrackingAuthorizationStatusSig /></Tooltip> to return the authorization status code as an **integer**.
 
 <AppTrackingAuthorizationStatus />
-
-<Accordion>
 
 ### Example
 
@@ -92,8 +86,6 @@ This example demonstrates how to collect the user's authorization status and con
 string authorizationStatus = Convert.ToString(Adjust.getAppTrackingAuthorizationStatus());
 Adjust.addSessionPartnerParameter("status", authorizationStatus);
 ```
-
-</Accordion>
 
 ## Check for authorization status changes
 

--- a/src/content/docs/en/sdk/unity/configuration/deep-links.mdx
+++ b/src/content/docs/en/sdk/unity/configuration/deep-links.mdx
@@ -84,8 +84,6 @@ adjustConfig.setDeferredDeeplinkDelegate(DeferredDeeplinkCallback);
 Adjust.start(adjustConfig);
 ```
 
-<Accordion> 
-
 ### Example
 
 This example demonstrates how to log a deep link address when the user opens a deferred deep link.
@@ -100,8 +98,6 @@ adjustConfig.setDeferredDeeplinkDelegate(LogDeepLink);
 //...
 Adjust.start(adjustConfig);
 ```
-
-</Accordion>
 
 ### Enable LinkMe
 

--- a/src/content/docs/en/sdk/unity/configuration/skad.mdx
+++ b/src/content/docs/en/sdk/unity/configuration/skad.mdx
@@ -45,8 +45,6 @@ If you manage your conversion values with Adjust, the servers update this value 
 
 <UpdateConversionValue />
 
-<Accordion>
-
 ### Example
 
 This example demonstrates how to update a conversion value to `10` in response to a user triggering an event.
@@ -57,15 +55,11 @@ public void OnButtonClick() {
 }
 ```
 
-</Accordion>
-
 ## Listen for changes to conversion values
 
 If you use Adjust to manage conversion values, the Adjust's servers send conversion value updates to the SDK. You can set up a delegate function to listen for these changes using the `setConversionValueUpdatedDelegate` method. Pass your function as an argument.
 
 <SetConversionValueUpdatedDelegate />
-
-<Accordion>
 
 ### Example
 
@@ -94,5 +88,3 @@ public class ExampleGUI : MonoBehaviour {
     }
 }
 ```
-
-</Accordion>

--- a/src/content/docs/en/sdk/unity/features/ad-revenue.mdx
+++ b/src/content/docs/en/sdk/unity/features/ad-revenue.mdx
@@ -77,17 +77,11 @@ Check the [guide to tracking purchases in different currencies](https://help.adj
 
 The ad revenue object contains properties you can use to report on your ad campaigns.
 
-<Accordion>
-
 ### Ad impressions
 
 Record the number of ad impressions by passing an **integer** value to the <Tooltip>`setAdImpressionsCount` method || <SetAdImpressionsCountSig/></Tooltip>.
 
 <SetAdImpressionsCount />
-
-</Accordion>
-
-<Accordion>
 
 ### Ad revenue network
 
@@ -95,27 +89,17 @@ Record which network generated the revenue by passing a **string** value to the 
 
 <SetAdRevenueNetwork />
 
-</Accordion>
-
-<Accordion>
-
 ### Ad revenue unit
 
 Record which ad revenue unit generated the revenue by passing a **string** value to the <Tooltip>`setAdRevenueUnit` method || <SetAdRevenueUnitSig/></Tooltip>.
 
 <SetAdRevenueUnit />
 
-</Accordion>
-
-<Accordion>
-
 ### Ad revenue placement
 
 Record the placement of your ad by passing a **string** value to the <Tooltip>`setAdRevenuePlacement` method || <SetAdRevenuePlacementSig/></Tooltip>.
 
 <SetAdRevenuePlacement />
-
-</Accordion>
 
 ## Add callback parameters
 

--- a/src/content/docs/en/sdk/unity/features/callbacks.mdx
+++ b/src/content/docs/en/sdk/unity/features/callbacks.mdx
@@ -41,8 +41,6 @@ Set up success callbacks to trigger functions when the SDK records a session.
 
 <SetSessionSuccessDelegate />
 
-<Accordion>
-
 ### Example
 
 This example demonstrates how to created a callback function `sessionSuccess` and register it as a **success** callback. The function logs the timestamp at which the SDK recorded the session.
@@ -59,15 +57,11 @@ public void sessionSuccess (AdjustSessionSuccess sessionSuccessData) {
 }
 ```
 
-</Accordion>
-
 ### Failure callbacks
 
 Set up failure callbacks to trigger functions when the SDK fails to record a session.
 
 <SetSessionFailureDelegate />
-
-<Accordion>
 
 ### Example
 
@@ -84,8 +78,6 @@ public void sessionFailure (AdjustSessionFailure sessionFailureData) {
    Debug.Log("Session recording failed. Response: " + sessionFailureData.Message);
 }
 ```
-
-</Accordion>
 
 ## Event callbacks
 
@@ -113,8 +105,6 @@ Set up success callbacks to trigger functions when the SDK records an event.
 
 <SetEventSuccessDelegate />
 
-<Accordion>
-
 ### Example
 
 This example demonstrates how to created a callback function `eventSuccess` and register it as a **success** callback. The function logs the timestamp at which the SDK recorded the event.
@@ -131,15 +121,11 @@ public void eventSuccess (AdjustEventSuccess eventSuccessData) {
 }
 ```
 
-</Accordion>
-
 ### Failure callbacks
 
 Set up failure callbacks to trigger functions when the SDK fails to record an event.
 
 <SetEventFailureDelegate />
-
-<Accordion>
 
 ### Example
 
@@ -156,5 +142,3 @@ public void eventFailure (AdjustEventFailure eventFailureData) {
    Debug.Log("Event recording failed. Response: " + eventFailureData.Message);
 }
 ```
-
-</Accordion>

--- a/src/content/docs/en/sdk/unity/features/events.mdx
+++ b/src/content/docs/en/sdk/unity/features/events.mdx
@@ -24,8 +24,6 @@ You can associate your [Adjust event tokens](https://help.adjust.com/en/article/
 
 <TrackEvent />
 
-<Accordion>
-
 ### Example
 
 This example demonstrates how to record an event with the token `g3mfiw` whenever a user interacts with a button.
@@ -36,8 +34,6 @@ if (GUI.Button(new Rect(0, Screen.height * 1 / numberOfButtons, Screen.width, Sc
   Adjust.trackEvent(adjustEvent);
 }
 ```
-
-</Accordion>
 
 ## Record event revenue
 
@@ -59,8 +55,6 @@ Check the guide to [tracking purchases in different currencies](https://help.adj
 
 <SetRevenue />
 
-<Accordion>
-
 ### Example
 
 This example demonstrates how to record an event with the token `g3mfiw` whenever a user interacts with a button. The function sets the `revenue` property of this event to _`0.25`_ and the `currency` property to _`EUR`_.
@@ -73,8 +67,6 @@ if (GUI.Button(new Rect(0, Screen.height * 2 / numberOfButtons, Screen.width, Sc
 }
 ```
 
-</Accordion>
-
 ## Unique events
 
 You can pass an optional identifier to avoid recording duplicate events. The SDK stores the last ten identifiers and skips revenue events with duplicate transaction IDs.
@@ -82,8 +74,6 @@ You can pass an optional identifier to avoid recording duplicate events. The SDK
 To set the identifier, call the <Tooltip>`setTransactionId` method || <SetTransactionIdSig /></Tooltip> and pass your transaction ID as a **string** argument.
 
 <SetTransactionId />
-
-<Accordion>
 
 ### Example
 
@@ -97,8 +87,6 @@ if (GUI.Button(new Rect(0, Screen.height * 2 / numberOfButtons, Screen.width, Sc
   Adjust.trackEvent(adjustEvent);
 }
 ```
-
-</Accordion>
 
 ## Add callback parameters
 
@@ -132,8 +120,6 @@ You can read more about using URL callbacks, including a full list of available 
 
 </Callout>
 
-<Accordion>
-
 ### Example
 
 This example demonstrates how to record an event with the token `g3mfiw` whenever a user interacts with a button. The following callback parameters are added:
@@ -156,8 +142,6 @@ if (GUI.Button(new Rect(0, Screen.height * 2 / numberOfButtons, Screen.width, Sc
 }
 ```
 
-</Accordion>
-
 ## Add partner parameters
 
 You can send extra information to your network partners by adding [partner parameters](https://help.adjust.com/en/article/advanced-event-setup#receive-custom-data-with-partner-parameters).
@@ -173,8 +157,6 @@ Partner parameters don't appear in raw data by default. You can add the `{partne
 Add partner parameters to your event by calling the <Tooltip>`addPartnerParameter` method || <AddPartnerParameterSig /></Tooltip> with **string** key-value arguments. You can add multiple parameters by calling this method multiple times.
 
 <AddPartnerParameter />
-
-<Accordion>
 
 ### Example
 
@@ -192,8 +174,6 @@ if (GUI.Button(new Rect(0, Screen.height * 2 / numberOfButtons, Screen.width, Sc
 }
 ```
 
-</Accordion>
-
 ## Add a callback identifier
 
 You can add a custom string identifier to each event you want to measure. Adjust's servers can report on this identifier in event callbacks. This enables you to keep track of which events have been successfully measured.
@@ -201,8 +181,6 @@ You can add a custom string identifier to each event you want to measure. Adjust
 Set up this identifier by calling the <Tooltip>`setCallbackId` method || <SetCallbackIdSig /></Tooltip> with your ID as a **string** argument.
 
 <SetCallbackId />
-
-<Accordion>
 
 ### Example
 
@@ -216,5 +194,3 @@ if (GUI.Button(new Rect(0, Screen.height * 2 / numberOfButtons, Screen.width, Sc
   Adjust.trackEvent(adjustEvent);
 }
 ```
-
-</Accordion>

--- a/src/content/docs/en/sdk/unity/index.mdx
+++ b/src/content/docs/en/sdk/unity/index.mdx
@@ -55,11 +55,12 @@ Adjust.start(adjustConfig);
 
 Apps that target the Google Play Store must use the <Abbr>gps_adid (Google Advertising ID)</Abbr> to identify devices. You need to add the `play-services-ads-identifier` AAR to your project to access the `gps_adid`.
 
-<Accordion>
+<Tabs>
+<Tab sync="google">
 
-### Google External Dependency Manager
+### External Dependency Manager
 
-If you are using the [Google External Dependency Manager plugin](https://developers.google.com/unity/archive#external_dependency_manager_for_unity), add the following to your `Dependencies.xml` file:
+If you are using the [External Dependency Manager plugin](https://developers.google.com/unity/archive#external_dependency_manager_for_unity), add the following to your `Dependencies.xml` file:
 
 ```xml
 <androidPackages>
@@ -67,23 +68,24 @@ If you are using the [Google External Dependency Manager plugin](https://develop
 </androidPackages>
 ```
 
-</Accordion>
-
-<Accordion> 
+</Tab>
+<Tab sync="manual">
 
 ### Manual installation
 
 To install the <Abbr>ARR (Android Archive)</Abbr> manually, [download it from Maven](https://maven.google.com/web/index.html#com.google.android.gms:play-services-ads-identifier:18.0.1 "A link to the AAR artifact on Maven.") and add it to the `Assets/Plugins/Android` directory.
 
-</Accordion>
+</Tab>
+</Tabs>
 
 ### Collect App Set Identifier
 
 The [App Set Identifier](https://developer.android.com/design-for-safety/privacy-sandbox/reference/adservices/appsetid/AppSetId) is a unique identifier that enables you to measure information from any of your apps that a user has installed on their device. All apps by the same developer share the same App Set ID, meaning you can gather meaningful insights from users across all your apps.
 
-<Accordion>
+<Tabs>
+<Tab sync="google">
 
-### Google External Dependency Manager
+### External Dependency Manager
 
 To record a device's App Set ID, you need to add the following dependency to your `Dependencies.xml` file:
 
@@ -93,15 +95,15 @@ To record a device's App Set ID, you need to add the following dependency to you
 </androidPackages>
 ```
 
-</Accordion>
-
-<Accordion>
+</Tab>
+<Tab sync="manual">
 
 ### Manual installation
 
 To install the <Abbr>ARR (Android Archive)</Abbr> manually, [download it from Maven](https://maven.google.com/web/index.html#com.google.android.gms:play-services-appset:16.0.2 "A link to the AAR artifact on Maven.") and add it to the `Assets/Plugins/Android` directory.
 
-</Accordion>
+</Tab>
+</Tabs>
 
 ### Set up Proguard
 
@@ -129,7 +131,8 @@ The install referrer is a unique identifier which you can use to attribute an ap
 -  Use the [Google Play Referrer API](https://developer.android.com/google/play/installreferrer).
 -  Use the Huawei Referrer API.
 
-<Accordion>
+<Tabs>
+<Tab>
 
 ### Google Play Referrer API
 
@@ -145,15 +148,15 @@ dependencies {
 
 2. Download the install referrer library from [Maven](https://maven.google.com/web/index.html?q=install#com.android.installreferrer:installreferrer) and put the <Abbr>ARR (Android Archive)</Abbr> file in your `Plugins/Android` folder.
 
-</Accordion>
-
-<Accordion>
+</Tab>
+<Tab>
 
 ### Huawei Referrer API
 
 As of v4.21.1, the Adjust SDK supports install tracking on Huawei devices using Huawei App Gallery v10.4 and later. You don't need to make any changes to start using the Huawei Referrer API.
 
-</Accordion>
+</Tab>
+</Tabs>
 
 ## 4. Build your app
 
@@ -163,7 +166,8 @@ This process is performed by the `OnPostprocessBuild` method in `AdjustEditor.cs
 
 ![A screenshot of the Adjust SDK post-build configuration script in the Unity editor.](https://images.ctfassets.net/5s247im0esyq/5yFmvFN4y3LJSieJQcF4qE/bad5913682af34cfe61224daca312373/post-build-unity.png)
 
-<Accordion>
+<Tabs>
+<Tab icon="PlatformIos">
 
 ### iOS
 
@@ -178,52 +182,74 @@ The iOS post-build process makes the following changes to your generated Xcode p
 -  Adds the other linker flag `-ObjC`: required to recognize Adjust Objective-C categories at build time.
 -  Enables Objective-C exceptions.
 
-### Frameworks
+#### Frameworks
 
 You can enable the following frameworks to access iOS features:
 
--  <GuiLabel>AdServices.framework</GuiLabel>: required for Apple Search Ads tracking
--  <GuiLabel>AdSupport.framework</GuiLabel>: required to read the device IDFA
--  <GuiLabel>AppTrackingTransparency.framework</GuiLabel>: required to ask for user's consent to be tracked and obtain consent status
--  <GuiLabel>StoreKit.framework</GuiLabel>: required to communicate with the SKAdNetwork framework.
--  <GuiLabel>iAd.framework</GuiLabel> - **Deprecated**. Use `AdServices.framework`
+<GuiLabel>AdServices.framework</GuiLabel>
+: Required for Apple Search Ads tracking
 
-### App Tracking Transparency consent dialog
+<GuiLabel>AdSupport.framework</GuiLabel>
+: Required to read the device IDFA
+
+<GuiLabel>AppTrackingTransparency.framework</GuiLabel>
+: Required to ask for user's consent to be tracked and obtain consent status
+
+<GuiLabel>StoreKit.framework</GuiLabel>
+: Required to communicate with the SKAdNetwork framework.
+
+<GuiLabel>iAd.framework</GuiLabel> <Badge color="warning">Deprecated</Badge>
+: Use `AdServices.framework`
+
+#### App Tracking Transparency consent dialog
 
 If you are using the <Abbr>ATT (App Tracking Transparency)</Abbr> wrapper, enter a **User Tracking Description** message. This displays when you present the tracking consent dialog to your user.
 
-### Deep linking
+#### Deep linking
 
 To enable deep linking, add the following information:
 
--  <GuiLabel>iOS Universal Links Domain</GuiLabel>: the associated domain used for universal links.
--  <GuiLabel>iOS URL Identifier</GuiLabel>: your app's bundle ID.
--  <GuiLabel>iOS URL Schemes</GuiLabel>: the URL scheme associated with your app.
+<GuiLabel>iOS Universal Links Domain</GuiLabel>
+: The associated domain used for universal links.
 
-</Accordion>
+<GuiLabel>iOS URL Identifier</GuiLabel>
+: Your app's bundle ID.
 
-<Accordion> 
+<GuiLabel>iOS URL Schemes</GuiLabel>
+: The URL scheme associated with your app.
+
+</Tab>
+<Tab icon="PlatformAndroid">
 
 ### Android
 
 The Android post-build process checks for an `AndroidManifest.xml` file in `Assets/Plugins/Android/`. If this file isn't present, it creates a copy from [`AdjustAndroidManifest.xml`](https://github.com/adjust/unity_sdk/blob/master/Assets/Adjust/Android/AdjustAndroidManifest.xml "A link to the AdjustAndroidManifest file on GitHub").
 
-### Permissions
+#### Permissions
 
 You can enable the following permissions to access Android features:
 
--  <GuiLabel>android.permission.INTERNET</GuiLabel>: required to connect to the internet.
--  <GuiLabel>android.permission.ACCESS_NETWORK_STATE</GuiLabel>: required to read the type of network the device is connected to.
--  <GuiLabel>com.android.finsky.permission.BIND_GET_INSTALL_REFERRER_SERVICE</GuiLabel>: **Deprecated**. Required to fetch install referrer information via Google Play Store intent.
--  <GuiLabel>com.google.android.gms.permission.AD_ID</GuiLabel>: required to read the device advertising ID on Android 12 (API level 31) and above. See [Google's `AdvertisingIdClient.info` documentation](https://developers.google.com/android/reference/com/google/android/gms/ads/identifier/AdvertisingIdClient.Info#public-string-getid) for more information.
+<GuiLabel>android.permission.INTERNET</GuiLabel>
+: Required to connect to the internet.
 
-### Deep linking
+<GuiLabel>android.permission.ACCESS_NETWORK_STATE</GuiLabel>
+: Required to read the type of network the device is connected to.
+
+<GuiLabel>com.android.finsky.permission.BIND_GET_INSTALL_REFERRER_SERVICE</GuiLabel> <Badge color="warning">Deprecated</Badge>
+: Required to fetch install referrer information via Google Play Store intent.
+
+<GuiLabel>com.google.android.gms.permission.AD_ID</GuiLabel>
+: Required to read the device advertising ID on Android 12 (API level 31) and above. See [Google's `AdvertisingIdClient.info` documentation](https://developers.google.com/android/reference/com/google/android/gms/ads/identifier/AdvertisingIdClient.Info#public-string-getid) for more information.
+
+#### Deep linking
 
 To enable deep linking, add the following information:
 
--  <GuiLabel>Android URI Schemes</GuiLabel>: the destination of your deep link.
+<GuiLabel>Android URI Schemes</GuiLabel>
+: The destination of your deep link.
 
-</Accordion>
+</Tab>
+</Tabs>
 
 ## 5. Add the Adjust SDK signature
 
@@ -233,24 +259,20 @@ To get started with the Adjust SDK signature, contact your Technical Account Man
 
 ## 6. Test your integration
 
-The Adjust SDK provides tools for testing and troubleshooting issues with your integration. To test your setup:
-
--  Set your environment to **Sandbox**.
--  Add a sandbox filter to your Adjust dashboard results.
--  Set your [log level](/en/sdk/unity/configuration/log-level) to **verbose**.
-
 <Callout type="tip">
 
 If you encounter any issues, email support@adjust.com with all details and logs.
 
 </Callout>
 
-<Accordion>
+The Adjust SDK provides tools for testing and troubleshooting issues with your integration. To test your setup:
+
+-  Set your environment to **Sandbox**.
+-  Add a sandbox filter to your Adjust dashboard results.
+-  Set your [log level](/en/sdk/unity/configuration/log-level) to **verbose**.
 
 ### Test Google Play Services integration
 
 To test that the Adjust SDK can receive a device's Google Advertising ID, set the [log level](/en/sdk/unity/configuration/log-level) to **verbose** and the environment to **Sandbox**. Start your app and measure a `session` or an event. The SDK logs the <Abbr>gps_adid (Google Play Services Advertiser ID)</Abbr> parameter if it has read the advertising ID.
 
 If you are having issues retrieving the Google Advertising ID, open an issue in the [GitHub repository](https://github.com/adjust/unity_sdk) or contact support@adjust.com.
-
-</Accordion>

--- a/src/content/docs/en/sdk/web/features/events.mdx
+++ b/src/content/docs/en/sdk/web/features/events.mdx
@@ -15,8 +15,6 @@ You can associate your [Adjust event tokens](https://help.adjust.com/en/article/
 
 <TrackEvent />
 
-<Accordion>
-
 ### Example
 
 This example demonstrates how to record an event with the token _`g3mfiw`_ whenever a user interacts with a button.
@@ -49,8 +47,6 @@ _timeoutId = setTimeout(() => {
 
 ```
 
-</Accordion>
-
 ## Record event revenue
 
 You can record revenue associated with an event by setting the `revenue` and `currency` properties on your event instance. Use this feature to record revenue-generating actions in your app.
@@ -78,8 +74,6 @@ Adjust.trackEvent({
    currency: "EUR",
 });
 ```
-
-<Accordion>
 
 ### Example
 
@@ -114,8 +108,6 @@ _timeoutId = setTimeout(() => {
 }
 ```
 
-</Accordion>
-
 ## Unique events
 
 You can pass an optional identifier to avoid measuring duplicate events. The SDK stores the last 10 identifiers and skips revenue events with duplicate transaction IDs.
@@ -128,8 +120,6 @@ Adjust.trackEvent({
    deduplicationId: "{YourDeduplicationId}",
 });
 ```
-
-<Accordion>
 
 ### Example
 
@@ -163,8 +153,6 @@ _timeoutId = setTimeout(() => {
 }
 
 ```
-
-</Accordion>
 
 You can override the deduplication limit to change the number of identifiers the Adjust SDK stores. To do this, specify the new limit in the `eventDeduplicationListLimit` argument of the <Tooltip>`initSdk` method || <InitSdk /></Tooltip>.
 
@@ -216,8 +204,6 @@ You can read more about using URL callbacks, including a full list of available 
 
 </Callout>
 
-<Accordion>
-
 ### Example
 
 This example demonstrates how to record an event with the token _`g3mfiw`_ whenever a user interacts with a button. The following callback parameters are added:
@@ -262,8 +248,6 @@ _timeoutId = setTimeout(() => {
 }
 ```
 
-</Accordion>
-
 ## Add partner parameters
 
 You can send extra information to your network partners by adding [partner parameters](https://help.adjust.com/en/article/advanced-event-setup#receive-custom-data-with-partner-parameters).
@@ -287,8 +271,6 @@ Adjust.trackEvent({
    ],
 });
 ```
-
-<Accordion>
 
 ### Example
 
@@ -329,8 +311,6 @@ _timeoutId = setTimeout(() => {
 
 ```
 
-</Accordion>
-
 ## Record event and redirect to an external page
 
 You can record redirects to external pages as events with the Adjust SDK. To ensure the SDK records the event before the redirect happens, the <Tooltip>`trackEvent` method || <TrackEventSig /></Tooltip> returns a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). This `Promise` is fulfilled after the SDK receives a response from Adjust's servers. If an internal error response is returned, the `Promise` is rejected.
@@ -342,8 +322,6 @@ The promise can take a long time to resolve. Adding a timeout is recommended.
 </Callout>
 
 The Adjust SDK saves events to an internal queue. This means that even if your request times out or an error occurs, the SDK preserves the event to retry later.
-
-<Accordion>
 
 ### Example
 
@@ -365,5 +343,3 @@ Promise.race([
       window.location.href = "https://www.example.org/";
    });
 ```
-
-</Accordion>

--- a/src/content/docs/en/sdk/web/reference/adjust/recording.mdx
+++ b/src/content/docs/en/sdk/web/reference/adjust/recording.mdx
@@ -34,6 +34,7 @@ import TrackEvent from "@web-examples/Adjust/trackEvent.mdx"
 : Your Adjust event parameters.
 
 <Accordion>
+
 ### EventParams
 
 `eventToken` (string)

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -191,7 +191,7 @@ article ul {
   }
 }
 
-article ul li:not(#tabs-container li)::before {
+article ul li:not([role=tab])::before {
   content: "•";
   font-weight: 500;
   position: absolute;


### PR DESCRIPTION
As discussed with Marcie, we tend to rely on accordions to make pages look neater. However, it isn't obvious to all users that accordions are expandable, which can lead to important information being hidden.

Accordions should be used only to hide **supplementary** or **non-essential** information that is available elsewhere, such as lists of parameters. They should **not** be used to hide examples, alternative methods for achieving a goal, nor for anything else that is essential to informing the reader. This information should be structured appropriately in the page to make it more easily searchable and to give the reader all the information they might need in one glance. In cases of multiple sets of instructions being available, Tab elements are preferred.

This PR removes unnecessary accordions to put content front and center where needed.