### PR TITLE
Double endpoint documentation

### DIFF
--- a/src/content/docs/sdk/ios/features/att.mdx
+++ b/src/content/docs/sdk/ios/features/att.mdx
@@ -149,3 +149,29 @@ Adjust.checkForNewAttStatus();
 
 </Tab>
 </Tabs>
+
+## iOS 17 consent handling
+
+With the release of iOS 17, Apple implemented new rules on what data developers may send to third-parties. To ensure that developers can easily demonstrate compliance with Apple’s privacy guidelines, the Adjust SDK makes use of two separate endpoints for **consenting** and **non-consenting** users.
+
+By default, the Adjust SDK sends a limited set of data to Adjust’s servers for **probabilistic modeling** using the `analytics.adjust.com` endpoint. This endpoint **doesn’t** receive the following information:
+
+-  `idfa`: The device ID For Advertisers (IDFA).
+-  `started_at`: The device startup time.
+
+Only if the user [grants ATT consent](#app-tracking-authorization-wrapper), the Adjust SDK gains access to both the idfa and started_at properties for **deterministic attribution** and sends the full payload to `consent.adjust.com`.
+
+Both of these endpoints are available for all [URL strategies](/en/sdk/ios/features/privacy#data-residency).
+
+<Table>
+
+| URL strategy          | Non-consented endpoint    | Consented endpoint      |
+| --------------------- | ------------------------- | ----------------------- |
+| `ADJDataResidencyEU`  | `analytics.eu.adjust.com` | `consent.eu.adjust.com` |
+| `ADJDataResidencyTR`  | `analytics.tr.adjust.com` | `consent.tr.adjust.com` |
+| `ADJDataResidencyUS`  | `analytics.us.adjust.com` | `consent.us.adjust.com` |
+| `ADJUrlStrategyChina` | `analytics.adjust.world`  | `consent.adjust.world`  |
+| `ADJUrlStrategyCn`    | `analytics.adjust.cn`     | `consent.adjust.cn`     |
+| `ADJUrlStrategyIndia` | `analytics.adjust.net.in` | `consent.adjust.net.in` |
+
+</Table>

--- a/src/content/docs/sdk/ios/features/att.mdx
+++ b/src/content/docs/sdk/ios/features/att.mdx
@@ -152,7 +152,11 @@ Adjust.checkForNewAttStatus();
 
 ## iOS 17 consent handling
 
+<MinorVersion added="v4.38.0">
+
 With the release of iOS 17, Apple implemented new rules on what data developers may send to third-parties. To ensure that developers can easily demonstrate compliance with Apple’s privacy guidelines, the Adjust SDK makes use of two separate endpoints for **consenting** and **non-consenting** users.
+
+</MinorVersion>
 
 By default, the Adjust SDK sends a limited set of data to Adjust’s servers for **probabilistic modeling** using the `analytics.adjust.com` endpoint. This endpoint **doesn’t** receive the following information:
 


### PR DESCRIPTION
Adds documentation for the double endpoint solution and its interaction with ATT.

https://adjustcom.atlassian.net/browse/ADAPP-17446