### PR TITLE
Add script for translation fixes

### DIFF
--- a/.github/scripts/fix-i18n.sh
+++ b/.github/scripts/fix-i18n.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+LOCALES=("ja" "ko" "zh")
+
+for locale in ${LOCALES[@]}; do
+
+   # Fix broken MDX components in all files
+
+   for file in src/content/docs/**/*-$locale.mdx; do
+      echo "Fixing formatting for $locale content";
+
+      sed -i -e 's/<abbr/<Abbr/g' $file;
+      sed -i -e 's/[^\n]<accordion/\n\n<Accordion/g' $file;
+      sed -i -e 's/<accordion/<Accordion/g' $file;
+      sed -i -e 's/<badge/<Badge/g' $file;
+      sed -i -e 's/[^\n]<callout/\n\n<Callout/g' $file;
+      sed -i -e 's/<callout/<Callout/g' $file;
+      sed -i -e 's/<icon/<Icon/g' $file;
+      sed -i -e 's/<menuselection/<MenuSelection/g' $file;
+      sed -i -e 's/[^\n]<minorversion/\n\n<MinorVersion/g' $file;
+      sed -i -e 's/<minorversion/<MinorVersion/g' $file;
+      sed -i -e 's/[^\n]<table/\n\n<Table/g' $file;
+      sed -i -e 's/<table/<Table/g' $file;
+      sed -i -e 's/[^\n]<tabs/\n\n<Tabs/g' $file;
+      sed -i -e 's/<tabs/<Tabs/g' $file;
+      sed -i -e 's/[^\n]<\/Tabs/\n<\/Tabs/g' $file;
+      sed -i -e 's/[^\n]<tab/\n<Tab/g' $file;
+      sed -i -e 's/<tab/<Tab/g' $file;
+      sed -i -e 's/[^\n]<tile/\n\n<Tile/g' $file;
+      sed -i -e 's/<tile/<Tile/g' $file;
+
+      # Add newlines before the ending tag, if needed
+
+      sed -zri  's/([^\n]\n)(<\/Callout)/\1\n\2/g' $file;
+      sed -zri  's/([^\n]\n)(<\/Tile)/\1\n\2/g' $file;
+      sed -zri  's/([^\n]\n)(<\/Tab>)/\1\n\2/g' $file;
+      sed -zri  's/([^\n]\n)(<\/Accordion)/\1\n\2/g' $file;
+      sed -zri  's/([^\n]\n)(<\/MinorVersion)/\1\n\2/g' $file;
+   done;
+
+   # Replace slugs
+
+   for file in src/content/docs/**/*-$locale.mdx; do
+      echo "Updating slugs for $locale content";
+      sed -i -E "s/(slug)(.*)(en)/\1\2$locale/g" $file;
+   done;
+
+   for file in src/content/docs/**/*-$locale.mdx; do
+      echo "Updating URLs for $locale content";
+      sed -i -E "s/\/en\//\/$locale\//g" $file;
+   done;
+
+done;

--- a/.github/scripts/fix-i18n.sh
+++ b/.github/scripts/fix-i18n.sh
@@ -1,53 +1,40 @@
 #!/bin/sh
 
-LOCALES=("ja" "ko" "zh")
+set -- ja ko zh
 
-for locale in ${LOCALES[@]}; do
+for locale in "$@"; do
 
-   # Fix broken MDX components in all files
+    # Fix broken MDX components in all files
 
-   for file in src/content/docs/**/*-$locale.mdx; do
-      echo "Fixing formatting for $locale content";
+    find 'src/content/docs/' -name "*-$locale.mdx" -type f -exec sh -c \
+    'for file do echo '\''Fixing formatting for '"${locale}"' content'\''; \
+    sed -i -e "s/<abbr/<Abbr/g ; \
+    s/[^\n]<accordion/\n\n<Accordion/g ; \
+    s/<accordion/<Accordion/g ; \
+    s/<badge/<Badge/g ; \
+    s/[^\n]<callout/\n\n<Callout/g ; \
+    s/<callout/<Callout/g ; \
+    s/<icon/<Icon/g ; \
+    s/<menuselection/<MenuSelection/g ; \
+    s/[^\n]<minorversion/\n\n<MinorVersion/g ; \
+    s/<minorversion/<MinorVersion/g ; \
+    s/[^\n]<table/\n\n<Table/g ; \
+    s/<table/<Table/g ; \
+    s/[^\n]<tabs/\n\n<Tabs/g ; \
+    s/<tabs/<Tabs/g ; \
+    s/[^\n]<\/Tabs/\n<\/Tabs/g ; \
+    s/[^\n]<tab/\n<Tab/g ; \
+    s/<tab/<Tab/g ; \
+    s/[^\n]<tile/\n\n<Tile/g ; \
+    s/<tile/<Tile/g" "${file}"; \
+    sed -zri -e  "s/([^\n]\n)(<\/Callout)/\1\n\2/g ; \
+    s/([^\n]\n)(<\/Tile)/\1\n\2/g ; \
+    s/([^\n]\n)(<\/Tab>)/\1\n\2/g ; \
+    s/([^\n]\n)(<\/Accordion)/\1\n\2/g ; \
+    s/([^\n]\n)(<\/MinorVersion)/\1\n\2/g" "${file}"; \
+    echo "Updating slugs for '"${locale}"' content"; \
+    sed -i -E "s/(slug)(.*)(en)/\1\2'"${locale}"'/g" "${file}"; \
+    echo "Updating URLs for '"${locale}"' content"; \
+    sed -i -E "s/\/en\//\/'"${locale}"'\//g" "${file}"; done' none {} +
 
-      sed -i -e 's/<abbr/<Abbr/g' $file;
-      sed -i -e 's/[^\n]<accordion/\n\n<Accordion/g' $file;
-      sed -i -e 's/<accordion/<Accordion/g' $file;
-      sed -i -e 's/<badge/<Badge/g' $file;
-      sed -i -e 's/[^\n]<callout/\n\n<Callout/g' $file;
-      sed -i -e 's/<callout/<Callout/g' $file;
-      sed -i -e 's/<icon/<Icon/g' $file;
-      sed -i -e 's/<menuselection/<MenuSelection/g' $file;
-      sed -i -e 's/[^\n]<minorversion/\n\n<MinorVersion/g' $file;
-      sed -i -e 's/<minorversion/<MinorVersion/g' $file;
-      sed -i -e 's/[^\n]<table/\n\n<Table/g' $file;
-      sed -i -e 's/<table/<Table/g' $file;
-      sed -i -e 's/[^\n]<tabs/\n\n<Tabs/g' $file;
-      sed -i -e 's/<tabs/<Tabs/g' $file;
-      sed -i -e 's/[^\n]<\/Tabs/\n<\/Tabs/g' $file;
-      sed -i -e 's/[^\n]<tab/\n<Tab/g' $file;
-      sed -i -e 's/<tab/<Tab/g' $file;
-      sed -i -e 's/[^\n]<tile/\n\n<Tile/g' $file;
-      sed -i -e 's/<tile/<Tile/g' $file;
-
-      # Add newlines before the ending tag, if needed
-
-      sed -zri  's/([^\n]\n)(<\/Callout)/\1\n\2/g' $file;
-      sed -zri  's/([^\n]\n)(<\/Tile)/\1\n\2/g' $file;
-      sed -zri  's/([^\n]\n)(<\/Tab>)/\1\n\2/g' $file;
-      sed -zri  's/([^\n]\n)(<\/Accordion)/\1\n\2/g' $file;
-      sed -zri  's/([^\n]\n)(<\/MinorVersion)/\1\n\2/g' $file;
-   done;
-
-   # Replace slugs
-
-   for file in src/content/docs/**/*-$locale.mdx; do
-      echo "Updating slugs for $locale content";
-      sed -i -E "s/(slug)(.*)(en)/\1\2$locale/g" $file;
-   done;
-
-   for file in src/content/docs/**/*-$locale.mdx; do
-      echo "Updating URLs for $locale content";
-      sed -i -E "s/\/en\//\/$locale\//g" $file;
-   done;
-
-done;
+done

--- a/.github/workflows/fix_translations.yml
+++ b/.github/workflows/fix_translations.yml
@@ -1,0 +1,21 @@
+name: Fix translations
+on:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  i18n-fixes:
+    name: Fix translated files
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout the latest commit
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - name: Run translation fixes script
+        run: sh .github/scripts/fix-i18n.sh
+      - name: Commit changes
+        run: |
+          git config --global user.name github-actions
+          git config --global user.email github-actions@github.com
+          git commit -am "Fix translated files"
+          git push

--- a/.github/workflows/fix_translations.yml
+++ b/.github/workflows/fix_translations.yml
@@ -13,7 +13,11 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Run translation fixes script
         run: sh .github/scripts/fix-i18n.sh
+      - name: Check for modified files
+        id: git-check
+        run: echo ::set-output name=modified::$(if [ -n "$(git status --porcelain)" ]; then echo "true"; else echo "false"; fi)
       - name: Commit changes
+        if: steps.git-check.outputs.modified == 'true'
         run: |
           git config --global user.name github-actions
           git config --global user.email github-actions@github.com


### PR DESCRIPTION
This PR adds a new script and GitHub action for fixing files received from Smartling. It anticipates a file structure like this: `src/content/docs/**/*-${locale}.mdx`.

The script fixes all MDX-related formatting issues as well as performing string replacements for the `en` locale code. It is written entirely in POSIX-compliant shell for maximum portability.