### PR TITLE
Skip Vercel builds for Smartling user

### DIFF
--- a/.github/workflows/fix_translations.yml
+++ b/.github/workflows/fix_translations.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Commit changes
         if: ${{ steps.git-check.outputs.MODIFIED == 'true' }}
         run: |
-          git config --global user.name "adjust-pc-team"
-          git config --global user.email "153073226+adjust-pc-team@users.noreply.github.com"
+          git config --global user.name "github-actions"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -am "Fix translated files"
           git push

--- a/skip-smartling-build.sh
+++ b/skip-smartling-build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo "VERCEL_GIT_COMMIT_REF: $VERCEL_GIT_COMMIT_REF"
+
+AUTHOR=$(git show $(git log --format="%H" -n 1) | grep Author)
+
+echo "$AUTHOR"
+
+if [[ "$AUTHOR" != "Author: adjust-pc-team <153073226+adjust-pc-team@users.noreply.github.com>" ]]
+then
+   echo "Building site"
+   exit 1;
+else
+   # Don't build
+   echo "Skipping build from Smartling pending fixes"
+   exit 0;
+fi


### PR DESCRIPTION
Vercel is getting interrupted when building the sites for Smartling's commits. Given that Smartling commits are usually broken by default, we should only run the build process once we receive a commit from a different author.