### PR TITLE
THC 943 set up translatable UI strings

### DIFF
--- a/src/components/Layout/Footer/FooterLanguageSwitch.astro
+++ b/src/components/Layout/Footer/FooterLanguageSwitch.astro
@@ -1,5 +1,6 @@
 ---
-import { getLanguageFromURL, LOCALE_NAMES } from "@i18n/locales";
+import { LOCALE_NAMES } from "@i18n/locales";
+import { getLanguageFromURL } from "@i18n/utils";
 import LanguageSwitch from "../LanguageSwitch";
 import { Icon } from "@adjust/components";
 

--- a/src/components/Layout/Header/MainHeader.astro
+++ b/src/components/Layout/Header/MainHeader.astro
@@ -1,7 +1,7 @@
 ---
 import { Icon } from "@adjust/components";
 
-import { getLanguageFromURL } from "@i18n/locales";
+import { getLanguageFromURL } from "@i18n/utils";
 import AudienceDropdown from "../AudienceDropdown";
 import { HELP_CENTER_LINK } from "src/consts";
 

--- a/src/components/Layout/Header/MobileHeader.astro
+++ b/src/components/Layout/Header/MobileHeader.astro
@@ -1,6 +1,6 @@
 ---
 import IconSearch from "@components/Icons/astro/IconSearch.astro";
-import { getLanguageFromURL } from "@i18n/locales";
+import { getLanguageFromURL } from "@i18n/utils";
 
 import MenuToggle from "./SidebarToggle";
 

--- a/src/components/Layout/LeftSidebar/Navigation.astro
+++ b/src/components/Layout/LeftSidebar/Navigation.astro
@@ -1,7 +1,7 @@
 ---
 import classNames from "classnames";
 
-import { getLanguageFromURL } from "@i18n/locales";
+import { getLanguageFromURL } from "@i18n/utils";
 import NavigationItem from "./NavigationItem";
 import { getCurrentPage } from "@utils/helpers/navigation/getCurrentPage";
 

--- a/src/components/Layout/LeftSidebar/SidebarSearch/SidebarSearch.astro
+++ b/src/components/Layout/LeftSidebar/SidebarSearch/SidebarSearch.astro
@@ -1,6 +1,6 @@
 ---
 import IconSearch from "@components/Icons/astro/IconSearch.astro";
-import { getLanguageFromURL } from "@i18n/locales";
+import { getLanguageFromURL } from "@i18n/utils";
 
 const currentLang = getLanguageFromURL(Astro.url.pathname);
 ---

--- a/src/i18n/locales.ts
+++ b/src/i18n/locales.ts
@@ -7,13 +7,5 @@ export const LOCALE_NAMES: Locales = {
   ko: "한국어",
 };
 
-export const langPathRegex = /\/([a-z]{2}-?[A-Z]{0,2})(\/|$)/;
-export const langParamRegex = /(^|\/)([a-z]{2}-?[A-Z]{0,2})(\/|$)/;
-
 export const KNOWN_LANGUAGE_CODES = Object.keys(LOCALE_NAMES);
-
-export const getLanguageFromURL = (pathname: string) => {
-  const langCodeMatch = pathname.match(langPathRegex);
-  const langCode = langCodeMatch ? langCodeMatch[1] : "en";
-  return langCode as keyof Locales;
-};
+export const defaultLang = "en";

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -1,0 +1,4 @@
+{
+  "home.welcome": "Welcome to the Adjust Developer Hub",
+  "home.search": "Search"
+}

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -1,0 +1,4 @@
+{
+  "home.welcome": "Welcome to the Adjust Developer Hub",
+  "home.search": "Search"
+}

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -1,0 +1,4 @@
+{
+  "home.welcome": "Welcome to the Adjust Developer Hub",
+  "home.search": "Search"
+}

--- a/src/i18n/translations/zh.json
+++ b/src/i18n/translations/zh.json
@@ -1,0 +1,4 @@
+{
+  "home.welcome": "Welcome to the Adjust Developer Hub",
+  "home.search": "Search"
+}

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -1,0 +1,11 @@
+import en from "./translations/en.json";
+import ja from "./translations/ja.json";
+import ko from "./translations/ko.json";
+import zh from "./translations/zh.json";
+
+export const ui = {
+  en,
+  ja,
+  ko,
+  zh,
+} as const;

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -1,0 +1,17 @@
+import { defaultLang, type Locales } from "./locales";
+import { ui } from "./ui";
+
+export const langPathRegex = /\/([a-z]{2}-?[A-Z]{0,2})(\/|$)/;
+export const langParamRegex = /(^|\/)([a-z]{2}-?[A-Z]{0,2})(\/|$)/;
+
+export const getLanguageFromURL = (pathname: string) => {
+  const langCodeMatch = pathname.match(langPathRegex);
+  const langCode = langCodeMatch ? langCodeMatch[1] : "en";
+  return langCode as keyof Locales;
+};
+
+export const useTranslations = (lang: keyof typeof ui) => {
+  return function t(key: keyof (typeof ui)[typeof defaultLang]) {
+    return ui[lang][key] || ui[defaultLang][key];
+  };
+};

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -12,7 +12,8 @@ import { getNavigationEntries } from "src/utils/helpers/navigation/getNavigation
 import SidebarHeader from "@components/Layout/LeftSidebar/SidebarHeader/SidebarHeader.astro";
 import SidebarSearch from "@components/Layout/LeftSidebar/SidebarSearch/SidebarSearch.astro";
 import LanguageSwitch from "@components/Layout/LanguageSwitch";
-import { LOCALE_NAMES, getLanguageFromURL } from "@i18n/locales";
+import { LOCALE_NAMES } from "@i18n/locales";
+import { getLanguageFromURL } from "@i18n/utils";
 import MobileHeader from "@components/Layout/Header/MobileHeader.astro";
 import Footer from "@components/Layout/Footer/FooterContent.astro";
 import BodyNoScript from "@components/Layout/GoogleTagManager/BodyNoScript.astro";

--- a/src/pages/[lang]/[...slug].astro
+++ b/src/pages/[lang]/[...slug].astro
@@ -2,7 +2,8 @@
 import { differenceBy } from "lodash-es";
 import { type CollectionEntry, getCollection } from "astro:content";
 import MainLayout from "./../../layouts/MainLayout.astro";
-import { KNOWN_LANGUAGE_CODES, langParamRegex } from "@i18n/locales";
+import { KNOWN_LANGUAGE_CODES } from "@i18n/locales";
+import { langParamRegex } from "@i18n/utils";
 import { SITE } from "src/consts";
 
 export async function getStaticPaths() {

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -6,8 +6,9 @@ import HeadCommon from "@components/HeadCommon.astro";
 import HeadSEO from "@components/HeadSEO.astro";
 import MainHeader from "@components/Layout/Header/MainHeader.astro";
 import { SITE } from "src/consts";
-import { KNOWN_LANGUAGE_CODES } from "@i18n/locales";
+import { KNOWN_LANGUAGE_CODES, type Locales } from "@i18n/locales";
 import BodyNoScript from "@components/Layout/GoogleTagManager/BodyNoScript.astro";
+import { useTranslations } from "@i18n/utils";
 
 export const getStaticPaths = () => {
   return KNOWN_LANGUAGE_CODES.flatMap((langKey) => ({
@@ -33,6 +34,7 @@ const topCategories = [
 ];
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+const t = useTranslations(lang as keyof Locales);
 ---
 
 <html dir={`/${lang}`} lang={lang} class="initial">
@@ -52,7 +54,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
       <h1
         class="text-heading-1 xs:pt-6 md:pt-0 mb-[106px] font-semibold mx-auto"
       >
-        Welcome to the Adjust Developer Hub
+        {t("home.welcome")}
       </h1>
       <div class="w-full max-w-[790px] mb-[106px]">
         <a
@@ -62,7 +64,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
           <div>
             <IconSearch color="#000" />
           </div>
-          <span class="font-medium pl-2.5">Search</span>
+          <span class="font-medium pl-2.5">{t("home.search")}</span>
         </a>
       </div>
       <div


### PR DESCRIPTION
Added basic setup for the UI translations using this approach: https://docs.astro.build/en/recipes/i18n/#translate-ui-strings

I`ve created a separate folder for the translations strings to be sure that we will be able to properly pickup these files on the Smartling side