### PR TITLE
Reenable experimental build cache

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -48,5 +48,8 @@ export default defineConfig({
         ...defListHastHandlers
       }
     }
+  },
+  experimental: {
+    contentCollectionCache: true
   }
 });


### PR DESCRIPTION
As the site grows, each build takes longer to complete. Astro has an [experimental caching feature](https://docs.astro.build/en/reference/configuration-reference/#experimentalcontentcollectioncache) which aims to reduce this by creating manifests of the content collection for each build and building only what is changed in each version.

Previously, this caused issues with styling and output. However, with the stabilization of our content collection and the inlining of all critical styles it's worth enabling this again to see if it can improve build performance.