### PR TITLE
Add minor version badges

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -39,6 +39,7 @@ export default defineConfig({
         "@components/Tooltip.astro",
         "@components/Version.astro",
         "@components/FigmaEmbed/FigmaEmbed.astro",
+        "@components/MinorVersion.astro",
       ],
     }),
     // Enable React for the Algolia search component.

--- a/src/components/MinorVersion.astro
+++ b/src/components/MinorVersion.astro
@@ -1,5 +1,5 @@
 ---
-import { Badge as AtlasBadge, type IconName } from "@adjust/components";
+import { Badge as AtlasBadge, type IconName} from "@adjust/components";
 
 export interface Props {
   added?: string;
@@ -7,11 +7,11 @@ export interface Props {
   removed?: string;
 }
 
-const {added = null, changed = null, removed = null} = Astro.props as Props;
+const {added, changed, removed} = Astro.props as Props;
 
-let badgeIcon: IconName
+let badgeIcon: IconName = "Info"
 let version: string | undefined
-let color: BadgeColor
+let color: BadgeColor = "neutral"
 
 if (added) {
   version = `Added in ${added}`
@@ -33,5 +33,13 @@ if (removed) {
 
 ---
 
-<AtlasBadge client:only="react" color={color} iconName={badgeIcon} label={version} /><slot />
+<AtlasBadge
+  client:only="react"
+  color={color}
+  iconName={badgeIcon}
+  label={version}
+  css={{ marginBottom: "1rem" }}
+  allowFullWidth
+/>
+<slot />
 

--- a/src/components/MinorVersion.astro
+++ b/src/components/MinorVersion.astro
@@ -1,0 +1,37 @@
+---
+import { Badge as AtlasBadge, type IconName } from "@adjust/components";
+
+export interface Props {
+  added?: string;
+  changed?: string;
+  removed?: string;
+}
+
+const {added = null, changed = null, removed = null} = Astro.props as Props;
+
+let badgeIcon: IconName
+let version: string | undefined
+let color: BadgeColor
+
+if (added) {
+  version = `Added in ${added}`
+  badgeIcon = "Check"
+  color = "positive"
+}
+
+if (changed) {
+  version = `Changed in ${changed}`
+  badgeIcon = "Negative"
+  color = "warning"
+}
+
+if (removed) {
+  version = `Deprecated in ${removed}`
+  badgeIcon = "Cross"
+  color = "negative"
+}
+
+---
+
+<AtlasBadge client:only="react" color={color} iconName={badgeIcon} label={version} /><slot />
+

--- a/src/content/docs/en/kitchen-sink/minor-version.mdx
+++ b/src/content/docs/en/kitchen-sink/minor-version.mdx
@@ -1,0 +1,65 @@
+---
+title: "Minor versions"
+description: "Reference for the minor version component"
+slug: en/kitchen-sink/minor-versions
+---
+
+Use the Minor Version component to indicate when an SDK feature was introduced, changed, or deprecated.
+
+## Props
+
+This component should contain **only one** of the following properties. Each should take the format `v.{version_number}`.
+
+<Table>
+
+| Prop      | Data type | Required | Description                                     |
+| --------- | --------- | -------- | ----------------------------------------------- |
+| `added`   | string    | No       | The version in which the feature was added.     |
+| `changed` | string    | No       | The version in which the feature was changed.   |
+| `removed` | string    | No       | The version in which the feature was deprecated |
+
+</Table>
+
+## Examples
+
+```mdx
+<MinorVersion added="v4.24.0">
+
+The `trackEvent` feature enables you to send event information from your mobile app to Adjust's servers.
+
+</MinorVersion>
+```
+
+<MinorVersion added="v4.24.0">
+
+The `trackEvent` feature enables you to send event information from your mobile app to Adjust's servers.
+
+</MinorVersion>
+
+```mdx
+<MinorVersion changed="v4.24.0">
+
+The `trackEvent` feature enables you to send event information from your mobile app to Adjust's servers.
+
+</MinorVersion>
+```
+
+<MinorVersion changed="v4.24.0">
+
+The `trackEvent` feature enables you to send event information from your mobile app to Adjust's servers.
+
+</MinorVersion>
+
+```mdx
+<MinorVersion removed="v4.24.0">
+
+The `trackEvent` feature enables you to send event information from your mobile app to Adjust's servers.
+
+</MinorVersion>
+```
+
+<MinorVersion removed="v4.24.0">
+
+The `trackEvent` feature enables you to send event information from your mobile app to Adjust's servers.
+
+</MinorVersion>

--- a/src/content/docs/en/kitchen-sink/test-page.mdx
+++ b/src/content/docs/en/kitchen-sink/test-page.mdx
@@ -17,9 +17,9 @@ sidebar-position: 1
 
 ## Typography
 
-- Unordered
-- Bullet
-- List
+-  Unordered
+-  Bullet
+-  List
 
 1. Ordered
 2. Bullet
@@ -44,7 +44,9 @@ Select the copy button (<Icon name="Copy" />).
 
 <Badge color="important">An important badge</Badge>
 
-<Badge color="warning" icon="Warning">Warning with icon</Badge>
+<Badge color="warning" icon="Warning">
+   Warning with icon
+</Badge>
 
 Select <MenuSelection>File --> My Profile --> Billing</MenuSelection>
 
@@ -349,3 +351,23 @@ _It_ **contains** [Markdown](https://www.markdownguide.org/).
 </Table>
 
 [Reference link]: https://help.adjust.com
+
+## Feature versions
+
+<MinorVersion added="v4.20.0">
+
+This feature was introduced in version 4.20.0
+
+</MinorVersion>
+
+<MinorVersion changed="v4.21.0">
+
+This feature was changed in version 4.21.0
+
+</MinorVersion>
+
+<MinorVersion removed="v4.22.0">
+
+This feature was removed in version 4.22.0
+
+</MinorVersion>


### PR DESCRIPTION
This MR adds support for a new component that adds a badge displaying the relevant version information for minor version changes. This appears as a badge above the enclosed text.