### PR TITLE
Use frontmatter for multiversion docs

### DIFF
--- a/src/components/Layout/PageContent/PageContent.astro
+++ b/src/components/Layout/PageContent/PageContent.astro
@@ -20,9 +20,10 @@ type Props = {
   title: string;
   headings: MarkdownHeading[];
   childLinks: NavigationData["childLinks"];
+  multiVersion: boolean;
 };
 
-const { title, headings, childLinks } = Astro.props;
+const { title, headings, childLinks, multiVersion } = Astro.props;
 
 const sortedLinks = childLinks.sort((a, b) => {
   if (!a.position && !b.position) {
@@ -50,12 +51,12 @@ const sortedLinks = childLinks.sort((a, b) => {
       id="article-content"
     >
       {
-        Astro.url.pathname.includes("sdk") && (
+        Astro.url.pathname.includes("sdk") && multiVersion && (
           <SdkVersionSwitch client:only="react" lang={currentLang} />
         )
       }
       {
-        Astro.url.pathname.includes("api") && (
+        Astro.url.pathname.includes("api") && multiVersion && (
           <ApiVersionSwitch client:only="react" lang={currentLang} />
         )
       }

--- a/src/components/Version/SdkVersionSwitch.tsx
+++ b/src/components/Version/SdkVersionSwitch.tsx
@@ -18,18 +18,8 @@ const supportedVersions = ["v4", "v5"];
 const VersionSwitch: FC<{ lang: string }> = ({ lang }) => {
   const t = useTranslations(lang as keyof Locales);
   const versions = useStore($versions);
-  const [versionsOnPage, setVersionsOnPage] = useState(false);
-
-  if (versions.items.length < 1) {
-    return null; // Do not display the version switch if there are one or fewer options
-  }
 
   useEffect(() => {
-    // Check to see if there are any version blocks on the page.
-    setVersionsOnPage(
-      document.querySelector('[role="SdkVersionSelector"]') != null,
-    );
-
     // Check the URL for a query parameter called "version"
     // If it exists and is in the array of supported versions, set the value of the store to the query param
     // Otherwise, set the URL query param to the current value of the store
@@ -58,8 +48,7 @@ const VersionSwitch: FC<{ lang: string }> = ({ lang }) => {
   return (
     <div
       className={
-        "flex flex-col w-full min-h-90px justify-start gap-y-8 bg-slate-100 p-6 rounded-lg mb-14 md:flex-row md:items-center md:gap-x-8 " +
-        (!versionsOnPage ? "hidden" : "")
+        "flex flex-col w-full min-h-90px justify-start gap-y-8 bg-slate-100 p-6 rounded-lg mb-14 md:flex-row md:items-center md:gap-x-8"
       }
     >
       <label>{label}</label>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -19,6 +19,7 @@ const docs = defineCollection({
       .optional(),
     ogLocale: z.string().optional(),
     type: z.enum(["category"]).optional(),
+    multiVersion: z.boolean().default(false),
   }),
 });
 

--- a/src/content/docs/api/campaign-api/get-links.mdx
+++ b/src/content/docs/api/campaign-api/get-links.mdx
@@ -4,6 +4,7 @@ description: "Use this endpoint to get the network-level links for your specifie
 slug: en/api/campaign-api/get-links
 sidebar-position: 2
 sidebar-label: Get links
+multiVersion: true
 ---
 
 Use this endpoint to get the network-level links for your specified app.

--- a/src/content/docs/api/campaign-api/get-sublinks.mdx
+++ b/src/content/docs/api/campaign-api/get-sublinks.mdx
@@ -3,6 +3,7 @@ title: "Get sublinks"
 description: "Use this endpoint to get the sublinks for your specified app."
 slug: en/api/campaign-api/get-sublinks
 sidebar-position: 3
+multiVersion: true
 ---
 
 Use this endpoint to get the sublinks for your specified app.

--- a/src/content/docs/sdk/android/index.mdx
+++ b/src/content/docs/sdk/android/index.mdx
@@ -4,6 +4,7 @@ description: Use the Android SDK to access Adjust's features in your Android app
 category-title: Android SDK
 slug: en/sdk/android
 sidebar-position: 1
+multiVersion: true
 ---
 
 The Adjust Android SDK enables you to record attribution, events, and more in your Android app. Follow the steps in this guide to set up your app to work with the Adjust SDK.

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -7,7 +7,6 @@ import HeadSEO from "../components/HeadSEO.astro";
 import PageContent from "../components/Layout/PageContent/PageContent.astro";
 import PageBreadcrumbs from "@components/Layout/PageBreadcrumbs/PageBreadcrumbs.astro";
 import Navigation from "../components/Layout/LeftSidebar/Navigation.astro";
-import { SITE } from "../consts";
 import { getNavigationEntries } from "src/utils/helpers/navigation/getNavigationEntries";
 import SidebarHeader from "@components/Layout/LeftSidebar/SidebarHeader/SidebarHeader.astro";
 import SidebarSearch from "@components/Layout/LeftSidebar/SidebarSearch/SidebarSearch.astro";

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -83,6 +83,7 @@ const t = useTranslations(currentLang as keyof Locales);
             title={data.title}
             headings={headings}
             childLinks={navigationEntries.childLinks}
+            multiVersion={data.multiVersion}
           >
             <slot />
           </PageContent>


### PR DESCRIPTION
The current approach to the version switcher uses a lot of expensive checks to see if versioned content is present. This update changes the approach to use the `multiVersion` property in a file's frontmatter to determine if the switcher should appear.