### PR TITLE
Enable sharing versioned content with query param

### DIFF
--- a/src/components/Version/ApiVersionSwitch.tsx
+++ b/src/components/Version/ApiVersionSwitch.tsx
@@ -3,8 +3,12 @@ import { ComboBox } from "@adjust/components";
 import { useStore } from "@nanostores/react";
 import type { Locales } from "@i18n/locales";
 import { useTranslations } from "@i18n/utils";
-
+import type { Option } from "@adjust/components/build/ComboBox/ComboBox";
 import { $versions, changeVersionValue } from "@store/apiVersionsStore";
+import {
+  getQueryParameter,
+  updateQueryParameter,
+} from "@components/utils/queryParamHelpers";
 
 const VersionSwitch: FC<{ lang: string }> = ({ lang }) => {
   const t = useTranslations(lang as keyof Locales);
@@ -22,8 +26,27 @@ const VersionSwitch: FC<{ lang: string }> = ({ lang }) => {
     const higherVersion = versions.items.reduce((prev, current) =>
       prev && prev.value > current.value ? prev : current,
     );
-    changeVersionValue(higherVersion);
+    const queryVersion = getQueryParameter("version");
+    if (
+      queryVersion &&
+      versions.items.some((version) => version.label === queryVersion)
+    ) {
+      const versionOption: Option = {
+        label: queryVersion,
+        value: queryVersion,
+      };
+      changeVersionValue(versionOption);
+    } else {
+      changeVersionValue(higherVersion);
+    }
   }, []);
+
+  const handleVersionChange = (newVersion: Option) => {
+    // Set the new value in the store
+    changeVersionValue(newVersion);
+    // Update the query params in the URL
+    updateQueryParameter("version", newVersion.value);
+  };
 
   let label = t("apiversionswitch.label");
 
@@ -33,7 +56,7 @@ const VersionSwitch: FC<{ lang: string }> = ({ lang }) => {
       <ComboBox
         value={versions.currentVersion}
         options={versions.items}
-        onChange={changeVersionValue}
+        onChange={handleVersionChange}
       />
     </div>
   );

--- a/src/components/Version/SdkVersionSwitch.tsx
+++ b/src/components/Version/SdkVersionSwitch.tsx
@@ -4,6 +4,10 @@ import { useStore } from "@nanostores/react";
 import type { Locales } from "@i18n/locales";
 import { useTranslations } from "@i18n/utils";
 import type { Option } from "@adjust/components/build/ComboBox/ComboBox";
+import {
+  getQueryParameter,
+  updateQueryParameter,
+} from "@components/utils/queryParamHelpers";
 import { $versions, changeVersionValue } from "@store/sdkVersionsStore";
 
 // Declare the supported values.
@@ -19,21 +23,6 @@ const VersionSwitch: FC<{ lang: string }> = ({ lang }) => {
   if (versions.items.length < 1) {
     return null; // Do not display the version switch if there are one or fewer options
   }
-
-  // Get query parameters from the URL
-
-  const getQueryParameter = (name: string) => {
-    const urlParams = new URLSearchParams(window.location.search);
-    return urlParams.get(name);
-  };
-
-  // Set query params in the URL
-
-  const updateQueryParameter = (name: string, value: string) => {
-    const url = new URL(window.location.href);
-    url.searchParams.set(name, value);
-    window.history.replaceState(null, "", url.toString());
-  };
 
   useEffect(() => {
     // Check to see if there are any version blocks on the page.

--- a/src/components/Version/SdkVersionSwitch.tsx
+++ b/src/components/Version/SdkVersionSwitch.tsx
@@ -3,27 +3,68 @@ import { ComboBox } from "@adjust/components";
 import { useStore } from "@nanostores/react";
 import type { Locales } from "@i18n/locales";
 import { useTranslations } from "@i18n/utils";
-
+import type { Option } from "@adjust/components/build/ComboBox/ComboBox";
 import { $versions, changeVersionValue } from "@store/sdkVersionsStore";
+
+// Declare the supported values.
+// If another value is provided (e.g. "version=v3"), ignore it.
+
+const supportedVersions = ["v4", "v5"];
 
 const VersionSwitch: FC<{ lang: string }> = ({ lang }) => {
   const t = useTranslations(lang as keyof Locales);
   const versions = useStore($versions);
-  const versionsPresent = false;
-  const [versionsOnPage, setversionsPresent] = useState(versionsPresent);
+  const [versionsOnPage, setVersionsOnPage] = useState(false);
 
   if (versions.items.length < 1) {
-    // we don`t need to display the version switch when we have only one or less options
-    return null;
+    return null; // Do not display the version switch if there are one or fewer options
   }
 
+  // Get query parameters from the URL
+
+  const getQueryParameter = (name: string) => {
+    const urlParams = new URLSearchParams(window.location.search);
+    return urlParams.get(name);
+  };
+
+  // Set query params in the URL
+
+  const updateQueryParameter = (name: string, value: string) => {
+    const url = new URL(window.location.href);
+    url.searchParams.set(name, value);
+    window.history.replaceState(null, "", url.toString());
+  };
+
   useEffect(() => {
-    setversionsPresent(
+    // Check to see if there are any version blocks on the page.
+    setVersionsOnPage(
       document.querySelector('[role="SdkVersionSelector"]') != null,
     );
-  });
 
-  let label = t("sdkversionswitch.label");
+    // Check the URL for a query parameter called "version"
+    // If it exists and is in the array of supported versions, set the value of the store to the query param
+    // Otherwise, set the URL query param to the current value of the store
+
+    const queryVersion = getQueryParameter("version");
+    if (queryVersion && supportedVersions.includes(queryVersion)) {
+      const versionOption: Option = {
+        label: queryVersion,
+        value: queryVersion,
+      };
+      changeVersionValue(versionOption);
+    } else {
+      updateQueryParameter("version", versions.currentVersion.value);
+    }
+  }, []);
+
+  const handleVersionChange = (newVersion: Option) => {
+    // Set the new value in the store
+    changeVersionValue(newVersion);
+    // Update the query params in the URL
+    updateQueryParameter("version", newVersion.value);
+  };
+
+  const label = t("sdkversionswitch.label");
 
   return (
     <div
@@ -36,7 +77,7 @@ const VersionSwitch: FC<{ lang: string }> = ({ lang }) => {
       <ComboBox
         value={versions.currentVersion}
         options={versions.items}
-        onChange={changeVersionValue}
+        onChange={handleVersionChange}
       />
     </div>
   );

--- a/src/components/utils/queryParamHelpers.ts
+++ b/src/components/utils/queryParamHelpers.ts
@@ -1,0 +1,12 @@
+export const getQueryParameter = (name: string) => {
+   const urlParams = new URLSearchParams(window.location.search);
+   return urlParams.get(name);
+};
+
+// Set query params in the URL
+
+export const updateQueryParameter = (name: string, value: string) => {
+   const url = new URL(window.location.href);
+   url.searchParams.set(name, value);
+   window.history.replaceState(null, "", url.toString());
+};


### PR DESCRIPTION
Closes https://adjustcom.atlassian.net/browse/THC-1011

Enables controlling SDK versioned content with a query param in the URL (e.g. `?version={version}`) if the version specified is supported.