### PR TITLE
Make ToC update with version change

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,7 +4,6 @@ import tailwind from "@astrojs/tailwind";
 import AutoImport from "astro-auto-import";
 import mdx from "@astrojs/mdx";
 import sitemap from "@astrojs/sitemap";
-import { remarkDefinitionList, defListHastHandlers } from "remark-definition-list";
 import expressiveCode from "astro-expressive-code";
 import playformCompress from "@playform/compress";
 import remarkReplaceVersions from "./src/integrations/remarkReplaceVersions";
@@ -28,7 +27,7 @@ export default defineConfig({
   }), expressiveCode(), mdx(), tailwind(), sitemap(), playformCompress()],
   site: "https://dev.adjust.com/",
   markdown: {
-    remarkPlugins: [remarkDefinitionList, [remarkReplaceVersions, versions], remarkHeaderLinkToId],
+    remarkPlugins: [[remarkReplaceVersions, versions], remarkHeaderLinkToId],
     rehypePlugins: [[rehypeAutolinkHeadings, {
       behavior: 'append',
       properties: {
@@ -72,10 +71,5 @@ export default defineConfig({
         }]
       }
     }]],
-    remarkRehype: {
-      handlers: {
-        ...defListHastHandlers
-      }
-    }
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
         "rehype-external-links": "^3.0.0",
         "rehype-raw": "^7.0.0",
         "remark": "^15.0.1",
-        "remark-definition-list": "^2.0.0",
         "remark-directive": "^3.0.0",
         "tailwindcss": "^3.4.4",
         "unist-util-remove": "^4.0.0",
@@ -4166,18 +4165,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/assert": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
-      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "is-nan": "^1.3.2",
-        "object-is": "^1.1.5",
-        "object.assign": "^4.1.4",
-        "util": "^0.12.5"
-      }
-    },
     "node_modules/astring": {
       "version": "1.8.6",
       "resolved": "https://registry.npmjs.org/astring/-/astring-1.8.6.tgz",
@@ -4384,20 +4371,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "dependencies": {
-        "possible-typed-array-names": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/axios": {
@@ -4615,24 +4588,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
-    },
-    "node_modules/call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -5202,38 +5157,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/define-properties": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dependencies": {
-        "define-data-property": "^1.0.1",
-        "has-property-descriptors": "^1.0.0",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -5463,25 +5386,6 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dependencies": {
         "is-arrayish": "^0.2.1"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/es-module-lexer": {
@@ -6136,14 +6040,6 @@
         }
       }
     },
-    "node_modules/for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-      "dependencies": {
-        "is-callable": "^1.1.3"
-      }
-    },
     "node_modules/form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -6214,24 +6110,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/get-stream": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
@@ -6288,17 +6166,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -6353,53 +6220,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-proto": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -6409,37 +6229,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/hast-util-definition-list": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-definition-list/-/hast-util-definition-list-2.0.0.tgz",
-      "integrity": "sha512-EnkqD6a7R1fwyC9F5R6fu0ucpcwfkxjiga7/G8J7KU+uuUHVENzmgo/Da68fZBy9SZAkQOAC/8gK3m2BnuutUg==",
-      "dependencies": {
-        "@types/hast": "^3.0.1",
-        "@types/mdast": "^4.0.1",
-        "@types/unist": "^3.0.0",
-        "hast-util-to-mdast": "^10.1.0",
-        "mdast-util-definition-list": "^2.0.0",
-        "mdast-util-phrasing": "^4.0.0"
-      }
-    },
-    "node_modules/hast-util-definition-list/node_modules/@types/unist": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
-      "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w=="
-    },
-    "node_modules/hast-util-embedded": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-3.0.0.tgz",
-      "integrity": "sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-is-element": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/hast-util-from-html": {
@@ -6580,18 +6369,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hast-util-is-body-ok-link": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.0.tgz",
-      "integrity": "sha512-VFHY5bo2nY8HiV6nir2ynmEB1XkxzuUffhEGeVx7orbu/B1KaGyeGgMZldvMVx5xWrDlLLG/kQ6YkJAMkBEx0w==",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-is-element": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
@@ -6610,22 +6387,6 @@
       "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
       "dependencies": {
         "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-phrasing": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-3.0.1.tgz",
-      "integrity": "sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-embedded": "^3.0.0",
-        "hast-util-has-property": "^3.0.0",
-        "hast-util-is-body-ok-link": "^3.0.0",
-        "hast-util-is-element": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6816,31 +6577,6 @@
       "integrity": "sha512-rDRwHtoDD3UMMrmZ6BzOW0naTjMsVZLIjsGleSKS/0Oz+cgCfAPRspaqJuE8rDzpKha/nEvnM0IF4seEAZUTKQ==",
       "dependencies": {
         "inline-style-parser": "0.2.2"
-      }
-    },
-    "node_modules/hast-util-to-mdast": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-10.1.0.tgz",
-      "integrity": "sha512-DsL/SvCK9V7+vfc6SLQ+vKIyBDXTk2KLSbfBYkH4zeF/uR1yBajHRhkzuaUSGOB1WJSTieJBdHwxlC+HLKvZZw==",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/mdast": "^4.0.0",
-        "@ungap/structured-clone": "^1.0.0",
-        "hast-util-phrasing": "^3.0.0",
-        "hast-util-to-html": "^9.0.0",
-        "hast-util-to-text": "^4.0.0",
-        "hast-util-whitespace": "^3.0.0",
-        "mdast-util-phrasing": "^4.0.0",
-        "mdast-util-to-hast": "^13.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-minify-whitespace": "^6.0.0",
-        "trim-trailing-lines": "^2.0.0",
-        "unist-util-position": "^5.0.0",
-        "unist-util-visit": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/hast-util-to-parse5": {
@@ -7202,21 +6938,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -7253,17 +6974,6 @@
       ],
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-core-module": {
@@ -7324,20 +7034,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-      "dependencies": {
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -7384,21 +7080,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-nan": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-number": {
@@ -7452,20 +7133,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-typed-array": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
-      "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
-      "dependencies": {
-        "which-typed-array": "^1.1.14"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-unicode-supported": {
@@ -8278,25 +7945,6 @@
         "remove-accents": "0.4.2"
       }
     },
-    "node_modules/mdast-util-definition-list": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-definition-list/-/mdast-util-definition-list-2.0.0.tgz",
-      "integrity": "sha512-aFWuASQs77BJndNSDcNdvB1HRqWZBptcEjwv67mnPbaAZsfwMHxI8MwoQxAz4I2bHx41hft/HDRC57ZkhpayOQ==",
-      "dependencies": {
-        "@types/mdast": "^4.0.1",
-        "@types/unist": "^3.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-hast": "^13.0.2",
-        "mdast-util-to-markdown": "^2.1.0",
-        "micromark-extension-definition-list": "^2.0.0",
-        "unist-builder": "^4.0.0"
-      }
-    },
-    "node_modules/mdast-util-definition-list/node_modules/@types/unist": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
-      "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w=="
-    },
     "node_modules/mdast-util-definitions": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
@@ -8782,21 +8430,6 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-extension-definition-list": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-definition-list/-/micromark-extension-definition-list-2.0.0.tgz",
-      "integrity": "sha512-92SSfTdG7YIXiYj60sNDPoo3MTJXK94LRLfKsoDHgDqiE61p4w4pzdyCc9SuoQ74/bzb5SXPVK11kjlYnIjzKA==",
-      "dependencies": {
-        "assert": "^2.0.0",
-        "micromark-core-commonmark": "^2.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.1",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0",
-        "ts-dedent": "^2.2.0"
       }
     },
     "node_modules/micromark-extension-directive": {
@@ -9691,46 +9324,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/object-is": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/object.assign": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
-      "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
-      "dependencies": {
-        "call-bind": "^1.0.5",
-        "define-properties": "^1.2.1",
-        "has-symbols": "^1.0.3",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/oblivious-set": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
@@ -10150,14 +9743,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/possible-typed-array-names": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
-      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -10935,39 +10520,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/rehype-minify-whitespace": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-6.0.0.tgz",
-      "integrity": "sha512-i9It4YHR0Sf3GsnlR5jFUKXRr9oayvEk9GKQUkwZv6hs70OH9q3OCZrq9PpLvIGKt3W+JxBOxCidNVpH/6rWdA==",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-embedded": "^3.0.0",
-        "hast-util-is-element": "^3.0.0",
-        "hast-util-whitespace": "^3.0.0",
-        "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-minify-whitespace/node_modules/@types/unist": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
-      "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w=="
-    },
-    "node_modules/rehype-minify-whitespace/node_modules/unist-util-is": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
-      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/rehype-parse": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.0.tgz",
@@ -11209,16 +10761,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-definition-list": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/remark-definition-list/-/remark-definition-list-2.0.0.tgz",
-      "integrity": "sha512-OOJ0zUrfUGITUNxOBnsipyFUjqq1m4AgYOqQk10jDXyz+RoODJL3qYvRn8qzYQDzRnz1wlCP3dbDEOpl05LlQw==",
-      "dependencies": {
-        "hast-util-definition-list": "^2.0.0",
-        "mdast-util-definition-list": "^2.0.0",
-        "micromark-extension-definition-list": "^2.0.0"
       }
     },
     "node_modules/remark-directive": {
@@ -11993,22 +11535,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/sharp": {
       "version": "0.33.4",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.4.tgz",
@@ -12653,15 +12179,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/trim-trailing-lines": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-2.1.0.tgz",
-      "integrity": "sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/trough": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
@@ -12681,14 +12198,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"
-      }
-    },
-    "node_modules/ts-dedent": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
-      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
-      "engines": {
-        "node": ">=6.10"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -12881,23 +12390,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
-    },
-    "node_modules/unist-builder": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-4.0.0.tgz",
-      "integrity": "sha512-wmRFnH+BLpZnTKpc5L7O67Kac89s9HMrtELpnNaE6TAobq5DTZZs5YaTQfAZBA9bFPECx2uVAPO31c+GVug8mg==",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-builder/node_modules/@types/unist": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
-      "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w=="
     },
     "node_modules/unist-util-find-after": {
       "version": "5.0.0",
@@ -13223,18 +12715,6 @@
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
       }
     },
     "node_modules/util-deprecate": {
@@ -13886,24 +13366,6 @@
       "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/which-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
-      "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/widest-line": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "rehype-external-links": "^3.0.0",
     "rehype-raw": "^7.0.0",
     "remark": "^15.0.1",
-    "remark-definition-list": "^2.0.0",
     "remark-directive": "^3.0.0",
     "tailwindcss": "^3.4.4",
     "unist-util-remove": "^4.0.0",

--- a/src/components/Layout/PageContent/PageContent.astro
+++ b/src/components/Layout/PageContent/PageContent.astro
@@ -94,7 +94,7 @@ const sortedLinks = childLinks.sort((a, b) => {
     @apply text-heading-2 text-black max-w-[40ch] mb-4 font-bold leading-[1] mt-1 ml-1 inline-block;
   }
 
-  .article-content h3:not([class^="Banner__"]) {
+  .article-content h3 {
     @apply text-heading-3 text-black mb-4 font-bold leading-[1];
   }
 
@@ -102,7 +102,7 @@ const sortedLinks = childLinks.sort((a, b) => {
     @apply text-heading-3 text-black mb-4 font-bold leading-[1] mt-2 ml-1 inline-block;
   }
 
-  .article-content h4:not([class^="Banner__"]) {
+  .article-content h4 {
     @apply text-heading-4 text-black mb-4 font-bold;
   }
 
@@ -110,7 +110,7 @@ const sortedLinks = childLinks.sort((a, b) => {
     @apply text-heading-4 text-black mt-3 mb-4 font-bold ml-1 inline-block;
   }
 
-  .article-content h5:not([class^="Banner__"]) {
+  .article-content h5 {
     @apply text-heading-5 text-black mb-4 font-bold;
   }
 

--- a/src/components/Layout/PageContent/PageContent.astro
+++ b/src/components/Layout/PageContent/PageContent.astro
@@ -86,35 +86,35 @@ const sortedLinks = childLinks.sort((a, b) => {
     @apply text-heading-1 max-w-[40ch] mb-4 font-bold leading-[1];
   }
 
-  .article-content > h2 {
+  .article-content h2:not([class^="Banner__"]) {
     @apply text-heading-2 text-black max-w-[40ch] mb-4 font-bold leading-[1] not-first:mt-1;
   }
 
-  .article-content > h2 svg {
+  .article-content h2 svg {
     @apply text-heading-2 text-black max-w-[40ch] mb-4 font-bold leading-[1] mt-1 ml-1 inline-block;
   }
 
-  .article-content > h3 {
+  .article-content h3:not([class^="Banner__"]) {
     @apply text-heading-3 text-black mb-4 font-bold leading-[1];
   }
 
-  .article-content > h3 svg {
+  .article-content h3 svg {
     @apply text-heading-3 text-black mb-4 font-bold leading-[1] mt-2 ml-1 inline-block;
   }
 
-  .article-content > h4 {
+  .article-content h4:not([class^="Banner__"]) {
     @apply text-heading-4 text-black mb-4 font-bold;
   }
 
-  .article-content > h4 svg {
+  .article-content h4 svg {
     @apply text-heading-4 text-black mt-3 mb-4 font-bold ml-1 inline-block;
   }
 
-  .article-content > h5 {
+  .article-content h5:not([class^="Banner__"]) {
     @apply text-heading-5 text-black mb-4 font-bold;
   }
 
-  .article-content > h5 svg {
+  .article-content h5 svg {
     @apply text-heading-5 text-black mt-8 mb-4 font-bold ml-1 inline-block;
   }
 
@@ -122,10 +122,10 @@ const sortedLinks = childLinks.sort((a, b) => {
     @apply md:invisible;
   }
 
-  .article-content > h2:hover > .copy-link,
-  .article-content > h3:hover > .copy-link,
-  .article-content > h4:hover > .copy-link,
-  .article-content > h5:hover > .copy-link {
+  .article-content h2:hover > .copy-link,
+  .article-content h3:hover > .copy-link,
+  .article-content h4:hover > .copy-link,
+  .article-content h5:hover > .copy-link {
     @apply md:visible;
   }
 

--- a/src/components/Layout/RightSidebar/TableOfContents/index.tsx
+++ b/src/components/Layout/RightSidebar/TableOfContents/index.tsx
@@ -47,31 +47,36 @@ const TableOfContents: FC<{
     setClickedId(id);
   };
 
-  // this selector is more accurate cause we don`t need nested headers
-
+  // Update the headings in the ToC when the page updates
   const updateHeadings = () => {
+    // Only select headers that are included in the article and are not callouts
     const headers = document.querySelectorAll(
       ".article-content h1, .article-content h2:not([class^='Banner__']), .article-content h3, .article-content h4",
     );
-    console.log(headers);
+
+    // Filter out any headers that are nested under a hidden div (non-selected version)
     const filteredHeaders = Array.from(headers).filter((header) => {
       const parentDiv = header.closest("div");
       return parentDiv && !parentDiv.matches(".hidden");
     });
-    console.log(filteredHeaders);
+
+    // Pass the headers to the getTocHeadings function to filter out headers
     const headingsParsed = getTocHeadings(filteredHeaders);
     setHeadingsLocal(headingsParsed);
   };
 
   useEffect(() => {
+    // Update the headers on first load
     updateHeadings();
   }, []);
 
   useEffect(() => {
+    // Ensure that URL changes are handled immediately
     const handleUrlChange = () => {
       setTimeout(updateHeadings, 0);
     };
 
+    // Listen for the urlChange event registered in queryParamHelers so that we can react to changes
     window.addEventListener("urlChange", handleUrlChange);
 
     return () => {

--- a/src/components/Layout/RightSidebar/TableOfContents/index.tsx
+++ b/src/components/Layout/RightSidebar/TableOfContents/index.tsx
@@ -47,10 +47,36 @@ const TableOfContents: FC<{
     setClickedId(id);
   };
 
-  useEffect(() => {
-    const headingsParsed = getTocHeadings();
+  // this selector is more accurate cause we don`t need nested headers
 
+  const updateHeadings = () => {
+    const headers = document.querySelectorAll(
+      ".article-content h1, .article-content h2:not([class^='Banner__']), .article-content h3, .article-content h4",
+    );
+    console.log(headers);
+    const filteredHeaders = Array.from(headers).filter((header) => {
+      const parentDiv = header.closest("div");
+      return parentDiv && !parentDiv.matches(".hidden");
+    });
+    console.log(filteredHeaders);
+    const headingsParsed = getTocHeadings(filteredHeaders);
     setHeadingsLocal(headingsParsed);
+  };
+
+  useEffect(() => {
+    updateHeadings();
+  }, []);
+
+  useEffect(() => {
+    const handleUrlChange = () => {
+      setTimeout(updateHeadings, 0);
+    };
+
+    window.addEventListener("urlChange", handleUrlChange);
+
+    return () => {
+      window.removeEventListener("urlChange", handleUrlChange);
+    };
   }, []);
 
   useEffect(() => {
@@ -80,10 +106,12 @@ const TableOfContents: FC<{
   // need to add right padding for the article when TOC is opened
   useEffect(() => {
     const article = document.getElementById("article-content");
-    article!.className =
-      isOpened && !isMobile && headingsLocal.length
-        ? "article-content pr-[275px]"
-        : "article-content";
+    if (article) {
+      article.className =
+        isOpened && !isMobile && headingsLocal.length
+          ? "article-content pr-[275px]"
+          : "article-content";
+    }
   }, [isOpened, isMobile, headingsLocal]);
 
   if (!headingsLocal.length) {
@@ -101,7 +129,7 @@ const TableOfContents: FC<{
           <div className="absolute top-0 bottom-0 flex items-start">
             <button
               onClick={() => setIsOpened(false)}
-              className="rounded-md overflow-hidden -ml-8 mt-8  bg-white relative w-6 h-6 [&_svg]:hover:bg-[#0b58fe] [&_svg]:hover:text-white"
+              className="rounded-md overflow-hidden -ml-8 mt-8 bg-white relative w-6 h-6 [&_svg]:hover:bg-[#0b58fe] [&_svg]:hover:text-white"
               aria-label={t("toc.toggle-label")}
             >
               <ChevronRight />

--- a/src/components/Layout/RightSidebar/TableOfContents/index.tsx
+++ b/src/components/Layout/RightSidebar/TableOfContents/index.tsx
@@ -76,7 +76,7 @@ const TableOfContents: FC<{
       setTimeout(updateHeadings, 0);
     };
 
-    // Listen for the urlChange event registered in queryParamHelers so that we can react to changes
+    // Listen for the urlChange event registered in queryParamHelpers so that we can react to changes
     window.addEventListener("urlChange", handleUrlChange);
 
     return () => {

--- a/src/components/Version/ApiVersionComponent.tsx
+++ b/src/components/Version/ApiVersionComponent.tsx
@@ -1,6 +1,5 @@
 import { useEffect, type FC } from "react";
 import { useStore } from "@nanostores/react";
-import classNames from "classnames";
 
 import { $versions, updateVersionsItems } from "@store/apiVersionsStore";
 

--- a/src/components/Version/ApiVersionComponent.tsx
+++ b/src/components/Version/ApiVersionComponent.tsx
@@ -20,8 +20,7 @@ const VersionComponent: FC<VersionProps> = ({ content, version }) => {
   return (
     <div
       className={
-        classNames("py-4 ") +
-        (version == versionsStore.currentVersion.value ? "block" : "hidden")
+        version == versionsStore.currentVersion.value ? "block" : "hidden"
       }
       role="ApiVersionSelector"
     >

--- a/src/components/Version/SdkVersionComponent.tsx
+++ b/src/components/Version/SdkVersionComponent.tsx
@@ -19,10 +19,9 @@ const VersionComponent: FC<VersionProps> = ({ content, version }) => {
 
   return (
     <div
-      className={
-        classNames("py-4 ") +
-        (version == versionsStore.currentVersion.value ? "block" : "hidden")
-      }
+      className={classNames(
+        version == versionsStore.currentVersion.value ? "block" : "hidden",
+      )}
       role="SdkVersionSelector"
     >
       {content}

--- a/src/components/Version/SdkVersionComponent.tsx
+++ b/src/components/Version/SdkVersionComponent.tsx
@@ -1,5 +1,4 @@
 import { useEffect, type FC } from "react";
-import classNames from "classnames";
 import { useStore } from "@nanostores/react";
 
 import { $versions, updateVersionsItems } from "@store/sdkVersionsStore";
@@ -19,9 +18,9 @@ const VersionComponent: FC<VersionProps> = ({ content, version }) => {
 
   return (
     <div
-      className={classNames(
-        version == versionsStore.currentVersion.value ? "block" : "hidden",
-      )}
+      className={
+        version == versionsStore.currentVersion.value ? "block" : "hidden"
+      }
       role="SdkVersionSelector"
     >
       {content}

--- a/src/components/utils/queryParamHelpers.ts
+++ b/src/components/utils/queryParamHelpers.ts
@@ -9,4 +9,7 @@ export const updateQueryParameter = (name: string, value: string) => {
    const url = new URL(window.location.href);
    url.searchParams.set(name, value);
    window.history.replaceState(null, "", url.toString());
+
+   const urlChangeEvent = new Event("urlChange");
+   window.dispatchEvent(urlChangeEvent);
 };

--- a/src/components/utils/queryParamHelpers.ts
+++ b/src/components/utils/queryParamHelpers.ts
@@ -10,6 +10,7 @@ export const updateQueryParameter = (name: string, value: string) => {
    url.searchParams.set(name, value);
    window.history.replaceState(null, "", url.toString());
 
+   // Notify the browser when the URL value has changed
    const urlChangeEvent = new Event("urlChange");
    window.dispatchEvent(urlChangeEvent);
 };

--- a/src/utils/helpers/toc/getTocHeadings.ts
+++ b/src/utils/helpers/toc/getTocHeadings.ts
@@ -1,15 +1,10 @@
 import type { MarkdownHeading } from "astro";
 
-export const getTocHeadings = () => {
-  // this selector is more accurate cause we don`t need nested headers
-  const headings = document.querySelectorAll(
-    ".article-content > :is(h1, h2, h3, h4)"
-  );
-
+export const getTocHeadings = (filteredHeaders: Element[]) => {
   const headingsParsed: MarkdownHeading[] = [];
   const duplicates: { [key: string]: number } = {};
   // parsing data for the TOC
-  for (const heading of headings) {
+  for (const heading of filteredHeaders) {
     const text = heading.textContent;
     let slug = "";
 


### PR DESCRIPTION
Currently, the Table of Contents is rendered upon page load and stays that way. However, with version switchers the headers present and visible on the page might change when the version is changed.

This PR registers a new event listener that checks for changes to the URL `version` param and updates the ToC with only visible headers that are available on the page.