### PR TITLE
Preserve code block attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "astro-expressive-code": "^0.35.3",
         "classnames": "^2.5.1",
         "html-escaper": "^3.0.3",
-        "jsdom": "^24.1.0",
         "lodash": "^4.17.21",
         "lodash-es": "^4.17.21",
         "marked": "^13.0.0",
@@ -3544,17 +3543,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -4547,33 +4535,10 @@
         "node": ">=4"
       }
     },
-    "node_modules/cssstyle": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.0.1.tgz",
-      "integrity": "sha512-8ZYiJ3A/3OkDd093CBT/0UKDWry7ak4BdPTFP2+QEP7cmhouyq/Up709ASSj2cK02BbZiMgk7kYjZNS4QP5qrQ==",
-      "dependencies": {
-        "rrweb-cssom": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/csstype": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
-    },
-    "node_modules/data-urls": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
-      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
-      "dependencies": {
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/date-fns": {
       "version": "2.28.0",
@@ -4603,11 +4568,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/decimal.js": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.0.2",
@@ -6032,17 +5992,6 @@
       "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
       "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ=="
     },
-    "node_modules/html-encoding-sniffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
-      "dependencies": {
-        "whatwg-encoding": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
@@ -6071,30 +6020,6 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
       "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
-    "node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/human-signals": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -6116,17 +6041,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -6428,11 +6342,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-potential-custom-element-name": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
-    },
     "node_modules/is-reference": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.2.tgz",
@@ -6510,52 +6419,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/jsdom": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.0.tgz",
-      "integrity": "sha512-6gpM7pRXCwIOKxX47cgOyvyQDN/Eh0f1MeKySBV2xGdKtqJBLj8P25eY3EVCWo2mglDDzozR2r2MW4T+JiNUZA==",
-      "license": "MIT",
-      "dependencies": {
-        "cssstyle": "^4.0.1",
-        "data-urls": "^5.0.0",
-        "decimal.js": "^10.4.3",
-        "form-data": "^4.0.0",
-        "html-encoding-sniffer": "^4.0.0",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.4",
-        "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.10",
-        "parse5": "^7.1.2",
-        "rrweb-cssom": "^0.7.0",
-        "saxes": "^6.0.0",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.4",
-        "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^3.1.1",
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0",
-        "ws": "^8.17.0",
-        "xml-name-validator": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "canvas": "^2.11.2"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jsdom/node_modules/rrweb-cssom": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.0.tgz",
-      "integrity": "sha512-KlSv0pm9kgQSRxXEMgtivPJ4h826YHsuob8pSHcfSZsSXGtvpEAie8S0AnXuObEJ7nhikOb4ahwxDm0H2yW17g==",
-      "license": "MIT"
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
@@ -8518,11 +8381,6 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
-    "node_modules/nwsapi": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.10.tgz",
-      "integrity": "sha512-QK0sRs7MKv0tKe1+5uZIQk/C8XGza4DAnztJG8iD+TpJIORARrCxczA738awHrZoHeTjSSoHqao2teO0dC/gFQ=="
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -9224,15 +9082,11 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
-    "node_modules/psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -9247,11 +9101,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -9796,11 +9645,6 @@
       "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
       "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
     },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
-    },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
@@ -10292,11 +10136,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/rrweb-cssom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
-      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw=="
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -10325,11 +10164,6 @@
       "integrity": "sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==",
       "dev": true
     },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
     "node_modules/sass-formatter": {
       "version": "0.7.9",
       "resolved": "https://registry.npmjs.org/sass-formatter/-/sass-formatter-0.7.9.tgz",
@@ -10343,17 +10177,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-    },
-    "node_modules/saxes": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
-      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dependencies": {
-        "xmlchars": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=v12.22.7"
-      }
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -10828,11 +10651,6 @@
         "node": ">= 4.7.0"
       }
     },
-    "node_modules/symbol-tree": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
-    },
     "node_modules/tabbable": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
@@ -10962,31 +10780,6 @@
       },
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/tough-cookie": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
-      "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tr46": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
-      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/trim-lines": {
@@ -11387,14 +11180,6 @@
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
       "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q=="
     },
-    "node_modules/universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/unload": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
@@ -11440,15 +11225,6 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
       }
     },
     "node_modules/use-isomorphic-layout-effect": {
@@ -11967,17 +11743,6 @@
         }
       }
     },
-    "node_modules/w3c-xmlserializer": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
-      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "dependencies": {
-        "xml-name-validator": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/warning": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
@@ -11993,45 +11758,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/whatwg-encoding": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/whatwg-mimetype": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
-      "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
-      "dependencies": {
-        "tr46": "^5.0.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -12156,39 +11882,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
-    "node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/xml-name-validator": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
-      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/xmlchars": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "astro-expressive-code": "^0.35.3",
     "classnames": "^2.5.1",
     "html-escaper": "^3.0.3",
-    "jsdom": "^24.1.0",
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",
     "marked": "^13.0.0",

--- a/src/components/CodeBlock.astro
+++ b/src/components/CodeBlock.astro
@@ -29,35 +29,41 @@ if (Astro.slots.has("default")) {
 }
 
 const parseHighlight = (
-  highlight: string
+  highlight: string,
 ): MarkerDefinition | MarkerDefinition[] => {
   return highlight.split(",").map((item) => {
-    item = item.trim();
-    if (item.startsWith("{") && item.endsWith("}")) {
-      const [key, value] = item
-        .slice(1, -1)
-        .split(":")
-        .map((part) => part.trim());
-      return { [key]: value.replace(/"/g, "") } as MarkerDefinition; // Remove quotes from the value
+    const trimmedItem = item.trim();
+
+    if (trimmedItem.startsWith("{") && trimmedItem.endsWith("}")) {
+      const innerContent = trimmedItem.slice(1, -1).trim();
+
+      // Check if the inner content contains a colon
+      if (innerContent.includes(":")) {
+        const [key, value] = innerContent.split(":").map((part) => part.trim());
+        return { [key]: value.replace(/"/g, "") } as MarkerDefinition;
+      }
+
+      // If no colon, treat it as a regular string token
+      return trimmedItem;
     }
-    if (item.startsWith("/") && item.endsWith("/")) {
-      return new RegExp(item.slice(1, -1), "g") as MarkerDefinition; // Return as RegExp
+
+    if (trimmedItem.startsWith("/") && trimmedItem.endsWith("/")) {
+      return new RegExp(trimmedItem.slice(1, -1), "g") as MarkerDefinition;
     }
-    return item.replace(/'/g, ""); // Remove single quotes from the item
+
+    return trimmedItem.replace(/'/g, "");
   }) as MarkerDefinition[];
 };
 
-const parseCollapse = (collapse: string | string[] | undefined): string[] => {
+const parseCollapse = (collapse?: string | string[]): string[] => {
   if (typeof collapse === "string") {
     return collapse.split(",").map((item) => item.trim());
   }
-  if (Array.isArray(collapse)) {
-    return collapse;
-  }
-  return [];
+
+  return Array.isArray(collapse) ? collapse : [];
 };
 
-const { code, lang } = extractCodeFromHTML(content);
+const { code, lang } = await extractCodeFromHTML(content);
 const parsedHighlight = highlight ? parseHighlight(highlight) : undefined;
 const parsedIns = ins ? parseHighlight(ins) : undefined;
 const parsedDel = del ? parseHighlight(del) : undefined;

--- a/src/components/Layout/PageContent/PageContent.astro
+++ b/src/components/Layout/PageContent/PageContent.astro
@@ -1,6 +1,5 @@
 ---
 import type { MarkdownHeading } from "astro";
-import classNames from "classnames";
 
 import TableOfContents from "@components/TableOfContents.astro";
 import type { NavigationData } from "@utils/helpers/navigation/types";
@@ -56,12 +55,7 @@ const sortedLinks = childLinks.sort((a, b) => {
     <h1 class="text-heading-1 font-bold leading-[1] mb-4" id="overview">
       {title}
     </h1>
-    <div
-      class={classNames({
-        "article-content": !sortedLinks.length,
-      })}
-      id="article-content"
-    >
+    <div class="article-content" id="article-content">
       {
         Astro.url.pathname.includes("sdk") && multiVersion && (
           <SdkVersionSwitch client:only="react" lang={currentLang} />

--- a/src/content/docs/api/ad-spend-api/cost-endpoint.mdx
+++ b/src/content/docs/api/ad-spend-api/cost-endpoint.mdx
@@ -20,9 +20,13 @@ Adjust accepts ad spend data for an engagement up to seven days after it happens
 
 ## [Endpoint](endpoint)
 
-```http title="Endpoint" "/cost"
+<CodeBlock title="Endpoint" highlight="/cost">
+
+```http
 POST https://app.adjust.com/cost
 ```
+
+</CodeBlock>
 
 ### [POST request](post-request)
 
@@ -55,10 +59,14 @@ Not sure how to format your request? Contact the integrations team at wizards@ad
 
 </Callout>
 
-```console title="cURL" "cost_type" "cost_currency" "cost_amount" "cost_id" "tag"
+<CodeBlock title="cURL" highlight="cost_type, cost_currency, cost_amount, cost_id, tag">
+
+```console
 $ curl -X POST https://app.adjust.com/cost \
 -d "cost_type=cpi&cost_currency=usd&cost_amount=2&cost_id=abc123_company_name_test_1&tag=company_name_test"
 ```
+
+</CodeBlock>
 
 ## [Responses](responses)
 

--- a/src/content/docs/api/app-automation-api/app-endpoint.mdx
+++ b/src/content/docs/api/app-automation-api/app-endpoint.mdx
@@ -11,9 +11,13 @@ Use the `/app` endpoint to automate creating and updating new apps.
 
 Create a new app using settings from your template app. If your app already exists, you can update it with new settings using the `force_update` parameter.
 
-```http title="Endpoint" "/app"
+<CodeBlock title="Endpoint" highlight="/app">
+
+```http
 POST https://settings.adjust.com/api/app
 ```
+
+</CodeBlock>
 
 ### [Parameters](parameters)
 
@@ -50,7 +54,9 @@ POST https://settings.adjust.com/api/app
 
 ### [Example](example)
 
-```console title="cURL" '"name"' '"bundle_id"' '"store_id"' '"platform"' '"channel_setup"'
+<CodeBlock title="cURL" highlight={"\"name\", \"bundle_id\", \"store_id\", \"platform\", \"channel_setup\""}>
+
+```console
 $ curl \
 --header "AdjustAuthorization: Token <adjust api token>" \
 --header "Content-Type: application/json" \
@@ -58,7 +64,11 @@ $ curl \
 -X POST https://settings.adjust.com/api/app
 ```
 
-```json title="Success response"
+</CodeBlock>
+
+<CodeBlock title="Success response">
+
+```json
 {
    "adjust_app_token": "p77yk727r18g",
    "name": "Test App Name",
@@ -69,13 +79,19 @@ $ curl \
 }
 ```
 
+</CodeBlock>
+
 ## [Fetch app details](fetch-app-details)
 
 Retrieve details about an app using the app store ID and platform name.
 
-```http title="Endpoint" "store_id={}" "platform={}"
+<CodeBlock title="Endpoint" highlight="store_id={}, platform={}">
+
+```http
 GET https://settings.adjust.com/api/app?store_id={}&platform={}
 ```
+
+</CodeBlock>
 
 ### [Parameters](parameters-1)
 
@@ -107,13 +123,19 @@ GET https://settings.adjust.com/api/app?store_id={}&platform={}
 
 ### [Example](example-1)
 
-```console title="cURL" "store_id" "platform"
+<CodeBlock title="cURL" highlight="store_id, platform">
+
+```console
 $ curl \
 --header "AdjustAuthorization: Token <adjust api token>" \
 -L -X GET 'https://settings.adjust.com/api/app?store_id=test.bundle.app&platform=android'
 ```
 
-```json title="Success response"
+</CodeBlock>
+
+<CodeBlock title="Success response">
+
+```json
 {
    "name": "Test App Name",
    "platform": "android",
@@ -129,13 +151,19 @@ $ curl \
 }
 ```
 
+</CodeBlock>
+
 ## [Fetch app details by Adjust token](fetch-app-details-by-adjust-token)
 
 Retrieve details about an app using the adjust app token.
 
-```http title="Endpoint" "{adjust_app_token}"
+<CodeBlock title="Endpoint" highlight="{adjust_app_token}">
+
+```http
 GET https://settings.adjust.com/api/app/{adjust_app_token}
 ```
+
+</CodeBlock>
 
 ### [Parameters](parameters-2)
 
@@ -166,13 +194,19 @@ GET https://settings.adjust.com/api/app/{adjust_app_token}
 
 ### [Example](example-2)
 
-```console title="cURL" "p77yk727r18g"
+<CodeBlock title="cURL" highlight="p77yk727r18g">
+
+```console
 $ curl \
 --header "AdjustAuthorization: Token <adjust api token>" \
 -X GET https://settings.adjust.com/api/app/p77yk727r18g/
 ```
 
-```json title="Success response"
+</CodeBlock>
+
+<CodeBlock title="Success response">
+
+```json
 {
    "name": "Test App Name",
    "platform": "android",
@@ -188,13 +222,19 @@ $ curl \
 }
 ```
 
+</CodeBlock>
+
 ## [Fetch app channels](fetch-app-channels)
 
 Retrieve a list of channels that have active links for an app.
 
-```http title="Endpoint" "{adjust_app_token}/channels"
+<CodeBlock title="Endpoint" highlight="{adjust_app_token}/channels">
+
+```http
 GET https://settings.adjust.com/api/app/{adjust_app_token}/channels
 ```
+
+</CodeBlock>
 
 ### [Parameters](parameters-3)
 
@@ -238,14 +278,20 @@ GET https://settings.adjust.com/api/app/{adjust_app_token}/channels
 
 ### [Example](example-3)
 
-```console title="cURL" "927t3s86rzsw"
+<CodeBlock title="cURL" highlight="927t3s86rzsw">
+
+```console
 $ curl \
 --header 'AdjustAuthorization: Token <adjust api token>' \
 --header "SignatureAuthorization: Token <adjust signature token>" \
 --X GET 'https://settings.adjust.com/api/app/927t3s86rzsw/channels'
 ```
 
-```json title="Success response"
+</CodeBlock>
+
+<CodeBlock title="Success response">
+
+```json
 [
    "unityads",
    "digitalturbine",
@@ -263,3 +309,5 @@ $ curl \
    "tradedoubler"
 ]
 ```
+
+</CodeBlock>

--- a/src/content/docs/api/app-automation-api/campaign-endpoint.mdx
+++ b/src/content/docs/api/app-automation-api/campaign-endpoint.mdx
@@ -7,9 +7,13 @@ sidebar-position: 5
 
 Use the Campaign endpoint to create links for your application.
 
-```http title="Endpoint" "/campaign"
+<CodeBlock title="Endpoint" highlight="/campaign">
+
+```http
 POST https://settings.adjust.com/api/campaign
 ```
+
+</CodeBlock>
 
 ## [Create new links](create-new-links)
 
@@ -61,16 +65,22 @@ Use this endpoint to create new links for your app. If you are working with part
 
 </Table>
 
-```json title="Response format"
+<CodeBlock title="Response format">
+
+```json
 {
    "click_url": "String",
    "impression_url": "String"
 }
 ```
 
+</CodeBlock>
+
 ## [Example](example)
 
-```console title="cURL" '"store_id"' '"platform"' '"channel"'
+<CodeBlock title="cURL" highlight={"\"store_id\", \"platform\", \"channel\""}>
+
+```console
 $ curl \
 --header "AdjustAuthorization: Token <adjust api token>" \
 --header "Content-Type: application/json" \
@@ -78,9 +88,15 @@ $ curl \
 -X POST https://settings.adjust.com/api/campaign
 ```
 
-```json title="Success response"
+</CodeBlock>
+
+<CodeBlock title="Success response">
+
+```json
 {
    "click_url": "https://app.adjust.com/1lwd85",
    "impression_url": "https://view.adjust.com/impression/1lwd85"
 }
 ```
+
+</CodeBlock>

--- a/src/content/docs/api/app-automation-api/channel-setup.mdx
+++ b/src/content/docs/api/app-automation-api/channel-setup.mdx
@@ -51,7 +51,9 @@ All parameters need to be passed as a key-value pair inside the `channel_setup` 
 
 The following example shows all available partners.
 
-```json title="Available partners"
+<CodeBlock title="Available partners">
+
+```json
 "channel_setup": {
   "snapchat": { "snap_app_id": "snapchat app id" },
   "facebook": { "app_id": "facebook_app_id" },
@@ -64,3 +66,5 @@ The following example shows all available partners.
   "inmobi": { "property_id": "inmobi_gmp_id", "advertiser_id": "adv_id" }
 }
 ```
+
+</CodeBlock>

--- a/src/content/docs/api/app-automation-api/status-endpoint.mdx
+++ b/src/content/docs/api/app-automation-api/status-endpoint.mdx
@@ -7,9 +7,13 @@ sidebar-position: 4
 
 Use the `/status` endpoint to check the status of your new app. This endpoint returns the status of the process that copies settings from your `_Template` app to your new app.
 
-```http title="Endpoint" "/status" "{ticket_token}"
+<CodeBlock title="Endpoint" highlight="/status, {ticket_token}">
+
+```http
 GET https://settings.adjust.com/api/status/{ticket_token}
 ```
+
+</CodeBlock>
 
 ## [Fetch copy process](fetch-copy-process)
 
@@ -38,14 +42,20 @@ Use this endpoint to return the status of a settings copy process. You receive y
 
 ## [Example](example)
 
-```console title="cURL" "<ticket_token>"
+<CodeBlock title="cURL" highlight="<ticket_token>">
+
+```console
 $ curl \
 --header "AdjustAuthorization: Token <adjust api token>" \
 --header "SignatureAuthorization: Token <adjust signature token>" \
 -X GET https://settings.adjust.com/api/status/<ticket_token>
 ```
 
-```json title="Success response"
+</CodeBlock>
+
+<CodeBlock title="Success response">
+
+```json
 {
    "status": "OPENED",
    "events": {
@@ -58,3 +68,5 @@ $ curl \
    }
 }
 ```
+
+</CodeBlock>

--- a/src/content/docs/api/blocklist-api/blocklist.mdx
+++ b/src/content/docs/api/blocklist-api/blocklist.mdx
@@ -13,9 +13,13 @@ sidebar-position: 2
 
 Blocklist a link to block engagement measurement, attribution and callbacks to it and any related sublinks.
 
-```http title="Endpoint" "{link}/blacklist"
+<CodeBlock title="Endpoint" highlight="{link}/blacklist">
+
+```http
 POST https://api.adjust.com/dashboard/api/trackers/{link}/blacklist
 ```
+
+</CodeBlock>
 
 ## [Blocklist a link](blocklist-a-link)
 
@@ -33,7 +37,9 @@ Blocklist the specified link.
 
 ### [Response format](response-format)
 
-```json title="Response format"
+<CodeBlock title="Response format">
+
+```json
 {
    "label": "string",
    "token": "string",
@@ -74,15 +80,23 @@ Blocklist the specified link.
 }
 ```
 
+</CodeBlock>
+
 ## [Example](example)
 
-```console title="cURL" "abc123"
+<CodeBlock title="cURL" highlight="abc123">
+
+```console
 $ curl \
 --header "Authorization: Token token={api_token}" \
 -L -X POST "https://api.adjust.com/dashboard/api/trackers/abc123/blacklist"
 ```
 
-```json title="Success response"
+</CodeBlock>
+
+<CodeBlock title="Success response">
+
+```json
 {
    "label": "Twitter installs",
    "token": "abc123",
@@ -122,3 +136,5 @@ $ curl \
    }
 }
 ```
+
+</CodeBlock>

--- a/src/content/docs/api/blocklist-api/unblocklist.mdx
+++ b/src/content/docs/api/blocklist-api/unblocklist.mdx
@@ -13,9 +13,13 @@ sidebar-position: 3
 
 Unblocklist a link to re-enable engagement measurement, attribution and callbacks to it and any related sublinks.
 
-```http title="Endpoint" "{link}/unblacklist"
+<CodeBlock title="Endpoint" highlight="{link}/unblacklist">
+
+```http
 POST https://api.adjust.com/dashboard/api/trackers/{link}/unblacklist
 ```
+
+</CodeBlock>
 
 ## [Unblocklist a link](unblocklist-a-link)
 
@@ -31,7 +35,9 @@ Unblocklist the specified link.
 
 ### [Response format](response-format)
 
-```json title="Response format"
+<CodeBlock title="Response format">
+
+```json
 {
    "label": "string",
    "token": "string",
@@ -72,15 +78,23 @@ Unblocklist the specified link.
 }
 ```
 
+</CodeBlock>
+
 ## [Example](example)
 
-```console title="cURL" "abc123"
+<CodeBlock title="cURL" highlight="abc123">
+
+```console
 $ curl \
 --header "Authorization: Token token={api_token}" \
 -L -X POST "https://api.adjust.com/dashboard/api/trackers/abc123/unblacklist"
 ```
 
-```json title="Success response"
+</CodeBlock>
+
+<CodeBlock title="Success response">
+
+```json
 {
    "label": "Twitter installs",
    "token": "abc123",
@@ -120,3 +134,5 @@ $ curl \
    }
 }
 ```
+
+</CodeBlock>

--- a/src/content/docs/api/campaign-api/create-link.mdx
+++ b/src/content/docs/api/campaign-api/create-link.mdx
@@ -7,9 +7,13 @@ sidebar-position: 4
 
 Use this endpoint to create new links and sublinks for your app.
 
-```http title="Endpoint" "{app_token}/trackers"
+<CodeBlock title="Endpoint" highlight="{app_token}/trackers">
+
+```http
 POST https://api.adjust.com/public/v1/apps/{app_token}/trackers
 ```
+
+</CodeBlock>
 
 ## [Create a link](create-a-link)
 
@@ -46,7 +50,9 @@ Create a new link or sublink associated to your app.
 
 </Table>
 
-```json title="Response format"
+<CodeBlock title="Response format">
+
+```json
 {
    "name": "String",
    "token": "String",
@@ -62,6 +68,8 @@ Create a new link or sublink associated to your app.
 }
 ```
 
+</CodeBlock>
+
 #### [Link levels](link-levels)
 
 -  Network = `1`
@@ -74,14 +82,20 @@ Create a new link or sublink associated to your app.
 <Tabs>
 <Tab title="Link" sync="link">
 
-```console title="cURL"
+<CodeBlock title="cURL">
+
+```console
 $ curl --location --request POST 'https://api.adjust.com/public/v1/apps/gwzpeepw8uf8/trackers' \
 --header 'Authorization: Token token={API_TOKEN}' \
 --header 'Content-Type: application/json' \
 --data-raw '{"name": "Adroll"}'
 ```
 
-```json title="Success response"
+</CodeBlock>
+
+<CodeBlock title="Success response">
+
+```json
 {
    "data": {
       "api_version": "1",
@@ -106,18 +120,26 @@ $ curl --location --request POST 'https://api.adjust.com/public/v1/apps/gwzpeepw
 }
 ```
 
+</CodeBlock>
+
 </Tab>
 
 <Tab title="Sublink" sync="sublink">
 
-```console title="cURL" '"parent_tracker"'
+<CodeBlock title="cURL" highlight={"\"parent_tracker\""}>
+
+```console
 $ curl --location --request POST 'https://api.adjust.com/public/v1/apps/gwzpeepw8uf8/trackers' \
 --header 'Authorization: Token token={API_TOKEN}' \
 --header 'Content-Type: application/json' \
 --data-raw '{"parent_tracker": "Adroll", "name": "SpringCampaign"}'
 ```
 
-```json title="Success response"
+</CodeBlock>
+
+<CodeBlock title="Success response">
+
+```json
 {
    "data": {
       "api_version": "1",
@@ -141,6 +163,8 @@ $ curl --location --request POST 'https://api.adjust.com/public/v1/apps/gwzpeepw
    }
 }
 ```
+
+</CodeBlock>
 
 </Tab>
 </Tabs>

--- a/src/content/docs/api/campaign-api/get-links.mdx
+++ b/src/content/docs/api/campaign-api/get-links.mdx
@@ -11,17 +11,25 @@ Use this endpoint to get the network-level links for your specified app.
 
 <ApiVersion version="v2">
 
-```http title="Endpoint" "v2/apps/{app_token}/trackers"
+<CodeBlock title="Endpoint" highlight="v2/apps/{app_token}/trackers">
+
+```http
 GET https://api.adjust.com/public/v2/apps/{app_token}/trackers
 ```
+
+</CodeBlock>
 
 </ApiVersion>
 
 <ApiVersion version="v1">
 
-```http title="Endpoint" "v1/apps/{app_token}/trackers"
+<CodeBlock title="Endpoint" highlight="v1/apps/{app_token}/trackers">
+
+```http
 GET https://api.adjust.com/public/v1/apps/{app_token}/trackers
 ```
+
+</CodeBlock>
 
 </ApiVersion>
 
@@ -66,24 +74,34 @@ Each results page contains a "paging" object containing the cursor positions. Yo
 
 <ApiVersion version="v2">
 
-```json title="Pagination example"
+<CodeBlock title="Pagination example">
+
+```json
 "paging": {
    "next": "https://api.adjust.com/public/v2/apps/yxs12pfewq/trackers?cursor=g2wAAAACYhW1_gxkAANuaWxq&limit=50",
    "cursor": "g2wAAAACYhW1_gxkAANuaWxq"
 }
 ```
 
+</CodeBlock>
+
 To go to the second page, follow the `next` link to return results from the next specified `cursor` position.
 
-```console title="cURL" "cursor=g2wAAAACYhW1_gxkAANuaWxq"
+<CodeBlock title="cURL" highlight="cursor=g2wAAAACYhW1_gxkAANuaWxq">
+
+```console
 $ curl "https://api.adjust.com/public/v2/apps/yxs12pfewq/trackers?cursor=g2wAAAACYhW1_gxkAANuaWxq&limit=50"
 ```
+
+</CodeBlock>
 
 </ApiVersion>
 
 <ApiVersion version="v1">
 
-```json title="Pagination example"
+<CodeBlock title="Pagination example">
+
+```json
 "paging": {
    "page_size": "50",
    "collection_size": "49",
@@ -97,11 +115,17 @@ $ curl "https://api.adjust.com/public/v2/apps/yxs12pfewq/trackers?cursor=g2wAAAA
 }
 ```
 
+</CodeBlock>
+
 To go to the second page, add the `after` value to the next request in the `after` parameter. For example:
 
-```console title="cURL" "after=g2wAAAACYhW1_gxkAANuaWxq"
+<CodeBlock title="cURL" highlight="after=g2wAAAACYhW1_gxkAANuaWxq">
+
+```console
 $ curl "https://api.adjust.com/public/v1/apps/yxs12pfewq/trackers?after=g2wAAAACYhW1_gxkAANuaWxq"
 ```
+
+</CodeBlock>
 
 </ApiVersion>
 
@@ -124,7 +148,9 @@ $ curl "https://api.adjust.com/public/v1/apps/yxs12pfewq/trackers?after=g2wAAAAC
 
 </Table>
 
-```json title="Success response"
+<CodeBlock title="Success response">
+
+```json
 {
    "name": "String",
    "token": "String",
@@ -140,17 +166,25 @@ $ curl "https://api.adjust.com/public/v1/apps/yxs12pfewq/trackers?after=g2wAAAAC
 }
 ```
 
+</CodeBlock>
+
 ## [Example](example)
 
 <ApiVersion version="v2">
 
-```console title="cURL" "gwzpeepw8uf8"
+<CodeBlock title="cURL" highlight="gwzpeepw8uf8">
+
+```console
 $ curl \
 --header 'Authorization: Token token={API_TOKEN}' \
 -L -X GET 'https://api.adjust.com/public/v2/apps/gwzpeepw8uf8/trackers?limit=1'
 ```
 
-```json title="Success response"
+</CodeBlock>
+
+<CodeBlock title="Success response">
+
+```json
 {
    "data": {
       "paging": {
@@ -176,17 +210,25 @@ $ curl \
 }
 ```
 
+</CodeBlock>
+
 </ApiVersion>
 
 <ApiVersion version="v1">
 
-```console title="cURL" "gwzpeepw8uf8"
+<CodeBlock title="cURL" highlight="gwzpeepw8uf8">
+
+```console
 $ curl \
 --header 'Authorization: Token token={API_TOKEN}' \
 -L -X GET 'https://api.adjust.com/public/v1/apps/gwzpeepw8uf8/trackers?limit=1'
 ```
 
-```json title="Success response"
+</CodeBlock>
+
+<CodeBlock title="Success response">
+
+```json
 {
    "data": {
       "api_version": "1",
@@ -221,5 +263,7 @@ $ curl \
    }
 }
 ```
+
+</CodeBlock>
 
 </ApiVersion>

--- a/src/content/docs/api/campaign-api/get-partners.mdx
+++ b/src/content/docs/api/campaign-api/get-partners.mdx
@@ -7,9 +7,13 @@ sidebar-position: 6
 
 Use this endpoint to fetch a list of partners and associated data.
 
-```http title="Endpoint" "/partners"
+<CodeBlock title="Endpoint" highlight="/partners">
+
+```http
 GET https://api.adjust.com/public/v1/partners
 ```
+
+</CodeBlock>
 
 ## [Fetch partners](fetch-partners)
 
@@ -33,7 +37,9 @@ Results from this endpoint are paginated using a cursor. Each page returns the l
 
 Each results page contains a "paging" object containing the cursor positions. You can use these cursor positions to programatically move between pages. For example, the first page might contain results like this:
 
-```json title="Pagination example"
+<CodeBlock title="Pagination example">
+
+```json
 "paging": {
    "page_size": "50",
    "collection_size": "49",
@@ -47,11 +53,17 @@ Each results page contains a "paging" object containing the cursor positions. Yo
 }
 ```
 
+</CodeBlock>
+
 To go to the second page, add the `after` value to the next request in the `after` parameter. For example:
 
-```console title="cURL" "after=g2wAAAACYhW1_gxkAANuaWxq"
+<CodeBlock title="cURL" highlight="after=g2wAAAACYhW1_gxkAANuaWxq">
+
+```console
 $ curl "https://api.adjust.com/public/v1/apps/yxs12pfewq/trackers?after=g2wAAAACYhW1_gxkAANuaWxq"
 ```
+
+</CodeBlock>
 
 ### [Response parameters](response-parameters)
 
@@ -65,7 +77,9 @@ $ curl "https://api.adjust.com/public/v1/apps/yxs12pfewq/trackers?after=g2wAAAAC
 
 </Table>
 
-```json title="Response format"
+<CodeBlock title="Response format">
+
+```json
 {
    "id": 1,
    "display_name": "String",
@@ -73,15 +87,24 @@ $ curl "https://api.adjust.com/public/v1/apps/yxs12pfewq/trackers?after=g2wAAAAC
 }
 ```
 
+</CodeBlock>
+
 ## [Example](example)
 
-```console title="cURL"
+<CodeBlock title="cURL">
+
+```console
 $ curl \
 --header 'Authorization: Token token={API_TOKEN}' \
 -L -X GET 'https://api.adjust.com/public/v1/partners?limit=1'
+
 ```
 
-```json title="Success response"
+</CodeBlock>
+
+<CodeBlock title="Success response">
+
+```json
 {
    "data": {
       "api_version": "1",
@@ -108,3 +131,5 @@ $ curl \
    }
 }
 ```
+
+</CodeBlock>

--- a/src/content/docs/api/campaign-api/get-sublinks.mdx
+++ b/src/content/docs/api/campaign-api/get-sublinks.mdx
@@ -10,17 +10,25 @@ Use this endpoint to get the sublinks for your specified app.
 
 <ApiVersion version="v2">
 
-```http title="Endpoint" "v2/apps/{app_token}/trackers/{link_token}/children"
+<CodeBlock title="Endpoint" highlight="v2/apps/{app_token}/trackers/{link_token}/children">
+
+```http
 GET https://api.adjust.com/public/v2/apps/{app_token}/trackers/{link_token}/children
 ```
+
+</CodeBlock>
 
 </ApiVersion>
 
 <ApiVersion version="v1">
 
-```http title="Endpoint" "v1/apps/{app_token}/trackers/{link_token}/children"
+<CodeBlock title="Endpoint" highlight="v1/apps/{app_token}/trackers/{link_token}/children">
+
+```http
 GET https://api.adjust.com/public/v1/apps/{app_token}/trackers/{link_token}/children
 ```
+
+</CodeBlock>
 
 </ApiVersion>
 
@@ -67,24 +75,35 @@ Each results page contains a "paging" object containing the cursor positions. Yo
 
 <ApiVersion version="v2">
 
-```json title="Pagination example"
+<CodeBlock title="Pagination example">
+
+```json
 "paging": {
    "next": "https://api.adjust.com/public/v2/apps/gwzpeepw8uf8/trackers/abc123/children?cursor=g2wAAAACYhW1_gxkAANuaWxq",
    "cursor": "g2wAAAACYhW1_gxkAANuaWxq"
 }
+
 ```
+
+</CodeBlock>
 
 To go to the second page, follow the `next` link to return results from the next specified `cursor` position.
 
-```console title="cURL" "cursor=g2wAAAACYhW1_gxkAANuaWxq"
+<CodeBlock title="cURL" highlight="cursor=g2wAAAACYhW1_gxkAANuaWxq">
+
+```console
 $ curl "https://api.adjust.com/public/v2/apps/gwzpeepw8uf8/trackers/abc123/children?cursor=g2wAAAACYhW1_gxkAANuaWxq"
 ```
+
+</CodeBlock>
 
 </ApiVersion>
 
 <ApiVersion version="v1">
 
-```json title="Pagination example"
+<CodeBlock title="Pagination example">
+
+```json
 "paging": {
    "page_size": "50",
    "collection_size": "49",
@@ -96,13 +115,20 @@ $ curl "https://api.adjust.com/public/v2/apps/gwzpeepw8uf8/trackers/abc123/child
    "next": "https://api.adjust.com/public/v1/apps/gwzpeepw8uf8/trackers/abc123/children?after=g2wAAAACYhW1_gxkAANuaWxq&limit=50",
    "previous": null
 }
+
 ```
+
+</CodeBlock>
 
 To go to the second page, add the `after` value to the next request in the `after` parameter. For example:
 
-```console title="cURL" "after=g2wAAAACYhW1_gxkAANuaWxq"
+<CodeBlock title="cURL" highlight="after=g2wAAAACYhW1_gxkAANuaWxq">
+
+```console
 $ curl "https://api.adjust.com/public/v1/apps/gwzpeepw8uf8/trackers/abc123/children?after=g2wAAAACYhW1_gxkAANuaWxq"
 ```
+
+</CodeBlock>
 
 </ApiVersion>
 
@@ -125,7 +151,9 @@ $ curl "https://api.adjust.com/public/v1/apps/gwzpeepw8uf8/trackers/abc123/child
 
 </Table>
 
-```json title="Response format"
+<CodeBlock title="Response format">
+
+```json
 {
    "name": "String",
    "token": "String",
@@ -141,17 +169,25 @@ $ curl "https://api.adjust.com/public/v1/apps/gwzpeepw8uf8/trackers/abc123/child
 }
 ```
 
+</CodeBlock>
+
 ## [Example](example)
 
 <ApiVersion version="v2">
 
-```console title="cURL" "gwzpeepw8uf8" "abc123"
+<CodeBlock title="cURL" highlight="gwzpeepw8uf8, abc123">
+
+```console
 $ curl \
 --header 'Authorization: Token token={API_TOKEN}'
 -L -X GET 'https://api.adjust.com/public/v2/apps/gwzpeepw8uf8/trackers/abc123/children?limit=1' \
 ```
 
-```json title="Success response"
+</CodeBlock>
+
+<CodeBlock title="Success response">
+
+```json
 {
    "data": {
       "paging": {
@@ -177,17 +213,25 @@ $ curl \
 }
 ```
 
+</CodeBlock>
+
 </ApiVersion>
 
 <ApiVersion version="v1">
 
-```console title="cURL" "gwzpeepw8uf8" "abc123"
+<CodeBlock title="cURL" highlight="gwzpeepw8uf8, abc123">
+
+```console
 $ curl \
 --header 'Authorization: Token token={API_TOKEN}'
 -L -X GET 'https://api.adjust.com/public/v1/apps/gwzpeepw8uf8/trackers/abc123/children?limit=1' \
 ```
 
-```json title="Success response"
+</CodeBlock>
+
+<CodeBlock title="Success response">
+
+```json
 {
    "data": {
       "api_version": "1",
@@ -222,5 +266,7 @@ $ curl \
    }
 }
 ```
+
+</CodeBlock>
 
 </ApiVersion>

--- a/src/content/docs/api/campaign-api/update-link.mdx
+++ b/src/content/docs/api/campaign-api/update-link.mdx
@@ -7,9 +7,13 @@ sidebar-position: 5
 
 Use this endpoint to update existing links and sublinks for your app. You can add new partners to links or control whether cost data is enabled.
 
-```http title="Endpoint" "{app_token}/trackers/{link_token}"
+<CodeBlock title="Endpoint" highlight="{app_token}/trackers/{link_token}">
+
+```http
 PATCH https://api.adjust.com/public/v1/apps/{app_token}/trackers/{link_token}
 ```
+
+</CodeBlock>
 
 ## [Update a link](update-link)
 
@@ -54,7 +58,9 @@ Update a link or sublink associated to your app.
 -  Adgroup = `3`
 -  Creative = `4`
 
-```json title="Response format"
+<CodeBlock title="Response format">
+
+```json
 {
    "name": "String",
    "token": "String",
@@ -70,9 +76,13 @@ Update a link or sublink associated to your app.
 }
 ```
 
+</CodeBlock>
+
 ## [Example](example)
 
-```console title="cURL" "gwzpeepw8uf8" "klm789"
+<CodeBlock title="cURL" highlight="gwzpeepw8uf8, klm789">
+
+```console
 $ curl \
 --header 'Authorization: Token token={API_TOKEN}' \
 --header 'Content-Type: application/json' \
@@ -80,7 +90,11 @@ $ curl \
 --data-raw '{"partner_id": 174, "cost_data_enabled": false}'
 ```
 
-```json title="Success response"
+</CodeBlock>
+
+<CodeBlock title="Success response">
+
+```json
 {
    "data": {
       "api_version": "1",
@@ -104,3 +118,5 @@ $ curl \
    }
 }
 ```
+
+</CodeBlock>

--- a/src/content/docs/api/data-erasure-api/index.mdx
+++ b/src/content/docs/api/data-erasure-api/index.mdx
@@ -21,9 +21,13 @@ This action is **permanent**. Adjust can't reinstate data previously associated 
 
 </Callout>
 
-```http title="Endpoint" "/gdpr_forget_device"
+<CodeBlock title="Endpoint" highlight="/gdpr_forget_device">
+
+```http
 POST https://gdpr.adjust.com/gdpr_forget_device
 ```
+
+</CodeBlock>
 
 ## [Send an erasure request](send-an-erasure-request)
 
@@ -64,9 +68,13 @@ You must include a device identifier in your request. Below is a list of accepte
 
 ## [Example](example)
 
-```console title="cURL" "app_token=kwrqhymtnsr2&idfa=9C5CBC1D-4F42-4764-A5E6-84DAF3D24707"
+<CodeBlock title="cURL" highlight="app_token=kwrqhymtnsr2&idfa=9C5CBC1D-4F42-4764-A5E6-84DAF3D24707">
+
+```console
 $ curl -X POST "https://gdpr.adjust.com/gdpr_forget_device?s2s=1&app_token=kwrqhymtnsr2&idfa=9C5CBC1D-4F42-4764-A5E6-84DAF3D24707"
 ```
+
+</CodeBlock>
 
 ### [Responses](responses)
 

--- a/src/content/docs/api/device-api/forget.mdx
+++ b/src/content/docs/api/device-api/forget.mdx
@@ -13,9 +13,13 @@ You need **Admin** or **Editor** permissions to forget devices. If you have **Cu
 
 </Callout>
 
-```http title="Endpoint" "/forget_device"
+<CodeBlock title="Endpoint" highlight="/forget_device">
+
+```http
 POST https://api.adjust.com/device_service/api/v1/forget_device
 ```
+
+</CodeBlock>
 
 ## [Forget a device](forget-a-device)
 
@@ -32,16 +36,24 @@ Clears the device's information from Adjust.
 
 ## [Example](example)
 
-```console title="cURL" "gwzpeepw8uf8" "acf8534f2f052395e617a38730682ccc"
+<CodeBlock title="cURL" highlight="gwzpeepw8uf8, acf8534f2f052395e617a38730682ccc">
+
+```console
 $ curl \
 --header "Authorization: Token token=ask43jskdp2tg2hg87" \
 --location --request POST "https://api.adjust.com/device_service/api/v1/forget_device" \
 --data "adid=acf8534f2f052395e617a38730682ccc&app_token=gwzpeepw8uf8"
 ```
 
-```http title="Success response"
+</CodeBlock>
+
+<CodeBlock title="Success response">
+
+```http
 200: Forgot device
 ```
+
+</CodeBlock>
 
 ### [Response codes](response-codes)
 

--- a/src/content/docs/api/device-api/inspect.mdx
+++ b/src/content/docs/api/device-api/inspect.mdx
@@ -7,9 +7,13 @@ sidebar-position: 2
 
 Use the Inspect device endpoint to see information about a device. Provide your app ID and your device's advertising ID to return device and link information relating to the app.
 
-```http title="Endpoint" "/inspect_device"
+<CodeBlock title="Endpoint" highlight="/inspect_device">
+
+```http
 GET https://api.adjust.com/device_service/api/v1/inspect_device
 ```
+
+</CodeBlock>
 
 ## [Fetch device information](fetch-device-information)
 
@@ -34,7 +38,9 @@ Return device information as a JSON object.
 
 </Accordion>
 
-```json title="Response format"
+<CodeBlock title="Response format">
+
+```json
 {
    "Adid": "string",
    "AdvertisingId": "string",
@@ -53,15 +59,23 @@ Return device information as a JSON object.
 }
 ```
 
+</CodeBlock>
+
 ## [Example](example)
 
-```console title="cURL" "advertising_id=1234-5678-9012-3456" "app_token=gwzpeepw8uf8"
+<CodeBlock title="cURL" highlight="advertising_id=1234-5678-9012-3456, app_token=gwzpeepw8uf8">
+
+```console
 $ curl \
 --header "Authorization: Bearer ask43jskdp2tg2hg87" \
 -L -X GET "https://api.adjust.com/device_service/api/v1/inspect_device?advertising_id=1234-5678-9012-3456&app_token=gwzpeepw8uf8"
 ```
 
-```json title="Successful response"
+</CodeBlock>
+
+<CodeBlock title="Successful response">
+
+```json
 {
    "Adid": "acf8534f2f052395e617a38730682ccc",
    "AdvertisingId": "1234-5678-9012-3456",
@@ -79,3 +93,5 @@ $ curl \
    "State": "installed"
 }
 ```
+
+</CodeBlock>

--- a/src/content/docs/api/rs-api/csv.mdx
+++ b/src/content/docs/api/rs-api/csv.mdx
@@ -14,9 +14,13 @@ The CSV Report Service provides an API to get aggregated data from different sou
 
 ## [Fetch CSV report](fetch-csv-report)
 
-```http title="Endpoint" "/reports-service/csv_report"
+<CodeBlock title="Endpoint" highlight="/reports-service/csv_report">
+
+```http
 GET https://automate.adjust.com/reports-service/csv_report
 ```
+
+</CodeBlock>
 
 The `GET` method returns filtered data from the report service in CSV format. The API returns columns of data for each parameter passed in the request. By default the parameter's slug is used as the column header. You can return human-readable names by passing `readable_names=true` in your request.
 
@@ -162,10 +166,15 @@ A full list of metrics is available in the [Datascape metrics glossary](https://
 
 </Table>
 
-```text title="Response format"
+<CodeBlock title="Response format">
+
+```text
 app,partner_name,campaign,campaign_id_network,campaign_network,installs,network_cost
 String,String,String,String,String,Number,Number
+
 ```
+
+</CodeBlock>
 
 ### [Response codes](response-codes)
 
@@ -186,13 +195,23 @@ String,String,String,String,String,Number,Number
 
 ## [Example](example)
 
-```console title="cURL"
+<CodeBlock title="cURL">
+
+```console
 $ curl \
 --header 'Authorization: Bearer <adjust_api_token>' \
 --location --request GET 'https://automate.adjust.com/reports-service/csv_report?cost_mode=network&app_token__in={app_token1},{app_token2}&date_period=2021-05-01:2021-05-02&dimensions=app,partner_name,campaign,campaign_id_network,campaign_network&metrics=installs,network_cost'
+
 ```
 
-```text title="Success response"
+</CodeBlock>
+
+<CodeBlock title="Success response">
+
+```text
 app,partner_name,campaign,campaign_id_network,campaign_network,installs,network_cost
 App Name,AppLovin,Campaign Name (Campaign ID),Campaign ID,Campaign Network,64,1000
+
 ```
+
+</CodeBlock>

--- a/src/content/docs/api/rs-api/events.mdx
+++ b/src/content/docs/api/rs-api/events.mdx
@@ -9,9 +9,13 @@ Use the Events endpoint to retrieve event slugs to use in your report service qu
 
 ## [Return events](return-events)
 
-```http title="Endpoint" "/reports-service/events"
+<CodeBlock title="Endpoint" highlight="/reports-service/events">
+
+```http
 GET https://automate.adjust.com/reports-service/events
 ```
+
+</CodeBlock>
 
 Return a list of event objects.
 
@@ -60,7 +64,9 @@ Return a list of event objects.
 
 </Table>
 
-```json title="Response format"
+<CodeBlock title="Response format">
+
+```json
 [
    {
       "id": "string",
@@ -75,6 +81,8 @@ Return a list of event objects.
    }
 ]
 ```
+
+</CodeBlock>
 
 ### [Responses](responses)
 
@@ -97,13 +105,20 @@ This endpoint returns the following responses:
 
 ## [Example](example)
 
-```console title="cURL" "events__contains=purchase"
+<CodeBlock title="cURL" highlight="events__contains=purchase">
+
+```console
 $ curl \
 'https://automate.adjust.com/reports-service/events?events__contains=purchase' \
 --header 'Authorization: Bearer {API_TOKEN}'
+
 ```
 
-```json title="Success response"
+</CodeBlock>
+
+<CodeBlock title="Success response">
+
+```json
 [
    {
       "id": "purchase",
@@ -118,3 +133,5 @@ $ curl \
    }
 ]
 ```
+
+</CodeBlock>

--- a/src/content/docs/api/rs-api/pivot.mdx
+++ b/src/content/docs/api/rs-api/pivot.mdx
@@ -11,9 +11,13 @@ The reports endpoint enables you to combine data from many services in a single 
 
 ## [Fetch pivot report](fetch-pivot-report)
 
-```http title="Endpoint" "/reports-service/pivot_report"
+<CodeBlock title="Endpoint" highlight="/reports-service/pivot_report">
+
+```http
 GET https://automate.adjust.com/reports-service/pivot_report
 ```
+
+</CodeBlock>
 
 The `GET` method returns filtered data from the report service in JSON format.
 
@@ -138,7 +142,9 @@ A full list of metrics is available in the [Datascape metrics glossary](https://
 
 ### [Response format](response-format)
 
-```json title="Response format"
+<CodeBlock title="Response format">
+
+```json
 {
    "rows": [
       {
@@ -161,6 +167,8 @@ A full list of metrics is available in the [Datascape metrics glossary](https://
 }
 ```
 
+</CodeBlock>
+
 ### [Response codes](response-codes)
 
 This endpoint returns the following responses:
@@ -182,13 +190,20 @@ This endpoint returns the following responses:
 
 ## [Example](example)
 
-```console title="cURL"
+<CodeBlock title="cURL">
+
+```console
 $ curl \
 --header 'Authorization: Bearer <adjust_api_token>' \
 -L -X GET 'https://automate.adjust.com/reports-service/pivot_report?cost_mode=network&app_token__in={app_token1},{app_token2}&date_period=2021-05-01:2021-05-02&dimensions=app,partner_name,campaign,campaign_id_network,campaign_network&metrics=installs,network_installs,network_cost,network_ecpi&index=app' \
+
 ```
 
-```json title="Success response"
+</CodeBlock>
+
+<CodeBlock title="Success response">
+
+```json
 {
    "rows": [
       {
@@ -261,3 +276,5 @@ $ curl \
    }
 }
 ```
+
+</CodeBlock>

--- a/src/content/docs/api/rs-api/reports.mdx
+++ b/src/content/docs/api/rs-api/reports.mdx
@@ -9,9 +9,13 @@ The reports endpoint enables you to combine data from many services in a single 
 
 ## [Fetch JSON report](fetch-json-report)
 
-```http title="Endpoint" "/reports-service/report"
+<CodeBlock title="Endpoint" highlight="/reports-service/report">
+
+```http
 GET https://automate.adjust.com/reports-service/report
 ```
+
+</CodeBlock>
 
 Returns filtered data from the report service in JSON format.
 
@@ -134,7 +138,9 @@ A full list of metrics is available in the [Datascape metrics glossary](https://
 
 ### [Response format](response-format)
 
-```json title="Response format"
+<CodeBlock title="Response format">
+
+```json
 {
    "rows": [
       {
@@ -155,6 +161,8 @@ A full list of metrics is available in the [Datascape metrics glossary](https://
    "warnings": []
 }
 ```
+
+</CodeBlock>
 
 ### [Response codes](response-codes)
 
@@ -177,13 +185,20 @@ This endpoint returns the following responses:
 
 ## [Example](example)
 
-```console title="cURL"
+<CodeBlock title="cURL">
+
+```console
 $ curl \
 --header 'Authorization: Bearer <adjust_api_token>' \
 --location --request GET 'https://automate.adjust.com/reports-service/report?cost_mode=network&app_token__in={app_token1},{app_token2}&date_period=2021-05-01:2021-05-02&dimensions=app,partner_name,campaign,campaign_id_network,campaign_network&metrics=installs,network_installs,network_cost,network_ecpi'
+
 ```
 
-```json title="Success response"
+</CodeBlock>
+
+<CodeBlock title="Success response">
+
+```json
 {
    "rows": [
       {
@@ -213,3 +228,5 @@ $ curl \
    "pagination": null
 }
 ```
+
+</CodeBlock>

--- a/src/content/docs/api/s2s-api/ad-revenue.mdx
+++ b/src/content/docs/api/s2s-api/ad-revenue.mdx
@@ -10,9 +10,13 @@ If you record ad revenue yourself, you can share this data server-to-server (S2S
 
 Send your ad revenue data to Adjust server-to-server to view it in your dashboard Statistics and Cohorts.
 
-```text title="Endpoint" "/ad_revenue"
+<CodeBlock title="Endpoint" highlight="/ad_revenue">
+
+```text
 https://s2s.adjust.com/ad_revenue
 ```
+
+</CodeBlock>
 
 ## [Before you begin](before-you-begin)
 
@@ -93,7 +97,7 @@ The following parameters are **recommended** but not mandatory.
 
 ## [Example](example)
 
-```sh {3}
+```console
 curl -X POST \
 -H "Authorization: Bearer b9eb9d6228842aeb05d64f30d56b361e" \
 "https://s2s.adjust.com/ad_revenue?app_token=abc123abc123&idfa=FAD135C7-C5F8-4DCC-9478-2203956B0870&source=publisher&ad_impressions_count=1&revenue=0.01&currency=USD&s2s=1"

--- a/src/content/docs/api/s2s-api/events.mdx
+++ b/src/content/docs/api/s2s-api/events.mdx
@@ -18,9 +18,13 @@ For attribution, Adjust doesn't distinguish between clicks that are sent from th
 
 In this article, you'll learn how to set up and troubleshoot S2S event recording.
 
-```text title="Endpoint" "/event"
+<CodeBlock title="Endpoint" highlight="/event">
+
+```text
 https://s2s.adjust.com/event
 ```
+
+</CodeBlock>
 
 ## [Send S2S events](send-s2s-events)
 
@@ -116,28 +120,44 @@ Don't nest objects in your custom data objects.
 
 </Callout>
 
-```json title="Unencoded example"
+<CodeBlock title="Unencoded example">
+
+```json
 {
    "f0o": "bar",
    "bar": "baz"
 }
 ```
 
-```text title="Encoded example" "f0o" "bar" "baz"
+</CodeBlock>
+
+<CodeBlock title="Encoded example" highlight="f0o, bar, baz">
+
+```text
 %7B%22f0o%22%3A%22bar%22%2C%20%22bar%22%3A%22baz%22%7D
 ```
 
+</CodeBlock>
+
 To receive callback parameters in raw data exports, add data in the `callback_params` parameter of your S2S call.
 
-```console title="Callback parameters" "callback_params"
+<CodeBlock title="Callback parameters" highlight="callback_params">
+
+```console
 curl --location https://s2s.adjust.com/event?s2s=1&event_token=f0ob4r&app_token=4w565xzmb54d&idfa=8A3CB124-5A79-4334-8802-F75FEC099C58&callback_params=%7B%22f0o%22%3A%22bar%22%2C%20%22bar%22%3A%22baz%22%7D
 ```
 
+</CodeBlock>
+
 To send event information to your network partners, add data in the `partner_params` parameter of your S2S call.
 
-```console title="Partner parameters" "partner_params"
+<CodeBlock title="Partner parameters" highlight="partner_params">
+
+```console
 curl --location https://s2s.adjust.com/event?s2s=1&event_token=f0ob4r&app_token=4w565xzmb54d&idfa=8A3CB124-5A79-4334-8802-F75FEC099C58&partner_params=%7B%22f0o%22%3A%22bar%22%2C%20%22bar%22%3A%22baz%22%7D
 ```
+
+</CodeBlock>
 
 ### [Record revenue events](record-revenue-events)
 
@@ -158,14 +178,14 @@ Add the following revenue parameters to your event submissions to record S2S rev
 <Tabs>
 <Tab title="GET">
 
-```sh
+```console
 curl "https://s2s.adjust.com/event?s2s=1&event_token=f0ob4r&app_token=4w565xzmb54d&idfa=D2CADB5F-410F-4963-AC0C-2A78534BDF1E&created_at=2017-01-02T15%3A04%3A05Z%2B0200&callback_params=%7B%22f0o%22%3A%22bar%22%2C%20%22bar%22%3A%22baz%22%7D&partner_params=%7B%22f0o%22%3A%22bar%22%2C%20%22bar%22%3A%22baz%22%7D&currency=EUR&revenue=123.4&environment=sandbox"
 ```
 
 </Tab>
 <Tab title="POST with URL parameters">
 
-```sh {2}
+```console
 curl -X POST \
 "https://s2s.adjust.com/event?s2s=1&event_token=f0ob4r&app_token=4w565xzmb54d&idfa=D2CADB5F-410F-4963-AC0C-2A78534BDF1E&created_at=2017-01-02T15%3A04%3A05Z%2B0200&callback_params=%7B%22f0o%22%3A%22bar%22%2C%20%22bar%22%3A%22baz%22%7D&partner_params=%7B%22f0o%22%3A%22bar%22%2C%20%22bar%22%3A%22baz%22%7D&currency=EUR&revenue=123.4&environment=sandbox"
 ```
@@ -173,7 +193,7 @@ curl -X POST \
 </Tab>
 <Tab title="POST with body">
 
-```sh {3}
+```console
 curl -X POST \
 -H "Content-Type: application/x-www-form-urlencoded" \
 --data "s2s=1&event_token=f0ob4r&app_token=4w565xzmb54d&idfa=D2CADB5F-410F-4963-AC0C-2A78534BDF1E&created_at=2017-01-02T15%3A04%3A05Z%2B0200&callback_params=%7B%22f0o%22%3A%22bar%22%2C%20%22bar%22%3A%22baz%22%7D&partner_params=%7B%22f0o%22%3A%22bar%22%2C%20%22bar%22%3A%22baz%22%7D&currency=EUR&revenue=123.4&environment=sandbox" \

--- a/src/content/docs/api/s2s-api/index.mdx
+++ b/src/content/docs/api/s2s-api/index.mdx
@@ -53,9 +53,13 @@ All successfully recorded events return an `OK` response.
 
 Failed events return an HTTP error code and JSON message.
 
-```json title="Error response"
+<CodeBlock title="Error response">
+
+```json
 { "error": "Event request failed (${error_message})" }
 ```
+
+</CodeBlock>
 
 Error messages define the request problem. Use this table to identify your error, then review your setup or reach out to support@adjust.com for help.
 

--- a/src/content/docs/api/s2s-api/sessions.mdx
+++ b/src/content/docs/api/s2s-api/sessions.mdx
@@ -24,9 +24,13 @@ Adjust needs to turn this feature on for you. Contact your Technical Account Man
 
 Adjust groups sessions to save resources. This means there must be a gap of at least 30 minutes after a session, before the Adjust server accepts a new session as triggered.
 
-```text title="endpoint" "/session"
+<CodeBlock title="endpoint" highlight="/session">
+
+```text
 https://s2s.adjust.com/session
 ```
+
+</CodeBlock>
 
 ### [Headers](headers)
 
@@ -112,15 +116,22 @@ You must send the `ad_personalization` parameter if you are working with Google 
 
 ## [Example](example)
 
-```sh title="Request"
+<CodeBlock title="Request">
+
+```sh
 curl -X "POST" \
 -H 'Authorization: Bearer ADD_YOUR_AUTH_TOKEN_HERE' \
 -H 'User-Agent: Adjust Streaming Job (akka-http)' \
 -d "app_token=a1234b2x3a4o&app_version=Roku%2FDVP-10.5+%2810.5.0.0010%29&created_at_unix=1543915806015&environment=production&os_name=android&rida=099aa0bc-d123-4567-8999-a1b7c50767b1&s2s=1" \
 "https://s2s.adjust.com/session"
+
 ```
 
-```json title="Response"
+</CodeBlock>
+
+<CodeBlock title="Response">
+
+```json
 {
    "Host": "s2s.adjust.com",
    "Path": "/session",
@@ -145,3 +156,5 @@ curl -X "POST" \
    }
 }
 ```
+
+</CodeBlock>

--- a/src/content/docs/sdk/android/configuration.mdx
+++ b/src/content/docs/sdk/android/configuration.mdx
@@ -515,11 +515,16 @@ Use the methods in this document to configure the behavior of the Adjust SDK.
 
 ## [Instantiate your config object](instantiate-your-config-object)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public AdjustConfig(Context context, String appToken, String environment, boolean allowSuppressLogLevel) {
         init(context, appToken, environment, allowSuppressLogLevel);
 }
+
 ```
+
+</CodeBlock>
 
 To configure the Adjust SDK, you need to instantiate an `AdjustConfig` object. This object contains the **read-only** configuration options that you need to pass to the Adjust SDK.
 
@@ -533,7 +538,7 @@ To instantiate your config object, create a new `AdjustConfig` instance and pass
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {3}
+```kotlin
 val appToken = "{YourAppToken}"
 val environment = AdjustConfig.ENVIRONMENT_SANDBOX
 val config = AdjustConfig(this, appToken, environment, false)
@@ -542,7 +547,7 @@ val config = AdjustConfig(this, appToken, environment, false)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {3}
+```java
 String appToken = "{YourAppToken}";
 String environment = AdjustConfig.ENVIRONMENT_SANDBOX;
 AdjustConfig config = new AdjustConfig(this, appToken, environment, false);
@@ -551,7 +556,7 @@ AdjustConfig config = new AdjustConfig(this, appToken, environment, false);
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {3}
+```js
 var yourAppToken = yourAppToken;
 var environment = AdjustConfig.EnvironmentSandbox;
 var adjustConfig = new AdjustConfig(yourAppToken, environment, false);
@@ -566,9 +571,13 @@ var adjustConfig = new AdjustConfig(yourAppToken, environment, false);
 
 ### [Set your logging level](set-your-logging-level)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void setLogLevel(LogLevel logLevel)
 ```
+
+</CodeBlock>
 
 The Adjust SDK provides configurable log levels to return different amounts of information. The following log levels are available:
 
@@ -593,7 +602,7 @@ You can set your log level by calling the `setLogLevel` method on your `AdjustCo
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {4}
+```kotlin
 val appToken = "{YourAppToken}"
 val environment = AdjustConfig.ENVIRONMENT_SANDBOX
 val config = AdjustConfig(this, appToken, environment)
@@ -605,7 +614,7 @@ Adjust.onCreate(config)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {4}
+```java
 String appToken = "{YourAppToken}";
 String environment = AdjustConfig.ENVIRONMENT_SANDBOX;
 AdjustConfig config = new AdjustConfig(this, appToken, environment);
@@ -617,7 +626,7 @@ Adjust.onCreate(config);
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {4}
+```js
 var yourAppToken = yourAppToken;
 var environment = AdjustConfig.EnvironmentSandbox;
 var adjustConfig = new AdjustConfig(yourAppToken, environment);
@@ -629,9 +638,13 @@ adjustConfig.setLogLevel(AdjustConfig.LogLevelVerbose);
 
 ### [Set external device identifier](set-external-device-identifier)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void setExternalDeviceId(String externalDeviceId)
 ```
+
+</CodeBlock>
 
 An external device identifier is a custom value that you can assign to a device or user. They help you recognize users across sessions and platforms. They can also help you deduplicate installs by user so that a user isn't counted as duplicate new installs. Contact your Adjust representative to get started with external device IDs.
 
@@ -648,7 +661,7 @@ See the [External device identifiers article](https://help.adjust.com/en/article
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {4}
+```kotlin
 val appToken = "{YourAppToken}"
 val environment = AdjustConfig.ENVIRONMENT_SANDBOX
 val config = AdjustConfig(this, appToken, environment)
@@ -661,7 +674,7 @@ Adjust.onCreate(config)
 
 <Tab title="Java" sync="java">
 
-```java {4}
+```java
 String appToken = "{YourAppToken}";
 String environment = AdjustConfig.ENVIRONMENT_SANDBOX;
 AdjustConfig config = new AdjustConfig(this, appToken, environment);
@@ -673,7 +686,7 @@ Adjust.onCreate(config);
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {4}
+```js
 var yourAppToken = yourAppToken;
 var environment = AdjustConfig.EnvironmentSandbox;
 var adjustConfig = new AdjustConfig(yourAppToken, environment);
@@ -689,9 +702,13 @@ You can import existing external device IDs into Adjust. This ensures that the A
 
 ### [Set default link token](set-default-link-token)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void setDefaultTracker(String defaultTracker)
 ```
+
+</CodeBlock>
 
 You can configure a default link token if your app is preinstalled on a device. When a user opens the preinstalled app for the first time, the install is attributed to the default link token. To set your default link token, call the `setDefaultTracker` method with the following argument:
 
@@ -700,7 +717,7 @@ You can configure a default link token if your app is preinstalled on a device. 
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {4}
+```kotlin
 val appToken = "{YourAppToken}"
 val environment = AdjustConfig.ENVIRONMENT_SANDBOX
 val config = AdjustConfig(this, appToken, environment)
@@ -712,7 +729,7 @@ Adjust.onCreate(config)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {4}
+```java
 String appToken = "{YourAppToken}";
 String environment = AdjustConfig.ENVIRONMENT_SANDBOX;
 AdjustConfig config = new AdjustConfig(this, appToken, environment);
@@ -724,7 +741,7 @@ Adjust.onCreate(config);
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {4}
+```js
 var yourAppToken = yourAppToken;
 var environment = AdjustConfig.EnvironmentSandbox;
 var adjustConfig = new AdjustConfig(yourAppToken, environment);
@@ -736,9 +753,13 @@ adjustConfig.setDefaultTracker("{Token}");
 
 ### [Enable cost data sending](enable-cost-data-sending)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void setNeedsCost(boolean needsCost)
 ```
+
+</CodeBlock>
 
 By default, the Adjust SDK doesn't send cost data as part of a user's attribution. You can configure the SDK to send this data by enabling cost data sending. To enable cost data sending, call the `setNeedsCost` method on your config instance with the following parameter:
 
@@ -749,7 +770,7 @@ Cost data is accessible in the user's [attribution information](/en/sdk/android/
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {2}
+```kotlin
 val config = AdjustConfig(this, appToken, environment)
 config.setNeedsCost(true)
 Adjust.onCreate(config)
@@ -758,7 +779,7 @@ Adjust.onCreate(config)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {2}
+```java
 AdjustConfig config = new AdjustConfig(this, appToken, environment);
 config.setNeedsCost(true);
 Adjust.onCreate(config);
@@ -767,7 +788,7 @@ Adjust.onCreate(config);
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {2}
+```js
 var adjustConfig = new AdjustConfig(yourAppToken, environment);
 adjustConfig.setNeedsCost(true);
 Adjust.onCreate(adjustConfig);
@@ -778,9 +799,13 @@ Adjust.onCreate(adjustConfig);
 
 ### [Enable background recording](enable-background-recording)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void setSendInBackground(boolean sendInBackground)
 ```
+
+</CodeBlock>
 
 By default, the Adjust SDK pauses the sending of requests when your app is running in the background. You can configure the SDK to send requests in the background by enabling the background recording. To enable background recording, call the `setSendInBackground` method on your config instance with the following parameter:
 
@@ -789,7 +814,7 @@ By default, the Adjust SDK pauses the sending of requests when your app is runni
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {4}
+```kotlin
 val appToken = "{YourAppToken}"
 val environment = AdjustConfig.ENVIRONMENT_SANDBOX
 val config = AdjustConfig(this, appToken, environment)
@@ -801,7 +826,7 @@ Adjust.onCreate(config)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {4}
+```java
 String appToken = "{YourAppToken}";
 String environment = AdjustConfig.ENVIRONMENT_SANDBOX;
 AdjustConfig config = new AdjustConfig(this, appToken, environment);
@@ -813,7 +838,7 @@ Adjust.onCreate(config);
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {4}
+```js
 var yourAppToken = yourAppToken;
 var environment = AdjustConfig.EnvironmentSandbox;
 var adjustConfig = new AdjustConfig(yourAppToken, environment);
@@ -825,9 +850,13 @@ adjustConfig.setSendInBackground(true);
 
 ### [Enable event buffering](enable-event-buffering)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void setEventBufferingEnabled(Boolean eventBufferingEnabled)
 ```
+
+</CodeBlock>
 
 The Adjust SDK sends event information as soon as a user triggers an event in your app. You can send event information on a schedule by enabling event buffering. Event buffering stores events in a local buffer on the device and sends all requests once per minute.
 
@@ -838,7 +867,7 @@ Your config object contains a boolean `eventBufferingEnabled` property that cont
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {4}
+```kotlin
 val appToken = "{YourAppToken}"
 val environment = AdjustConfig.ENVIRONMENT_SANDBOX
 val config = AdjustConfig(this, appToken, environment)
@@ -850,7 +879,7 @@ Adjust.onCreate(config)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {4}
+```java
 String appToken = "{YourAppToken}";
 String environment = AdjustConfig.ENVIRONMENT_SANDBOX;
 AdjustConfig config = new AdjustConfig(this, appToken, environment);
@@ -862,7 +891,7 @@ Adjust.onCreate(config);
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {4}
+```js
 var yourAppToken = yourAppToken;
 var environment = AdjustConfig.EnvironmentSandbox;
 var adjustConfig = new AdjustConfig(yourAppToken, environment);
@@ -874,9 +903,13 @@ adjustConfig.setEventBufferingEnabled(true);
 
 ### [Delay the start of the SDK](delay-the-start-of-the-sdk)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void setDelayStart(double delayStart)
 ```
+
+</CodeBlock>
 
 By default, the Adjust SDK starts as soon as your app opens. If you want to send data that isn't available at launch in [session parameters](/en/sdk/android/features/session-parameters), you can delay the start of the SDK. This can be helpful if you are sending information such as unique identifiers.
 
@@ -887,7 +920,7 @@ To configure a startup delay, call the `setDelayStart` method with the following
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {2}
+```kotlin
 val config = AdjustConfig(this, appToken, environment)
 config.setDelayStart(5.5)
 Adjust.onCreate(config)
@@ -896,7 +929,7 @@ Adjust.onCreate(config)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {2}
+```java
 AdjustConfig config = new AdjustConfig(this, appToken, environment);
 config.setDelayStart(5.5);
 Adjust.onCreate(config);
@@ -905,7 +938,7 @@ Adjust.onCreate(config);
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {2}
+```js
 var adjustConfig = new AdjustConfig(yourAppToken, environment);
 adjustConfig.setDelayStart(5.5);
 Adjust.onCreate(adjustConfig);
@@ -920,9 +953,13 @@ Adjust.onCreate(adjustConfig);
 
 ### [Toggle offline mode](toggle-offline-mode)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public static void setOfflineMode(boolean enabled)
 ```
+
+</CodeBlock>
 
 <Callout type="important">
 
@@ -964,9 +1001,13 @@ Adjust.setOfflineMode(true);
 
 ### [Set push tokens](set-push-tokens)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public static void setPushToken(final String token, final Context context)
 ```
+
+</CodeBlock>
 
 Push tokens are used for [Audiences](https://help.adjust.com/en/article/audiences) and client callbacks. They're also required for [Uninstall and reinstall measurement](https://help.adjust.com/en/article/uninstalls-reinstalls).
 
@@ -1015,9 +1056,13 @@ You can only call this method after the first session. This setting persists bet
 
 </Callout>
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public static void setEnabled(boolean enabled)
 ```
+
+</CodeBlock>
 
 The Adjust SDK runs by default when your app is open. You can disable and re-enable the Adjust SDK to pause and resume recording. When you disable the Adjust SDK, it doesn't send any data to Adjust's servers.
 
@@ -1053,9 +1098,13 @@ Adjust.setEnabled(false);
 
 #### [Check enabled status](check-enabled-status)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public static boolean isEnabled()
 ```
+
+</CodeBlock>
 
 You can check if the Adjust SDK is enabled at any time by calling the `isEnabled` method. This method returns a `Boolean` value indicating if the SDK is **enabled** (`true`) or **disabled** (`false`).
 

--- a/src/content/docs/sdk/android/features/ad-revenue.mdx
+++ b/src/content/docs/sdk/android/features/ad-revenue.mdx
@@ -452,9 +452,13 @@ You need to perform some extra setup steps in your Adjust dashboard to measure a
 
 ## [Instantiate an AdjustAdRevenue object](instantiate-an-adjustadrevenue-object)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public AdjustAdRevenue(final String source)
 ```
+
+</CodeBlock>
 
 To send ad revenue information with the Adjust SDK, you need to instantiate an `AdjustAdRevenue` object. This object contains variables that are sent to Adjust when ad revenue is recorded in your app.
 
@@ -481,7 +485,7 @@ To instantiate an ad revenue object, create a new `AdjustAdRevenue` instance and
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {1}
+```kotlin
 val adjustAdRevenue = AdjustAdRevenue("source")
 Adjust.trackAdRevenue(adjustAdRevenue)
 ```
@@ -490,7 +494,7 @@ Adjust.trackAdRevenue(adjustAdRevenue)
 
 <Tab title="Java" sync="java">
 
-```java {1}
+```java
 AdjustAdRevenue adjustAdRevenue = new AdjustAdRevenue("source");
 Adjust.trackAdRevenue(adjustAdRevenue);
 ```
@@ -499,7 +503,7 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 <Tab title="Javascript" sync="js">
 
-```js {1}
+```js
 let adjustAdRevenue = new AdjustAdRevenue("source");
 Adjust.trackAdRevenue(adjustAdRevenue);
 ```
@@ -509,16 +513,20 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 ## [Send ad revenue](send-ad-revenue)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public static void trackAdRevenue(AdjustAdRevenue adRevenue)
 ```
+
+</CodeBlock>
 
 To send ad revenue to Adjust, call the `trackAdRevenue` method with your ad revenue instance as an argument.
 
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {2}
+```kotlin
 val adjustAdRevenue = AdjustAdRevenue(AdjustConfig.AD_REVENUE_APPLOVIN_MAX)
 Adjust.trackAdRevenue(adjustAdRevenue)
 ```
@@ -527,7 +535,7 @@ Adjust.trackAdRevenue(adjustAdRevenue)
 
 <Tab title="Java" sync="java" >
 
-```java {2}
+```java
 AdjustAdRevenue adjustAdRevenue = new AdjustAdRevenue(AdjustConfig.AD_REVENUE_APPLOVIN_MAX);
 Adjust.trackAdRevenue(adjustAdRevenue)
 ```
@@ -536,7 +544,7 @@ Adjust.trackAdRevenue(adjustAdRevenue)
 
 <Tab title="Javascript" sync="js" >
 
-```js {2}
+```js
 let adjustAdRevenue = new AdjustAdRevenue(AdjustConfig.AD_REVENUE_APPLOVIN_MAX);
 Adjust.trackAdRevenue(adjustAdRevenue);
 ```
@@ -546,9 +554,13 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 ## [Record ad revenue amount](record-ad-revenue-amount)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void setRevenue(final Double revenue, final String currency)
 ```
+
+</CodeBlock>
 
 To send the ad revenue amount, call the `setRevenue` method and pass the following arguments:
 
@@ -564,7 +576,7 @@ Check the [guide to recording purchases in different currencies](https://help.ad
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {2}
+```kotlin
 val adjustAdRevenue = AdjustAdRevenue("source")
 adjustAdRevenue.setRevenue(1.00, "EUR")
 Adjust.trackAdRevenue(adjustAdRevenue)
@@ -574,7 +586,7 @@ Adjust.trackAdRevenue(adjustAdRevenue)
 
 <Tab title="Java" sync="java">
 
-```java {2}
+```java
 AdjustAdRevenue adjustAdRevenue = new AdjustAdRevenue("source");
 adjustAdRevenue.setRevenue(1.00, "EUR");
 Adjust.trackAdRevenue(adjustAdRevenue);
@@ -584,7 +596,7 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 <Tab title="Javascript" sync="js">
 
-```js {2}
+```js
 let adjustAdRevenue = new AdjustAdRevenue("source");
 adjustAdRevenue.setRevenue(1.0, "EUR");
 Adjust.trackAdRevenue(adjustAdRevenue);
@@ -599,9 +611,13 @@ The `AdjustAdRevenue` class contains properties you can use to report on your ad
 
 ### [Ad impressions](ad-impressions)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void setAdImpressionsCount(final Integer adImpressionsCount)
 ```
+
+</CodeBlock>
 
 To send the number of recorded ad impressions, call the `setAdImpressionsCount` method and pass the following arguments:
 
@@ -610,7 +626,7 @@ To send the number of recorded ad impressions, call the `setAdImpressionsCount` 
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {2}
+```kotlin
 val adjustAdRevenue = AdjustAdRevenue("source")
 adjustAdRevenue.setAdImpressionsCount(10)
 Adjust.trackAdRevenue(adjustAdRevenue)
@@ -620,7 +636,7 @@ Adjust.trackAdRevenue(adjustAdRevenue)
 
 <Tab title="Java" sync="java">
 
-```java {2}
+```java
 AdjustAdRevenue adjustAdRevenue = new AdjustAdRevenue("source");
 adjustAdRevenue.setAdImpressionsCount(10);
 Adjust.trackAdRevenue(adjustAdRevenue);
@@ -630,7 +646,7 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 <Tab title="Javascript" sync="js">
 
-```js {2}
+```js
 let adjustAdRevenue = new AdjustAdRevenue("source");
 adjustAdRevenue.setAdImpressionsCount(10);
 Adjust.trackAdRevenue(adjustAdRevenue);
@@ -641,9 +657,13 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 ### [Ad revenue network](ad-revenue-network)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void setAdRevenueNetwork(final String adRevenueNetwork)
 ```
+
+</CodeBlock>
 
 To send the ad revenue network, call the `setAdRevenueNetwork` method and pass the following arguments:
 
@@ -652,7 +672,7 @@ To send the ad revenue network, call the `setAdRevenueNetwork` method and pass t
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {2}
+```kotlin
 val adjustAdRevenue = AdjustAdRevenue("source")
 adjustAdRevenue.setAdRevenueNetwork("network1")
 Adjust.trackAdRevenue(adjustAdRevenue)
@@ -662,7 +682,7 @@ Adjust.trackAdRevenue(adjustAdRevenue)
 
 <Tab title="Java" sync="java">
 
-```java {2}
+```java
 AdjustAdRevenue adjustAdRevenue = new AdjustAdRevenue("source");
 adjustAdRevenue.setAdRevenueNetwork("network1");
 Adjust.trackAdRevenue(adjustAdRevenue);
@@ -672,7 +692,7 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 <Tab title="Javascript" sync="js">
 
-```js {2}
+```js
 let adjustAdRevenue = new AdjustAdRevenue("source");
 adjustAdRevenue.setAdRevenueNetwork("network1");
 Adjust.trackAdRevenue(adjustAdRevenue);
@@ -683,9 +703,13 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 ### [Ad revenue unit](ad-revenue-unit)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void setAdRevenueUnit(final String adRevenueUnit)
 ```
+
+</CodeBlock>
 
 To send the ad revenue unit, call the `setAdRevenueUnit` method and pass the following arguments:
 
@@ -694,7 +718,7 @@ To send the ad revenue unit, call the `setAdRevenueUnit` method and pass the fol
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {2}
+```kotlin
 val adjustAdRevenue = AdjustAdRevenue("source")
 adjustAdRevenue.setAdRevenueUnit("unit1")
 Adjust.trackAdRevenue(adjustAdRevenue)
@@ -704,7 +728,7 @@ Adjust.trackAdRevenue(adjustAdRevenue)
 
 <Tab title="Java" sync="java">
 
-```java {2}
+```java
 AdjustAdRevenue adjustAdRevenue = new AdjustAdRevenue("source");
 adjustAdRevenue.setAdRevenueUnit("unit1");
 Adjust.trackAdRevenue(adjustAdRevenue);
@@ -714,7 +738,7 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 <Tab title="Javascript" sync="js">
 
-```js {2}
+```js
 let adjustAdRevenue = new AdjustAdRevenue("source");
 adjustAdRevenue.setAdRevenueUnit("unit1");
 Adjust.trackAdRevenue(adjustAdRevenue);
@@ -725,9 +749,13 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 ### [Ad revenue placement](ad-revenue-placement)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void setAdRevenuePlacement(final String adRevenuePlacement)
 ```
+
+</CodeBlock>
 
 To send the ad revenue placement, call the `setAdRevenuePlacement` method and pass the following arguments:
 
@@ -736,7 +764,7 @@ To send the ad revenue placement, call the `setAdRevenuePlacement` method and pa
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {2}
+```kotlin
 val adjustAdRevenue = AdjustAdRevenue("source")
 adjustAdRevenue.setAdRevenuePlacement("banner")
 Adjust.trackAdRevenue(adjustAdRevenue)
@@ -746,7 +774,7 @@ Adjust.trackAdRevenue(adjustAdRevenue)
 
 <Tab title="Java" sync="java">
 
-```java {2}
+```java
 AdjustAdRevenue adjustAdRevenue = new AdjustAdRevenue("source");
 adjustAdRevenue.setAdRevenuePlacement("banner");
 Adjust.trackAdRevenue(adjustAdRevenue);
@@ -756,7 +784,7 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 <Tab title="Javascript" sync="js">
 
-```js {2}
+```js
 let adjustAdRevenue = new AdjustAdRevenue("source");
 adjustAdRevenue.setAdRevenuePlacement("banner");
 Adjust.trackAdRevenue(adjustAdRevenue);
@@ -767,9 +795,13 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 ## [Add callback parameters](add-callback-parameters)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void addCallbackParameter(final String key, final String value)
 ```
+
+</CodeBlock>
 
 If you [register a callback URL](https://help.adjust.com/en/article/recommended-placeholders-callbacks) in the Adjust dashboard, the SDK sends a GET request to your callback URL when it records an event.
 
@@ -779,9 +811,13 @@ Add callback parameters to your event by calling the `addCallbackParameter` meth
 
 The Adjust SDK measures the event and sends a request to your URL with the callback parameters. For example, if you register the URL `https://www.mydomain.com/callback`, your callback looks like this:
 
-```http "key=value" "foo=bar"
+<CodeBlock highlight="key=value, foo=bar">
+
+```http
 https://www.mydomain.com/callback?key=value&foo=bar
 ```
+
+</CodeBlock>
 
 <Callout type="note">
 
@@ -802,7 +838,7 @@ You can read more about using URL callbacks, including a full list of available 
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {2}
+```kotlin
 val adjustAdRevenue = AdjustAdRevenue("source")
 adjustAdRevenue.addCallbackParameter("key", "value")
 Adjust.trackAdRevenue(adjustAdRevenue)
@@ -812,7 +848,7 @@ Adjust.trackAdRevenue(adjustAdRevenue)
 
 <Tab title="Java" sync="java">
 
-```java {2}
+```java
 AdjustAdRevenue adjustAdRevenue = new AdjustAdRevenue("source");
 adjustAdRevenue.addCallbackParameter("key", "value");
 Adjust.trackAdRevenue(adjustAdRevenue);
@@ -822,7 +858,7 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 <Tab title="Javascript" sync="js">
 
-```js {2}
+```js
 let adjustAdRevenue = new AdjustAdRevenue("source");
 adjustAdRevenue.addCallbackParameter("key", "value");
 Adjust.trackAdRevenue(adjustAdRevenue);
@@ -833,9 +869,13 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 ## [Add partner parameters](add-partner-parameters)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void addPartnerParameter(String key, String value)
 ```
+
+</CodeBlock>
 
 You can send extra information to your network partners by adding [partner parameters](https://help.adjust.com/en/article/data-sharing-ad-network#map-parameters).
 
@@ -852,7 +892,7 @@ Add partner parameters to your event by calling the `addPartnerParameter` method
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {2}
+```kotlin
 val adjustAdRevenue = AdjustAdRevenue("source")
 adjustAdRevenue.addPartnerParameter("key", "value")
 Adjust.trackAdRevenue(adjustAdRevenue)
@@ -862,7 +902,7 @@ Adjust.trackAdRevenue(adjustAdRevenue)
 
 <Tab title="Java" sync="java">
 
-```java {2}
+```java
 AdjustAdRevenue adjustAdRevenue = new AdjustAdRevenue("source");
 adjustAdRevenue.addPartnerParameter("key", "value");
 Adjust.trackAdRevenue(adjustAdRevenue);
@@ -872,7 +912,7 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 <Tab title="Javascript" sync="js">
 
-```js {2}
+```js
 let adjustAdRevenue = new AdjustAdRevenue("source");
 adjustAdRevenue.addPartnerParameter("key", "value");
 Adjust.trackAdRevenue(adjustAdRevenue);

--- a/src/content/docs/sdk/android/features/attribution.mdx
+++ b/src/content/docs/sdk/android/features/attribution.mdx
@@ -222,9 +222,13 @@ The following values can only be accessed if the [`needsCost` property on your `
 
 ## [Trigger a function when attribution changes](trigger-a-function-when-attribution-changes)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void setOnAttributionChangedListener(OnAttributionChangedListener onAttributionChangedListener)
 ```
+
+</CodeBlock>
 
 The SDK can listen for attribution changes and call a function when it detects an update. To configure your callback function, call the `setOnAttributionChangedListener` method with your function name as an argument.
 
@@ -237,7 +241,7 @@ You must call the `setOnAttributionChangedListener` method **before** initializi
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {3-5}
+```kotlin
 val config = AdjustConfig(this, appToken, environment)
 //...
 config.setOnAttributionChangedListener {
@@ -250,7 +254,7 @@ Adjust.onCreate(config)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {3-6}
+```java
 AdjustConfig config = new AdjustConfig(this, appToken, environment);
 //...
 config.setOnAttributionChangedListener(new OnAttributionChangedListener() {
@@ -282,7 +286,7 @@ The Adjust SDK receives Facebook install referrer information as a `String` prop
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {3-14}
+```kotlin
 val config = AdjustConfig(this, appToken, environment)
 //...
 config.setOnAttributionChangedListener {
@@ -304,7 +308,7 @@ Adjust.onCreate(config)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {3-18}
+```java
 AdjustConfig config = new AdjustConfig(this, appToken, environment);
 //...
 config.setOnAttributionChangedListener(new OnAttributionChangedListener() {
@@ -332,9 +336,13 @@ Adjust.onCreate(config);
 
 ## [Get current attribution information](get-current-attribution-information)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public static AdjustAttribution getAttribution()
 ```
+
+</CodeBlock>
 
 When a user installs your app, Adjust attributes the install to a campaign. The Adjust SDK gives you access to campaign attribution details for your install. To return this information, call the `getAttribution` method to return the attribution information as an `AdjustAttribution` object.
 

--- a/src/content/docs/sdk/android/features/callbacks.mdx
+++ b/src/content/docs/sdk/android/features/callbacks.mdx
@@ -435,16 +435,20 @@ Session callbacks have access to a response data object. You can use its propert
 
 ### [Success callbacks](success-callbacks)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void setOnSessionTrackingSucceededListener(OnSessionTrackingSucceededListener onSessionTrackingSucceededListener)
 ```
+
+</CodeBlock>
 
 Set up success callbacks to trigger functions when the SDK records a session.
 
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {3-7}
+```kotlin
 val config = AdjustConfig(this, appToken, environment)
 //...
 config.setOnSessionTrackingSucceededListener(new OnSessionTrackingSucceededListener() {
@@ -459,7 +463,7 @@ Adjust.onCreate(config)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {3-8}
+```java
 AdjustConfig config = new AdjustConfig(this, appToken, environment);
 //...
 config.setOnSessionTrackingSucceededListener(new OnSessionTrackingSucceededListener() {
@@ -541,16 +545,20 @@ Adjust.onCreate(adjustConfig);
 
 ### [Failure callbacks](failure-callbacks)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void setOnSessionTrackingFailedListener(OnSessionTrackingFailedListener onSessionTrackingFailedListener)
 ```
+
+</CodeBlock>
 
 Set up failure callbacks to trigger functions when the SDK fails to record a session.
 
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {3-7}
+```kotlin
 val config = AdjustConfig(this, appToken, environment)
 //...
 config.setOnSessionTrackingFailedListener(new OnSessionTrackingFailedListener() {
@@ -565,7 +573,7 @@ Adjust.onCreate(config)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {3-8}
+```java
 AdjustConfig config = new AdjustConfig(this, appToken, environment);
 //...
 config.setOnSessionTrackingFailedListener(new OnSessionTrackingFailedListener() {
@@ -670,16 +678,20 @@ Event callbacks have access to a response data object. You can use its propertie
 
 ### [Success callbacks](success-callbacks-1)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void setOnEventTrackingSucceededListener(OnEventTrackingSucceededListener onEventTrackingSucceededListener)
 ```
+
+</CodeBlock>
 
 Set up success callbacks to trigger functions when the SDK records an event.
 
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {3-7}
+```kotlin
 val config = AdjustConfig(this, appToken, environment)
 //...
 config.setOnEventTrackingSucceededListener(new OnEventTrackingSucceededListener() {
@@ -694,7 +706,7 @@ Adjust.onCreate(config)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {3-8}
+```java
 AdjustConfig config = new AdjustConfig(this, appToken, environment);
 //...
 config.setOnEventTrackingSucceededListener(new OnEventTrackingSucceededListener() {
@@ -776,16 +788,20 @@ Adjust.onCreate(adjustConfig);
 
 ### [Failure callbacks](failure-callbacks-1)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void setOnEventTrackingFailedListener(OnEventTrackingFailedListener onEventTrackingFailedListener)
 ```
+
+</CodeBlock>
 
 Set up failure callbacks to trigger functions when the SDK fails to record an event.
 
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {3-7}
+```kotlin
 val config = AdjustConfig(this, appToken, environment)
 //...
 config.setOnEventTrackingFailedListener (OnEventTrackingFailedListener() {
@@ -800,7 +816,7 @@ Adjust.onCreate(config)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {3-8}
+```java
 AdjustConfig config = new AdjustConfig(this, appToken, environment);
 //...
 config.setOnEventTrackingFailedListener(new OnEventTrackingFailedListener() {

--- a/src/content/docs/sdk/android/features/deep-linking.mdx
+++ b/src/content/docs/sdk/android/features/deep-linking.mdx
@@ -363,7 +363,9 @@ You can launch a specific activity when a user interacts with a deep link. To do
 
 This example shows how to set up an activity called `MainActivity` to open with the **scheme name** `adjustExample`.
 
-```xml title="AndroidManifest.xml" '".MainActivity"' '"adjustExample"'
+<CodeBlock title="AndroidManifest.xml" highlight={"\".MainActivity\", \"adjustExample\""}>
+
+```xml
 <activity
    android:name=".MainActivity"
    android:configChanges="orientation|keyboardHidden"
@@ -384,11 +386,17 @@ This example shows how to set up an activity called `MainActivity` to open with 
 </activity>
 ```
 
+</CodeBlock>
+
 If a user clicks link with a `deep_link` parameter containing your **scheme name**, this activity fires.
 
-```html "deep_link=adjustExample%3A%2F%2F"
+<CodeBlock highlight="deep_link=adjustExample%3A%2F%2F">
+
+```html
 https://app.adjust.com/abc123?deep_link=adjustExample%3A%2F%2F
 ```
+
+</CodeBlock>
 
 ### [Access deep link information](access-deep-link-information)
 
@@ -469,9 +477,13 @@ The Adjust SDK opens deferred deep links by default. No additional setup is requ
 
 ### [Set up a deferred deep link callback](set-up-a-deferred-deep-link-callback)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void setOnDeeplinkResponseListener(OnDeeplinkResponseListener onDeeplinkResponseListener)
 ```
+
+</CodeBlock>
 
 You can configure the Adjust SDK to call a delegate function when it receives a deferred deep link. This delegate function receives the deep link as a `String` argument.
 
@@ -480,7 +492,7 @@ If you want to open the deep link, return `true` in your delegate function. If y
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {3-7}
+```kotlin
 val config = AdjustConfig(this, appToken, environment)
 //...
 config.setOnDeeplinkResponseListener { deeplink ->
@@ -495,7 +507,7 @@ Adjust.onCreate(config)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {3-12}
+```java
 AdjustConfig config = new AdjustConfig(this, appToken, environment);
 //...
 // Evaluate the deeplink to be launched.
@@ -515,7 +527,7 @@ Adjust.onCreate(config);
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {1-4}
+```js
 function deferredDeeplinkCallback(deeplink) {
    console.log("Deferred deep link callback called!");
    console.log(`Deep link URL: ${deeplink}`);
@@ -538,7 +550,7 @@ This example shows how to prevent the SDK from launching an activity by returnin
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin "false"
+```kotlin
 config.setOnDeeplinkResponseListener { deeplink ->
    false
 }
@@ -547,7 +559,7 @@ config.setOnDeeplinkResponseListener { deeplink ->
 </Tab>
 <Tab title="Java" sync="java">
 
-```java "false"
+```java
 config.setOnDeeplinkResponseListener(new OnDeeplinkResponseListener() {
    @Override
    public boolean launchReceivedDeeplink(Uri deeplink) {
@@ -569,9 +581,13 @@ public static void processDeeplink(Uri url, Context context)
 
 </CodeBlock>
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public static void appWillOpenUrl(Uri url, Context context)
 ```
+
+</CodeBlock>
 
 Adjust enables you to run re-engagement campaigns with usage of deep links. For more information, check out how to set up [Deep links in Campaign Lab](https://help.adjust.com/en/article/deep-links).
 
@@ -618,11 +634,16 @@ Adjust.appWillOpenUrl(deeplinkUrl);
 
 ## [Link resolution](link-resolution)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public static void resolveLink(final String url,
                                final String[] resolveUrlSuffixArray,
                                final AdjustLinkResolutionCallback adjustLinkResolutionCallback)
+
 ```
+
+</CodeBlock>
 
 Some Email Service Providers (ESPs) use their own custom domains for marketing campaigns. If you need to measure clicks through a custom domain, you need to set the SDK up to resolve the link. To do this, call the `resolveLink` method of the `AdjustLinkResolution` class. The Adjust SDK will then follow the custom link and resolve it when opening the deep link. This ensures that you record the interaction with your email measurement campaign.
 

--- a/src/content/docs/sdk/android/features/device-info.mdx
+++ b/src/content/docs/sdk/android/features/device-info.mdx
@@ -48,9 +48,13 @@ Adjust.getAdid(new OnAdidReadListener() {
 
 ## [Google Play Services Advertising ID](google-play-services-advertising-id)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public static void getGoogleAdId(Context context, OnDeviceIdsRead onDeviceIdRead)
 ```
+
+</CodeBlock>
 
 The Google Play Services Advertising ID (GPS ADID) is a device-specific identifier for Android devices.
 
@@ -82,9 +86,13 @@ Adjust.getGoogleAdId(this, new OnDeviceIdsRead() {
 
 ## [Amazon Advertiser ID](amazon-advertiser-id)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public static void getAmazonAdId(final Context context,final OnAmazonAdIdReadListener onAmazonAdIdReadListener)
 ```
+
+</CodeBlock>
 
 The Amazon Advertising ID (Amazon Ad ID) is a device-specific identifier for Android devices. You can request this information asynchronously from the Adjust SDK by passing a callback method to the `Adjust.getAmazonAdId` method.
 
@@ -153,9 +161,13 @@ The Adjust SDK contains helper methods that return device information. Use these
 
 ## [Adjust device identifier](adjust-device-identifier)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public static String getAdid()
 ```
+
+</CodeBlock>
 
 Adjust generates a unique Adjust Device ID (ADID) for each device. Call the `getAdid` method to return this ID as a `String`.
 
@@ -187,9 +199,13 @@ let adid = Adjust.getAdid();
 
 ## [Google Play Services Advertising ID](google-play-services-advertising-id)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public static void getGoogleAdId(Context context, OnDeviceIdsRead onDeviceIdRead)
 ```
+
+</CodeBlock>
 
 The Google Play Services Advertising ID (GPS ADID) is a device-specific identifier for Android devices.
 
@@ -232,9 +248,13 @@ Adjust.getGoogleAdId(function (googleAdId) {
 
 ## [Amazon Advertiser ID](amazon-advertiser-id)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public static String getAmazonAdId(final Context context)
 ```
+
+</CodeBlock>
 
 The Amazon Advertising ID (Amazon Ad ID) is a device-specific identifier for Android devices. Call the `getAmazonAdId` method to return this ID as a `String`.
 

--- a/src/content/docs/sdk/android/features/events.mdx
+++ b/src/content/docs/sdk/android/features/events.mdx
@@ -391,9 +391,13 @@ Parameters:
 
 ## [Add callback parameters](add-callback-parameters)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void addCallbackParameter(String key, String value)
 ```
+
+</CodeBlock>
 
 If you [register a callback URL](https://help.adjust.com/en/article/set-up-callbacks) in the Adjust dashboard, the SDK sends a GET request to your callback URL when it records an event.
 
@@ -438,7 +442,7 @@ The Adjust SDK measures the event and sends a request to your URL with the callb
 
 <CodeBlock highlight="key=value, foo=bar">
 
-```http "key=value" "foo=bar"
+```http
 https://www.mydomain.com/callback?key=value&foo=bar
 ```
 
@@ -700,7 +704,7 @@ public void onTrackUniqueEventClick(View v) {
 
 <CodeBlock title="Event log" highlight="{range: 7}">
 
-```txt title="Event log" {7}
+```txt
 Path:      /event
 ClientSdk: android$ANDROID_V4_VERSION
 Parameters:
@@ -720,9 +724,13 @@ The Adjust SDK provides an `AdjustEvent` object which can be used to structure a
 
 ## [Instantiate an AdjustEvent object](instantiate-an-adjustevent-object)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public AdjustEvent(String eventToken)
 ```
+
+</CodeBlock>
 
 To send event information with the Adjust SDK, you need to instantiate an `AdjustEvent` object. This object contains variables that are sent to Adjust when an event occurs in your app.
 
@@ -733,7 +741,7 @@ To instantiate an event object, create a new `AdjustEvent` instance and pass the
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {1}
+```kotlin
 val adjustEvent = AdjustEvent("abc123")
 Adjust.trackEvent(adjustEvent)
 ```
@@ -741,7 +749,7 @@ Adjust.trackEvent(adjustEvent)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {1}
+```java
 AdjustEvent adjustEvent = new AdjustEvent("abc123");
 Adjust.trackEvent(adjustEvent);
 ```
@@ -749,7 +757,7 @@ Adjust.trackEvent(adjustEvent);
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {1}
+```js
 let adjustEvent = new AdjustEvent("abc123");
 Adjust.trackEvent(adjustEvent);
 ```
@@ -759,9 +767,13 @@ Adjust.trackEvent(adjustEvent);
 
 ## [Send an event](send-an-event)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public static void trackEvent(AdjustEvent event)
 ```
+
+</CodeBlock>
 
 You can associate your [Adjust event tokens](https://help.adjust.com/en/article/add-events#add-event) to actions in your app to record them. To record an event:
 
@@ -771,7 +783,7 @@ You can associate your [Adjust event tokens](https://help.adjust.com/en/article/
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {2}
+```kotlin
 val adjustEvent = AdjustEvent("abc123")
 Adjust.trackEvent(adjustEvent)
 ```
@@ -779,7 +791,7 @@ Adjust.trackEvent(adjustEvent)
 </Tab>
 <Tab title="Java" sync="java" >
 
-```java {2}
+```java
 AdjustEvent adjustEvent = new AdjustEvent("abc123");
 Adjust.trackEvent(adjustEvent);
 ```
@@ -787,7 +799,7 @@ Adjust.trackEvent(adjustEvent);
 </Tab>
 <Tab title="Javascript" sync="js" >
 
-```js {2}
+```js
 let adjustEvent = new AdjustEvent("abc123");
 Adjust.trackEvent(adjustEvent);
 ```
@@ -836,7 +848,9 @@ window.onload = function () {
 </Tab>
 </Tabs>
 
-```txt collapse={6-46} title="Event log"
+<CodeBlock title="Event log" collapse="6-46">
+
+```txt
 Path:      /event
 ClientSdk: android$ANDROID_V4_VERSION
 Parameters:
@@ -883,13 +897,20 @@ Parameters:
   time_spent       23
   tracking_enabled 1
   ui_mode          1
+
 ```
+
+</CodeBlock>
 
 ## [Record event revenue](record-event-revenue)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void setRevenue(double revenue, String currency)
 ```
+
+</CodeBlock>
 
 You can record revenue associated with an event by setting the revenue and currency properties on your event instance. Use this feature to record revenue-generating actions in your app.
 
@@ -907,7 +928,7 @@ Check the guide to [recording purchases in different currencies](https://help.ad
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {2}
+```kotlin
 val adjustEvent = AdjustEvent("abc123")
 adjustEvent.setRevenue(0.01, "EUR")
 Adjust.trackEvent(adjustEvent)
@@ -916,7 +937,7 @@ Adjust.trackEvent(adjustEvent)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {2}
+```java
 AdjustEvent adjustEvent = new AdjustEvent("abc123");
 adjustEvent.setRevenue(0.01, "EUR");
 Adjust.trackEvent(adjustEvent);
@@ -925,7 +946,7 @@ Adjust.trackEvent(adjustEvent);
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {2}
+```js
 let adjustEvent = new AdjustEvent("abc123");
 adjustEvent.setRevenue(0.01, "EUR");
 Adjust.trackEvent(adjustEvent);
@@ -978,7 +999,9 @@ window.onload = function () {
 </Tab>
 </Tabs>
 
-```txt title="Event log" {7,8}
+<CodeBlock title="Event log" highlight="{range: 7-8}">
+
+```txt
 Path:      /event
 ClientSdk: android$ANDROID_V4_VERSION
 Parameters:
@@ -988,6 +1011,8 @@ Parameters:
   revenue          0.25
   currency         EUR
 ```
+
+</CodeBlock>
 
 ### [Purchase verification](purchase-verification)
 
@@ -1033,9 +1058,13 @@ Adjust.trackEvent(adjustEvent);
 
 ## [Deduplicate revenue events](deduplicate-revenue-events)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void setOrderId(String orderId)
 ```
+
+</CodeBlock>
 
 You can pass an optional identifier to avoid recording duplicate events. The SDK stores the last ten identifiers and skips revenue events with duplicate transaction IDs.
 
@@ -1044,7 +1073,7 @@ To set the identifier, call the `setOrderId` method and pass your transaction ID
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {3}
+```kotlin
 val adjustEvent = AdjustEvent("abc123")
 adjustEvent.setRevenue(0.01, "EUR")
 adjustEvent.setOrderId("{OrderId}")
@@ -1054,7 +1083,7 @@ Adjust.trackEvent(adjustEvent)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {3}
+```java
 AdjustEvent adjustEvent = new AdjustEvent("abc123");
 adjustEvent.setRevenue(0.01, "EUR");
 adjustEvent.setOrderId("{OrderId}");
@@ -1064,7 +1093,7 @@ Adjust.trackEvent(adjustEvent);
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {3}
+```js
 let adjustEvent = new AdjustEvent("abc123");
 adjustEvent.setRevenue(0.01, "EUR");
 adjustEvent.setOrderId("{OrderId}");
@@ -1118,7 +1147,9 @@ window.onload = function () {
 </Tab>
 </Tabs>
 
-```txt title="Event log" {7}
+<CodeBlock title="Event log" highlight="{range: 7}">
+
+```txt
 Path:      /event
 ClientSdk: android$ANDROID_V4_VERSION
 Parameters:
@@ -1128,11 +1159,17 @@ Parameters:
   order_id         5e85484b-1ebc-4141-aab7-25b869e54c49
 ```
 
+</CodeBlock>
+
 ## [Add callback parameters](add-callback-parameters)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void addCallbackParameter(String key, String value)
 ```
+
+</CodeBlock>
 
 If you [register a callback URL](https://help.adjust.com/en/article/set-up-callbacks) in the Adjust dashboard, the SDK sends a GET request to your callback URL when it records an event.
 
@@ -1143,7 +1180,7 @@ Add callback parameters to your event by calling the `addCallbackParameter` meth
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {2-3}
+```kotlin
 val adjustEvent = AdjustEvent("abc123")
 adjustEvent.addCallbackParameter("key", "value")
 adjustEvent.addCallbackParameter("foo", "bar")
@@ -1153,7 +1190,7 @@ Adjust.trackEvent(adjustEvent)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {2-3}
+```java
 AdjustEvent adjustEvent = new AdjustEvent("abc123");
 adjustEvent.addCallbackParameter("key", "value");
 adjustEvent.addCallbackParameter("foo", "bar");
@@ -1163,7 +1200,7 @@ Adjust.trackEvent(adjustEvent);
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {2-3}
+```js
 let adjustEvent = new AdjustEvent("abc123");
 adjustEvent.addCallbackParameter("key", "value");
 adjustEvent.addCallbackParameter("foo", "bar");
@@ -1175,9 +1212,13 @@ Adjust.trackEvent(adjustEvent);
 
 The Adjust SDK measures the event and sends a request to your URL with the callback parameters. For example, if you register the URL `https://www.mydomain.com/callback`, your callback looks like this:
 
-```http "key=value" "foo=bar"
+<CodeBlock highlight="key=value, foo=bar">
+
+```http
 https://www.mydomain.com/callback?key=value&foo=bar
 ```
+
+</CodeBlock>
 
 <Callout type="note">
 
@@ -1204,9 +1245,13 @@ This example shows how to record an event with the token `g3mfiw` whenever a use
 
 The resulting callback URL looks like this:
 
-```http "event_token=g3mfiw" "revenue_amount=0.05"
+<CodeBlock highlight="event_token=g3mfiw, revenue_amount=0.05">
+
+```http
 http://www.mydomain.com/callback?event_token=g3mfiw&revenue_amount=0.05
 ```
+
+</CodeBlock>
 
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
@@ -1253,7 +1298,9 @@ window.onload = function () {
 
 You can check the parameters were sent to Adjust by checking for `callback_params` in your logs.
 
-```txt {4} title="Event log"
+<CodeBlock title="Event log">
+
+```txt
 Path:      /event
 ClientSdk: android$ANDROID_V4_VERSION
 Parameters:
@@ -1261,13 +1308,20 @@ Parameters:
   environment      sandbox
   event_count      1
   event_token      g3mfiw
+
 ```
+
+</CodeBlock>
 
 ## [Add partner parameters](add-partner-parameters)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void addPartnerParameter(String key, String value)
 ```
+
+</CodeBlock>
 
 You can send extra information to your network partners by adding [partner parameters](https://help.adjust.com/en/article/data-sharing-ad-network#map-parameters).
 
@@ -1284,7 +1338,7 @@ Add partner parameters to your event by calling the `addPartnerParameter` method
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {2-3}
+```kotlin
 val adjustEvent = AdjustEvent("abc123")
 adjustEvent.addPartnerParameter("key", "value")
 adjustEvent.addPartnerParameter("foo", "bar")
@@ -1294,7 +1348,7 @@ Adjust.trackEvent(adjustEvent)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {2-3}
+```java
 AdjustEvent adjustEvent = new AdjustEvent("abc123");
 adjustEvent.addPartnerParameter("key", "value");
 adjustEvent.addPartnerParameter("foo", "bar");
@@ -1304,7 +1358,7 @@ Adjust.trackEvent(adjustEvent);
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {2-3}
+```js
 let adjustEvent = new AdjustEvent("abc123");
 adjustEvent.addPartnerParameter("key", "value");
 adjustEvent.addPartnerParameter("foo", "bar");
@@ -1366,7 +1420,9 @@ window.onload = function () {
 
 You can check the parameters were sent to Adjust by checking for `partner_params` in your logs.
 
-```txt title="Event log" {4}
+<CodeBlock title="Event log" highlight="{range: 4}">
+
+```txt
 Path:      /event
 ClientSdk: android$ANDROID_V4_VERSION
 Parameters:
@@ -1376,11 +1432,17 @@ Parameters:
   event_token      g3mfiw
 ```
 
+</CodeBlock>
+
 ## [Add a callback identifier](add-a-callback-identifier)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void setCallbackId(String callbackId)
 ```
+
+</CodeBlock>
 
 You can add a custom string identifier to each event you want to measure. Adjust's servers can report on this identifier in event callbacks. This enables you to keep track of which events have been successfully measured.
 
@@ -1389,7 +1451,7 @@ Set up this identifier by calling the `setCallbackId` method with your ID as a `
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {2}
+```kotlin
 val adjustEvent = AdjustEvent("abc123")
 adjustEvent.setCallbackId("{Your-Custom-Id}")
 Adjust.trackEvent(adjustEvent)
@@ -1398,7 +1460,7 @@ Adjust.trackEvent(adjustEvent)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {2}
+```java
 AdjustEvent adjustEvent = new AdjustEvent("abc123");
 adjustEvent.setCallbackId("{Your-Custom-Id}");
 Adjust.trackEvent(adjustEvent);
@@ -1407,7 +1469,7 @@ Adjust.trackEvent(adjustEvent);
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {2}
+```js
 let adjustEvent = new AdjustEvent("abc123");
 adjustEvent.setCallbackId("{Your-Custom-Id}");
 Adjust.trackEvent(adjustEvent);
@@ -1460,7 +1522,9 @@ window.onload = function () {
 </Tab>
 </Tabs>
 
-```txt title="Event log" {7}
+<CodeBlock title="Event log" highlight="{range: 7}">
+
+```txt
 Path:      /event
 ClientSdk: android$ANDROID_V4_VERSION
 Parameters:
@@ -1469,5 +1533,7 @@ Parameters:
   event_token      g3mfiw
   callback_id      f2e728d8-271b-49ab-80ea-27830a215147
 ```
+
+</CodeBlock>
 
 </SdkVersion>

--- a/src/content/docs/sdk/android/features/privacy.mdx
+++ b/src/content/docs/sdk/android/features/privacy.mdx
@@ -93,7 +93,7 @@ Once you've instantiated your `AdjustThirdPartySharing` object, you can send the
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {2}
+```kotlin
 val adjustThirdPartySharing = AdjustThirdPartySharing(true)
 Adjust.trackThirdPartySharing(adjustThirdPartySharing)
 ```
@@ -428,7 +428,7 @@ See the table below for a list of mappings.
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {4}
+```kotlin
 val domains: List<String> = mutableListOf("domain") // eg. eu.adjust.com
 val useSubdomains = true // or false
 val isDataResidency = false // or true for data residency
@@ -438,7 +438,7 @@ adjustConfig.setUrlStrategy(domains, useSubdomains, isDataResidency)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {4}
+```java
 List<String> domains = Arrays.asList("domain"); // eg. eu.adjust.com
 boolean useSubdomains = true; // or false
 boolean isDataResidency = false; // or true for data residency
@@ -762,9 +762,13 @@ The Adjust SDK contains features that you can use to handle user privacy in your
 
 ## [Send erasure request](send-erasure-request)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public static void gdprForgetMe(final Context context)
 ```
+
+</CodeBlock>
 
 The EU’s General Data Protection Regulation (GDPR) and similar privacy laws worldwide (CCPA, LGPD, etc.) grant data subjects comprehensive rights when it comes to the processing of their personal data. These rights include, among others, the right to erasure (see [Art. 17 GDPR](https://gdpr.eu/article-17-right-to-be-forgotten/))([1](https://help.adjust.com/en/article/gdpr#ref-1)). As a data processor, Adjust is obliged to support you (the data controller) in the processing of such requests from your (app) users.
 
@@ -796,9 +800,13 @@ You can use the Adjust SDK to record when a user changes their third-party shari
 
 ### [Instantiate an AdjustThirdPartySharing object](instantiate-an-adjustthirdpartysharing-object)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public AdjustThirdPartySharing(final Boolean isEnabled)
 ```
+
+</CodeBlock>
 
 To enable or disable third party sharing with the Adjust SDK, you need to instantiate an `AdjustThirdPartySharing` object. This object contains variables that control how third party sharing is handled by Adjust.
 
@@ -809,7 +817,7 @@ To instantiate a third party sharing object, create a new `AdjustThirdPartyShari
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {1}
+```kotlin
 val adjustThirdPartySharing = AdjustThirdPartySharing(true)
 Adjust.trackThirdPartySharing(adjustThirdPartySharing)
 ```
@@ -818,7 +826,7 @@ Adjust.trackThirdPartySharing(adjustThirdPartySharing)
 
 <Tab title="Java" sync="java" >
 
-```java {1}
+```java
 AdjustThirdPartySharing adjustThirdPartySharing = new AdjustThirdPartySharing(true);
 Adjust.trackThirdPartySharing(adjustThirdPartySharing);
 ```
@@ -827,7 +835,7 @@ Adjust.trackThirdPartySharing(adjustThirdPartySharing);
 
 <Tab title="Javascript" sync="js" >
 
-```js {1}
+```js
 let adjustThirdPartySharing = new AdjustThirdPartySharing(true);
 Adjust.trackThirdPartySharing(adjustThirdPartySharing);
 ```
@@ -846,7 +854,7 @@ Once you've instantiated your `AdjustThirdPartySharing` object, you can send the
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {2}
+```kotlin
 val adjustThirdPartySharing = AdjustThirdPartySharing(true)
 Adjust.trackThirdPartySharing(adjustThirdPartySharing)
 ```
@@ -855,7 +863,7 @@ Adjust.trackThirdPartySharing(adjustThirdPartySharing)
 
 <Tab title="Java" sync="java" >
 
-```java {2}
+```java
 AdjustThirdPartySharing adjustThirdPartySharing = new AdjustThirdPartySharing(true);
 Adjust.trackThirdPartySharing(adjustThirdPartySharing);
 ```
@@ -864,7 +872,7 @@ Adjust.trackThirdPartySharing(adjustThirdPartySharing);
 
 <Tab title="Javascript" sync="js" >
 
-```js {2}
+```js
 let adjustThirdPartySharing = new AdjustThirdPartySharing(true);
 Adjust.trackThirdPartySharing(adjustThirdPartySharing);
 ```
@@ -874,11 +882,16 @@ Adjust.trackThirdPartySharing(adjustThirdPartySharing);
 
 ### [Send granular information](send-granular-information)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void addGranularOption(final String partnerName,
                               final String key,
                               final String value)
+
 ```
+
+</CodeBlock>
 
 You can attach granular information when a user updates their third-party sharing preferences. Use this information to communicate more detail about a user's decision. To do this, call the `addGranularOption` method with the following parameters:
 
@@ -908,7 +921,7 @@ The following partners are available:
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {2}
+```kotlin
 val adjustThirdPartySharing = AdjustThirdPartySharing(true)
 adjustThirdPartySharing.addGranularOption("PartnerA", "foo", "bar")
 Adjust.trackThirdPartySharing(adjustThirdPartySharing)
@@ -918,7 +931,7 @@ Adjust.trackThirdPartySharing(adjustThirdPartySharing)
 
 <Tab title="Java" sync="java" >
 
-```java {2}
+```java
 AdjustThirdPartySharing adjustThirdPartySharing = new AdjustThirdPartySharing(true);
 adjustThirdPartySharing.addGranularOption("PartnerA", "foo", "bar");
 Adjust.trackThirdPartySharing(adjustThirdPartySharing);
@@ -928,7 +941,7 @@ Adjust.trackThirdPartySharing(adjustThirdPartySharing);
 
 <Tab title="Javascript" sync="js" >
 
-```js {2}
+```js
 let adjustThirdPartySharing = new AdjustThirdPartySharing(true);
 adjustThirdPartySharing.addGranularOption("PartnerA", "foo", "bar");
 Adjust.trackThirdPartySharing(adjustThirdPartySharing);
@@ -968,7 +981,7 @@ If you call this method with a `0` value for **either** `data_processing_options
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {2-3}
+```kotlin
 val adjustThirdPartySharing = AdjustThirdPartySharing(true)
 adjustThirdPartySharing.addGranularOption("facebook", "data_processing_options_country", "1")
 adjustThirdPartySharing.addGranularOption("facebook", "data_processing_options_state", "1000")
@@ -979,7 +992,7 @@ Adjust.trackThirdPartySharing(adjustThirdPartySharing)
 
 <Tab title="Java" sync="java" >
 
-```java {2-3}
+```java
 AdjustThirdPartySharing adjustThirdPartySharing = new AdjustThirdPartySharing(true);
 adjustThirdPartySharing.addGranularOption("facebook", "data_processing_options_country", "1");
 adjustThirdPartySharing.addGranularOption("facebook", "data_processing_options_state", "1000");
@@ -990,7 +1003,7 @@ Adjust.trackThirdPartySharing(adjustThirdPartySharing);
 
 <Tab title="Javascript" sync="js" >
 
-```js {2-3}
+```js
 let adjustThirdPartySharing = new AdjustThirdPartySharing(true);
 adjustThirdPartySharing.addGranularOption(
    "facebook",
@@ -1216,9 +1229,13 @@ Adjust.trackThirdPartySharing(adjustThirdPartySharing);
 
 ## [Disable third-party sharing](disable-third-party-sharing)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public static void disableThirdPartySharing(final Context context)
 ```
+
+</CodeBlock>
 
 To disable third-party sharing for all users, call the `disableThirdPartySharing` method. When Adjust's servers receive this information, Adjust stops sharing the user's data with third parties. The Adjust SDK continues to work as expected.
 
@@ -1250,9 +1267,13 @@ Adjust.disableThirdPartySharing();
 
 ## [Set URL strategy](set-url-strategy)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void setUrlStrategy(String urlStrategy)
 ```
+
+</CodeBlock>
 
 The URL strategy feature allows you to set either:
 
@@ -1282,7 +1303,7 @@ To set your country of data residency, call the `setUrlStrategy` method on your 
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {4}
+```kotlin
 val appToken = "{YourAppToken}"
 val environment = AdjustConfig.ENVIRONMENT_SANDBOX
 val config = AdjustConfig(this, appToken, environment)
@@ -1294,7 +1315,7 @@ Adjust.onCreate(config)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {4}
+```java
 String appToken = "{YourAppToken}";
 String environment = AdjustConfig.ENVIRONMENT_SANDBOX;
 AdjustConfig config = new AdjustConfig(this, appToken, environment);
@@ -1306,7 +1327,7 @@ Adjust.onCreate(config);
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {4}
+```js
 var yourAppToken = yourAppToken;
 var environment = AdjustConfig.EnvironmentSandbox;
 var adjustConfig = new AdjustConfig(yourAppToken, environment);
@@ -1318,9 +1339,13 @@ adjustConfig.setUrlStrategy(AdjustConfig.DATA_RESIDENCY_EU);
 
 ## [Consent measurement for specific users](consent-measurement-for-specific-users)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public static void trackMeasurementConsent(final boolean consentMeasurement)
 ```
+
+</CodeBlock>
 
 If you're using [Data Privacy settings](https://help.adjust.com/en/article/manage-data-collection-and-retention) in your Adjust dashboard, you need to set up the Adjust SDK to work with them. This includes settings such as consent expiry period and user data retention period.
 
@@ -1358,9 +1383,13 @@ Adjust.trackMeasurementConsent(true);
 
 ## [COPPA compliance](coppa-compliance)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void setCoppaCompliantEnabled(boolean coppaCompliantEnabled)
 ```
+
+</CodeBlock>
 
 If you need your app to be compliant with the Children's Online Privacy Protection Act (COPPA), call the `setCoppaCompliantEnabled` method. This method performs the following actions:
 
@@ -1370,7 +1399,7 @@ If you need your app to be compliant with the Children's Online Privacy Protecti
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {4}
+```kotlin
 val appToken = "{YourAppToken}"
 val environment = AdjustConfig.ENVIRONMENT_SANDBOX
 val config = AdjustConfig(this, appToken, environment)
@@ -1382,7 +1411,7 @@ Adjust.onCreate(config)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {4}
+```java
 String appToken = "{YourAppToken}";
 String environment = AdjustConfig.ENVIRONMENT_SANDBOX;
 AdjustConfig config = new AdjustConfig(this, appToken, environment);
@@ -1394,7 +1423,7 @@ Adjust.onCreate(config);
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {4}
+```js
 var yourAppToken = yourAppToken;
 var environment = AdjustConfig.EnvironmentSandbox;
 var adjustConfig = new AdjustConfig(yourAppToken, environment);
@@ -1414,9 +1443,13 @@ Disabling the `setCoppaCompliantEnabled` method **doesn't** re-enable third-part
 
 ## [Play Store Kids Apps](play-store-kids-apps)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void setPlayStoreKidsAppEnabled(boolean playStoreKidsAppEnabled)
 ```
+
+</CodeBlock>
 
 If your app targets users under the age of 13, and the install region **isn't** the USA, you need to mark it as a Kids App. This prevents the SDK from reading device and advertising IDs (for example: `gps_adid` and `android_id`).
 
@@ -1427,7 +1460,7 @@ To mark your app as a Kids App, call the `setPlayStoreKidsAppEnabled` method wit
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {4}
+```kotlin
 val appToken = "{YourAppToken}"
 val environment = AdjustConfig.ENVIRONMENT_SANDBOX
 val config = AdjustConfig(this, appToken, environment)
@@ -1439,7 +1472,7 @@ Adjust.onCreate(config)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {4}
+```java
 String appToken = "{YourAppToken}";
 String environment = AdjustConfig.ENVIRONMENT_SANDBOX;
 AdjustConfig config = new AdjustConfig(this, appToken, environment);
@@ -1451,7 +1484,7 @@ Adjust.onCreate(config);
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {4}
+```js
 var yourAppToken = yourAppToken;
 var environment = AdjustConfig.EnvironmentSandbox;
 var adjustConfig = new AdjustConfig(yourAppToken, environment);

--- a/src/content/docs/sdk/android/features/session-parameters.mdx
+++ b/src/content/docs/sdk/android/features/session-parameters.mdx
@@ -261,9 +261,13 @@ You can configure callback parameters to your servers. Once you configure parame
 
 ### [Add session callback parameters](add-session-callback-parameters)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public static void addSessionCallbackParameter(String key, String value)
 ```
+
+</CodeBlock>
 
 Add callback parameters to your event by calling the `addSessionCallbackParameter` method with `String` key-value arguments. You can add multiple parameters by calling this method multiple times.
 
@@ -295,16 +299,20 @@ Adjust.addSessionCallbackParameter("foo", "bar");
 
 ### [Remove session callback parameters](remove-session-callback-parameters)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public static void removeSessionCallbackParameter(String key)
 ```
+
+</CodeBlock>
 
 You can remove specific session callback parameters if they're no longer required. To do this, pass the parameter `key` to the `removeSessionCallbackParameter` method.
 
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin '"foo"'
+```kotlin
 Adjust.removeSessionCallbackParameter("foo")
 ```
 
@@ -312,7 +320,7 @@ Adjust.removeSessionCallbackParameter("foo")
 
 <Tab title="Java" sync="java" >
 
-```java '"foo"'
+```java
 Adjust.removeSessionCallbackParameter("foo");
 ```
 
@@ -320,7 +328,7 @@ Adjust.removeSessionCallbackParameter("foo");
 
 <Tab title="Javascript" sync="js" >
 
-```js '"foo"'
+```js
 Adjust.removeSessionCallbackParameter("foo");
 ```
 
@@ -329,9 +337,13 @@ Adjust.removeSessionCallbackParameter("foo");
 
 ### [Reset session callback parameters](reset-session-callback-parameters)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public static void resetSessionCallbackParameters()
 ```
+
+</CodeBlock>
 
 You can remove all session parameters if they're no longer required. To do this, call the `resetSessionCallbackParameters` method.
 
@@ -375,9 +387,13 @@ Partner parameters don't appear in raw data by default. You can add the `{partne
 
 ### [Add session partner parameters](add-session-partner-parameters)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public static void addSessionPartnerParameter(String key, String value)
 ```
+
+</CodeBlock>
 
 Send partner parameters with your session by calling the `addSessionPartnerParameter` method with **string** key-value arguments. You can add multiple parameters by calling this method multiple times.
 
@@ -409,9 +425,13 @@ Adjust.addSessionPartnerParameter("foo", "bar");
 
 ### [Remove session partner parameters](remove-session-partner-parameters)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public static void removeSessionPartnerParameter(String key)
 ```
+
+</CodeBlock>
 
 You can remove specific session partner parameters if they're no longer required. To do this, pass the parameter key to the `removeSessionPartnerParameter` method.
 
@@ -443,9 +463,13 @@ Adjust.removeSessionPartnerParameter("foo");
 
 ### [Reset session partner parameters](reset-session-partner-parameters)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public static void resetSessionPartnerParameters()
 ```
+
+</CodeBlock>
 
 You can remove all session partner parameters if they're no longer required. To do this, call the `resetSessionPartnerParameters` method.
 
@@ -488,7 +512,7 @@ The Adjust SDK starts as soon as your app opens. If you want to send data that's
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {2}
+```kotlin
 val config = AdjustConfig(this, appToken, environment)
 config.setDelayStart(5.5)
 Adjust.onCreate(config)
@@ -497,7 +521,7 @@ Adjust.onCreate(config)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {2}
+```java
 AdjustConfig config = new AdjustConfig(this, appToken, environment);
 config.setDelayStart(5.5);
 Adjust.onCreate(config);
@@ -506,7 +530,7 @@ Adjust.onCreate(config);
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {2}
+```js
 var adjustConfig = new AdjustConfig(yourAppToken, environment);
 adjustConfig.setDelayStart(5.5);
 Adjust.onCreate(adjustConfig);

--- a/src/content/docs/sdk/android/features/subscriptions.mdx
+++ b/src/content/docs/sdk/android/features/subscriptions.mdx
@@ -14,14 +14,19 @@ You can record Play Store subscriptions and verify their validity with the Adjus
 
 ## [1. Instantiate a subscription object](1-instantiate-a-subscription-object)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public AdjustPlayStoreSubscription(final long price,
                                        final String currency,
                                        final String sku,
                                        final String orderId,
                                        final String signature,
                                        final String purchaseToken)
+
 ```
+
+</CodeBlock>
 
 To get started, you need to instantiate a subscription object containing details of the subscription purchase. To do this, create a new `AdjustPlayStoreSubscription` object and pass the following arguments:
 
@@ -74,16 +79,20 @@ Adjust.trackPlayStoreSubscription(subscription);
 
 ### [Record the purchase date](record-the-purchase-date)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void setPurchaseTime(final long purchaseTime)
 ```
+
+</CodeBlock>
 
 You can record the date on which the user purchased a subscription. The SDK returns this data for you to report on. Call the `setPurchaseTime` method with a timestamp to record this information.
 
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {8}
+```kotlin
 val subscription = AdjustPlayStoreSubscription(
     price,
     currency,
@@ -100,7 +109,7 @@ Adjust.trackPlayStoreSubscription(subscription)
 
 <Tab title="Java" sync="java" >
 
-```java {8}
+```java
 AdjustPlayStoreSubscription subscription = new AdjustPlayStoreSubscription(
     price,
     currency,
@@ -118,9 +127,13 @@ Adjust.trackPlayStoreSubscription(subscription);
 
 ### [Add callback parameters](add-callback-parameters)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void addCallbackParameter(String key, String value)
 ```
+
+</CodeBlock>
 
 You can add callback parameters to your subscription object. The SDK appends these parameters to your callback URL. To add callback parameters, call the `addCallbackParameter` method on your subscription object. You can add multiple callback parameters by calling this method multiple times.
 
@@ -146,9 +159,13 @@ subscription.addCallbackParameter("foo", "bar");
 
 ### [Add partner parameters](add-partner-parameters)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void addPartnerParameter(String key, String value)
 ```
+
+</CodeBlock>
 
 You can add partner parameters to your subscription object. The SDK sends these to Adjust's servers when the user purchases a subscription. Adjust's servers forward the information on to your network partner. To add partner parameters, call the `addPartnerParameter` method on your subscription object. You can add multiple partner parameters by calling this method multiple times.
 
@@ -174,16 +191,20 @@ subscription.addPartnerParameter("foo", "bar");
 
 ## [2. Send subscription information](2-send-subscription-information)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public static void trackPlayStoreSubscription(final AdjustPlayStoreSubscription subscription)
 ```
+
+</CodeBlock>
 
 Once you have set up your subscription object, you can send it to Adjust using the Adjust SDK. Pass your completed object to the `trackPlayStoreSubscription` method to record the user's subscription purchase.
 
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {10}
+```kotlin
 val subscription = AdjustPlayStoreSubscription(
    price,
    currency,
@@ -200,7 +221,7 @@ Adjust.trackPlayStoreSubscription(subscription)
 
 <Tab title="Java" sync="java" >
 
-```java {10}
+```java
 AdjustPlayStoreSubscription subscription = new AdjustPlayStoreSubscription(
    price,
    currency,

--- a/src/content/docs/sdk/android/index.mdx
+++ b/src/content/docs/sdk/android/index.mdx
@@ -426,14 +426,19 @@ The minimum supported Android API level for the web view extension is 17 (Jelly 
 
 If you're using [Maven](https://maven.apache.org/), add the following to your `build.gradle` file:
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 dependencies {
    implementation 'com.adjust.sdk:adjust-android:v$ANDROID_V4_VERSION'
    implementation 'com.android.installreferrer:installreferrer:2.2'
    // Add the following if you're using the Adjust SDK inside web views on your app
    implementation 'com.adjust.sdk:adjust-android-webbridge:v$ANDROID_V4_VERSION'
 }
+
 ```
+
+</CodeBlock>
 
 ## [2. Add Google Play Services](2-add-google-play-services)
 
@@ -441,21 +446,31 @@ Apps that target the Google Play Store must use the gps_adid (Google Advertising
 
 If you're using Maven, add the following to your `build.gradle` file:
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 dependencies {
    implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
 }
+
 ```
+
+</CodeBlock>
 
 ### [Collect App Set Identifier](collect-app-set-identifier)
 
 The [App Set Identifier](https://developer.android.com/design-for-safety/privacy-sandbox/reference/adservices/appsetid/AppSetId) is a unique identifier that enables you to measure information from any of your apps that a user has installed on their device. All apps by the same developer share the same App Set ID, meaning you can gather meaningful insights from users across all your apps. To record a device's App Set ID, you need to add the following permission to your `build.gradle` file:
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 dependencies {
    implementation 'com.google.android.gms:play-services-appset:16.0.2'
 }
+
 ```
+
+</CodeBlock>
 
 If this permission is enabled, the App Set ID is sent to Adjust's servers as part of the device information payload.
 
@@ -465,28 +480,42 @@ To give the Adjust SDK access to device information, you need to declare which p
 
 Add the following permissions to get access to online features:
 
-```xml title="AndroidManifest.xml"
+<CodeBlock title="AndroidManifest.xml">
+
+```xml
 <uses-permission android:name="android.permission.INTERNET"/>
 <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 ```
 
+</CodeBlock>
+
 If your app doesn't target the Google Play Store, add the following permission to access the device's network state:
 
-```xml title="AndroidManifest.xml"
+<CodeBlock title="AndroidManifest.xml">
+
+```xml
 <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 ```
 
+</CodeBlock>
+
 The Adjust SDK includes the `com.google.android.gms.AD_ID` permission by default. If you need to make your app COPPA (Children's Online Privacy Protection Act) compliant or if your app doesn't target the Google Play Store, you must remove this permission using a `remove` directive.
 
-```xml title="AndroidManifest.xml" "tools:node="remove""
+<CodeBlock title="AndroidManifest.xml" highlight={"tools:node=\"remove\""}>
+
+```xml
 <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
 ```
+
+</CodeBlock>
 
 ## [4. Set up Proguard](4-set-up-proguard)
 
 If you're using Proguard to optimize your app, you must add rules to prevent Proguard from removing classes.
 
-```java title="Proguard.pro"
+<CodeBlock title="Proguard.pro">
+
+```java
 -keep class com.adjust.sdk.** { *; }
 -keep class com.google.android.gms.common.ConnectionResult {
    int SUCCESS;
@@ -499,13 +528,20 @@ If you're using Proguard to optimize your app, you must add rules to prevent Pro
    boolean isLimitAdTrackingEnabled();
 }
 -keep public class com.android.installreferrer.** { *; }
+
 ```
+
+</CodeBlock>
 
 If you're not publishing your app in the Google Play Store, add the following rule:
 
-```java title="Proguard.pro"
+<CodeBlock title="Proguard.pro">
+
+```java
 -keep public class com.adjust.sdk.** { *; }
 ```
+
+</CodeBlock>
 
 ## [5. Set up install referrer](5-set-up-install-referrer)
 
@@ -517,17 +553,26 @@ The Google Play Referrer API is available to apps that target the Google Play St
 
 To support the Google Play Referrer API, add the following to your `build.gradle` file:
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 dependencies {
    implementation 'com.android.installreferrer:installreferrer:2.2'
 }
+
 ```
+
+</CodeBlock>
 
 If you're using Proguard, remember to add a rule to prevent the dependency from being removed.
 
-```java title="Proguard.pro"
+<CodeBlock title="Proguard.pro">
+
+```java
 -keep public class com.android.installreferrer.** { *; }
 ```
+
+</CodeBlock>
 
 ### [Huawei Referrer API](huawei-referrer-api)
 
@@ -561,7 +606,7 @@ The Adjust SDK supports the [Meta Install Referrer](https://developers.facebook.
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {2}
+```kotlin
 val config = AdjustConfig(this, appToken, environment)
 config.setFbAppId(<FB_APP_ID_STRING>)
 Adjust.onCreate(config)
@@ -570,7 +615,7 @@ Adjust.onCreate(config)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {2}
+```java
 AdjustConfig config = new AdjustConfig(this, appToken, environment);
 config.setFbAppId(<FB_APP_ID_STRING>);
 Adjust.onCreate(config);
@@ -592,11 +637,16 @@ The recommended way to initialize the Adjust SDK is inside a global Android [App
 2. Open the `AndroidManifest.xml` file and locate the `<application>` element.
 3. Add the `android:name` attribute to the `<application>` element and set it to the name of your application class. For example, if your `Application` class is named `GlobalApplication`, you would set the following:
 
-```xml title="AndroidManifest.xml"
+<CodeBlock title="AndroidManifest.xml">
+
+```xml
 <application android:name=".GlobalApplication">
    <!-- ... -->
 </application>
+
 ```
+
+</CodeBlock>
 
 4. Find the `onCreate` method in your `Application` class or add one if it doesn't exist. Pass the following parameters to initialize the Adjust SDK:
 

--- a/src/content/docs/sdk/android/plugins/criteo.mdx
+++ b/src/content/docs/sdk/android/plugins/criteo.mdx
@@ -25,12 +25,17 @@ You can integrate the Adjust Android SDK with Criteo events by using the Adjust 
 
 If you are using Maven, add the following dependency to your `build.gradle` file:
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 dependencies {
    implementation 'com.adjust.sdk:adjust-android:$ANDROID_V4_VERSION'
    implementation 'com.adjust.sdk:adjust-android-criteo:$ANDROID_V4_VERSION'
 }
+
 ```
+
+</CodeBlock>
 
 ### [Add as JAR](add-as-jar)
 

--- a/src/content/docs/sdk/android/plugins/facebook-pixel.mdx
+++ b/src/content/docs/sdk/android/plugins/facebook-pixel.mdx
@@ -25,19 +25,27 @@ As described in [Facebook's Android SDK guide](https://developers.facebook.com/d
 3. Open `AndroidManifest.xml`.
 4. Add a uses-permission element to the manifest:
 
-   ```xml title="AndroidManifest.xml"
+   <CodeBlock title="AndroidManifest.xml">
+
+   ```xml
    <uses-permission android:name="android.permission.INTERNET"/>
    ```
 
+   </CodeBlock>
+
 5. Add a meta-data element to the application element:
 
-   ```xml title="AndroidManifest.xml"
+   <CodeBlock title="AndroidManifest.xml">
+
+   ```xml
    <application android:label="@string/app_name" ...>
    ...
    <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string/facebook_app_id"/>
    ...
    </application>
    ```
+
+   </CodeBlock>
 
 ### [Facebook pixel configuration](facebook-pixel-configuration)
 

--- a/src/content/docs/sdk/android/plugins/imei-plugin.mdx
+++ b/src/content/docs/sdk/android/plugins/imei-plugin.mdx
@@ -22,12 +22,17 @@ Before you use this plugin, make sure to follow the get started guide and integr
 
 If you are using Maven, add the following dependency to your `build.gradle` file:
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 dependencies {
    implementation 'com.adjust.sdk:adjust-android:$ANDROID_V4_VERSION'
    implementation 'com.adjust.sdk:adjust-android-imei:$ANDROID_V4_VERSION'
 }
+
 ```
+
+</CodeBlock>
 
 ### [Add as JAR](add-as-jar)
 
@@ -37,9 +42,13 @@ You can also add the plugin as a JAR file from the [releases page](https://githu
 
 Ensure the following permission is present in your `AndroidManifest.xml` file. If it isn't, add it.
 
-```xml title="AndroidManifest.xml"
+<CodeBlock title="AndroidManifest.xml">
+
+```xml
 <uses-permission android:name="android.permission.READ_PHONE_STATE" />
 ```
+
+</CodeBlock>
 
 As of Android 6.0 you may need to [request app permission](https://developer.android.com/training/permissions/requesting). This isn't necessary if the OS has been set up to not require app permissions.
 
@@ -47,9 +56,13 @@ As of Android 6.0 you may need to [request app permission](https://developer.and
 
 If your app isn't targeting the Google Play Store, you don't need to add all the rules set out in the get started guide. You can remove rules related to Google Play Services and install referrer libraries. You only need to keep the rules that apply to the Adjust SDK.
 
-```java title="Proguard.pro"
+<CodeBlock title="Proguard.pro">
+
+```java
 -keep public class com.adjust.sdk.** { *; }
 ```
+
+</CodeBlock>
 
 ## [Use the plugin](use-the-plugin)
 

--- a/src/content/docs/sdk/android/plugins/oaid-plugin.mdx
+++ b/src/content/docs/sdk/android/plugins/oaid-plugin.mdx
@@ -14,12 +14,17 @@ The OAID plugin provides the OAID of a device. The SDK will continue to use othe
 
 If you are using Maven, add the following dependency to your `build.gradle` file:
 
-```java title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 dependencies {
    implementation 'com.adjust.sdk:adjust-android:$ANDROID_V4_VERSION'
    implementation 'com.adjust.sdk:adjust-android-oaid:$ANDROID_V4_VERSION'
 }
+
 ```
+
+</CodeBlock>
 
 For Huawei OAID measurement, you must add a developer repository and additional dependencies.
 
@@ -31,7 +36,9 @@ Minimum SDK Version 4.28.2 and OAID plugin 4.33.0 are required for Huawei device
 
 1. Add the following to your project's `build.gradle` file:
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 allprojects {
     repositories {
         maven {
@@ -39,17 +46,25 @@ allprojects {
         }
     mavenCentral()
     }
+
 ```
+
+</CodeBlock>
 
 2. Add the following to your app-level `build.gradle` file:
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 dependencies {
    implementation 'com.adjust.sdk:adjust-android:4.33.4'
    implementation 'com.adjust.sdk:adjust-android-oaid:4.33.4'
    implementation 'com.huawei.hms:ads-identifier:3.4.62.300'
 }
+
 ```
+
+</CodeBlock>
 
 ### [Install standalone binary](install-standalone-binary)
 
@@ -88,35 +103,53 @@ You can use the HMS Core SDK to access the OAID of Huawei devices. To enable the
 
 1. Add the Huawei maven repository.
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 repositories {
   maven {
       url "https://developer.huawei.com/repo/"
   }
 }
+
 ```
+
+</CodeBlock>
 
 2. Add the HMS Core SDK.
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 dependencies {
    implementation 'com.huawei.hms:ads-identifier:3.4.56.300'
 }
+
 ```
+
+</CodeBlock>
 
 ## [Proguard settings](proguard-settings)
 
 If your app isn't targeting the Google Play Store, you don't need to add all the rules set out in the Android get started guide. You can remove rules related to Google Play Services and install referrer libraries. You only need to keep the rules that apply to the Adjust SDK.
 
-```java title="Proguard.pro"
+<CodeBlock title="Proguard.pro">
+
+```java
 -keep public class com.adjust.sdk.** { *; }
 ```
 
+</CodeBlock>
+
 If you are adding the MSA SDK AAR as a dependency, add the following rules:
 
-```java title="Proguard.pro"
+<CodeBlock title="Proguard.pro">
+
+```java
 -keep class com.bun.miitmdid.core.** { *; }
 ```
+
+</CodeBlock>
 
 ## [Use the plugin](use-the-plugin)
 

--- a/src/content/docs/sdk/android/plugins/samsung-clouddev.mdx
+++ b/src/content/docs/sdk/android/plugins/samsung-clouddev.mdx
@@ -19,9 +19,13 @@ There are two ways to install the Samsung CloudDev plugin:
 
 Add the following dependency to your `build.gradle` file under your Adjust SDK declaration.
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 implementation 'com.adjust.sdk:adjust-android-samsung-clouddev:4.38.3'
 ```
+
+</CodeBlock>
 
 ### [Add as a JAR or AAR](add-as-a-jar-or-aar)
 

--- a/src/content/docs/sdk/android/plugins/samsung-referrer-plugin.mdx
+++ b/src/content/docs/sdk/android/plugins/samsung-referrer-plugin.mdx
@@ -20,11 +20,16 @@ There are two ways to install the Samsung referrer plugin:
 
 Add the following dependency to your `build.gradle` file under your Adjust SDK declaration.
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 implementation 'com.adjust.sdk:adjust-android:$ANDROID_V4_VERSION'
 
 implementation 'com.adjust.sdk:adjust-android-samsung-referrer:$ANDROID_V4_VERSION'
+
 ```
+
+</CodeBlock>
 
 ### [JAR](jar)
 
@@ -44,9 +49,13 @@ Adding the Samsung install referrer library via Maven is available only in Adjus
 
 To install the Samsung install referrer library, you must add the following dependency to your `build.gradle` file under your Adjust SDK declaration:
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 implementation  'store.galaxy.samsung.installreferrer:samsung_galaxystore_install_referrer:3.0.1'
 ```
+
+</CodeBlock>
 
 </Accordion>
 
@@ -62,15 +71,23 @@ If you use Proguard, you must add rules to ensure that important classes aren't 
 
 Add the following rule to keep all Adjust classes.
 
-```java title="Proguard.pro"
+<CodeBlock title="Proguard.pro">
+
+```java
 -keep public class com.adjust.sdk.** { *; }
 ```
 
+</CodeBlock>
+
 Add the following rule to keep the Samsung install referrer library.
 
-```java title="Proguard.pro"
+<CodeBlock title="Proguard.pro">
+
+```java
 -keep class com.sec.android.app.samsungapps.installreferrer.** { *; }
 ```
+
+</CodeBlock>
 
 ## [Use the plugin](use-the-plugin)
 

--- a/src/content/docs/sdk/android/plugins/sociomatic.mdx
+++ b/src/content/docs/sdk/android/plugins/sociomatic.mdx
@@ -25,12 +25,17 @@ You can integrate the Adjust SDK with Sociomantic events.
 
 If you are using Maven, add the following dependency to your `build.gradle` file:
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 dependencies {
    implementation 'com.adjust.sdk:adjust-android:$ANDROID_V4_VERSION'
    implementation 'com.adjust.sdk:adjust-android-criteo:$ANDROID_V4_VERSION'
 }
+
 ```
+
+</CodeBlock>
 
 ### [JAR](jar)
 

--- a/src/content/docs/sdk/android/plugins/trademob.mdx
+++ b/src/content/docs/sdk/android/plugins/trademob.mdx
@@ -31,12 +31,17 @@ To use this feature, you first need to download and set up the Adjust SDK for yo
 
 If you are using Maven, add the following dependency to your `build.gradle` file:
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 dependencies {
    implementation 'com.adjust.sdk:adjust-android:$ANDROID_V4_VERSION'
    implementation 'com.adjust.sdk:adjust-android-trademob:$ANDROID_V4_VERSION'
 }
+
 ```
+
+</CodeBlock>
 
 ### [Add as JAR](add-as-jar)
 

--- a/src/content/docs/sdk/android/plugins/vivo-referrer-plugin.mdx
+++ b/src/content/docs/sdk/android/plugins/vivo-referrer-plugin.mdx
@@ -18,11 +18,16 @@ There are two ways to install the Vivo referrer plugin:
 
 Add the following dependency to your `build.gradle` file under your Adjust SDK declaration.
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 implementation 'com.adjust.sdk:adjust-android:$ANDROID_V4_VERSION'
 
 implementation 'com.adjust.sdk:adjust-android-vivo-referrer:$ANDROID_V4_VERSION'
+
 ```
+
+</CodeBlock>
 
 ### [JAR](jar)
 

--- a/src/content/docs/sdk/android/plugins/xiaomi-referrer-plugin.mdx
+++ b/src/content/docs/sdk/android/plugins/xiaomi-referrer-plugin.mdx
@@ -18,11 +18,16 @@ There are two ways to install the Xiaomi referrer plugin:
 
 Add the following dependency to your `build.gradle` file under your Adjust SDK declaration.
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 implementation 'com.adjust.sdk:adjust-android:$ANDROID_V4_VERSION'
 
 implementation 'com.adjust.sdk:adjust-android-xiaomi-referrer:$ANDROID_V4_VERSION'
+
 ```
+
+</CodeBlock>
 
 ### [JAR file](jar-file)
 
@@ -36,9 +41,13 @@ You must add the Xiaomi install referrer to your app to read the referrer value.
 
 Add the following dependency to your `build.gradle` file after the Adjust SDK.
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 implementation 'com.miui.referrer:homereferrer:1.0.0.6'
 ```
+
+</CodeBlock>
 
 For more information check out the [Xiaomi install referrer library documentation](https://global.developer.mi.com/document?doc=service.getAppsReferral).
 
@@ -48,15 +57,23 @@ If you use Proguard, you must add rules to ensure that important classes aren't 
 
 Add the following rule to keep all Adjust classes.
 
-```java title="Proguard.pro"
+<CodeBlock title="Proguard.pro">
+
+```java
 -keep public class com.adjust.sdk.** { *; }
 ```
 
+</CodeBlock>
+
 Add the following rule to keep the Xiaomi install referrer library.
 
-```java title="Proguard.pro"
+<CodeBlock title="Proguard.pro">
+
+```java
 -keep class com.miui.referrer.** {*;}
 ```
+
+</CodeBlock>
 
 ## [Use the plugin](use-the-plugin)
 

--- a/src/content/docs/sdk/android/setup/multi-processes.mdx
+++ b/src/content/docs/sdk/android/setup/multi-processes.mdx
@@ -155,19 +155,29 @@ Calling the SDK in multiple processes without setting the process name initializ
 
 Android apps can consist of one or more processes. To run services or activities in a process other than the main one, you need to add a process name to your activity or service. To do this, add an `android:process` property to your `activity` or `service` node in your `AndroidManifest.xml` file.
 
-```xml title="AndroidManifest.xml"
+<CodeBlock title="AndroidManifest.xml">
+
+```xml
 <activity
     android:name=".YourActivity"
     android:process=":YourProcessName">
 </activity>
+
 ```
 
-```xml title="AndroidManifest.xml"
+</CodeBlock>
+
+<CodeBlock title="AndroidManifest.xml">
+
+```xml
 <service
     android:name=".YourService"
     android:process=":YourProcessName">
 </service>
+
 ```
+
+</CodeBlock>
 
 Defining a process name forces the activity or service to run in a process other than the main process.
 
@@ -218,7 +228,9 @@ Adjust.onCreate(adjustConfig);
 
 To change the name of your main process, modify the `android:process` property of the `application` node in your `AndroidManifest.xml` file.
 
-```xml title="AndroidManifest.xml"
+<CodeBlock title="AndroidManifest.xml">
+
+```xml
 <application
   android:name=".YourApp"
   android:icon="@drawable/ic_launcher"
@@ -226,7 +238,10 @@ To change the name of your main process, modify the `android:process` property o
   android:theme="@style/AppTheme"
   android:process=":YourMainProcessName">
 </application>
+
 ```
+
+</CodeBlock>
 
 Then set your process name in your `AdjustConfig` object.
 

--- a/src/content/docs/sdk/android/setup/preinstall-tool.mdx
+++ b/src/content/docs/sdk/android/setup/preinstall-tool.mdx
@@ -125,7 +125,9 @@ Once you have your keystore file and your link token, you can create a configura
 
 Here's an example `adjust-config.yaml` file including settings for three stores named `store_1`, `store_2`, and `store_3`.
 
-```yaml title="adjust-config.yaml"
+<CodeBlock title="adjust-config.yaml">
+
+```yaml
 apk_path: /Users/username/Desktop/apk/example-release.apk
 keystore_path: /Users/username/Desktop/apk/mykeystore.jks
 keystore_pass: mykeystorepass
@@ -139,9 +141,13 @@ stores:
       default_tracker: abc789
 ```
 
+</CodeBlock>
+
 You can define global parameters in the root of the file if you want to use the same settings for each store. Parameters set on a store will override the global parameters for that store. For example:
 
-```yaml title="adjust-config.yaml"
+<CodeBlock title="adjust-config.yaml">
+
+```yaml
 apk_path: /Users/username/Desktop/apk/example-release.apk
 keystore_path: /Users/username/Desktop/apk/mykeystore.jks
 keystore_pass: mykeystorepass
@@ -157,6 +163,8 @@ stores:
    store_3:
       default_tracker: abc789
 ```
+
+</CodeBlock>
 
 In this example, the `adjust-dtt` tool uses `differentkeystore.jks`, `differentkeystorepass` and `differentkeystorealias` when generating the APK for `store_1`. The tool generates a modified APK for each store.
 

--- a/src/content/docs/sdk/android/setup/preinstalled.mdx
+++ b/src/content/docs/sdk/android/setup/preinstalled.mdx
@@ -215,7 +215,7 @@ Your config object contains a `Boolean` `preinstallTrackingEnabled` property tha
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {4}
+```kotlin
 val appToken = "{YourAppToken}"
 val environment = AdjustConfig.ENVIRONMENT_SANDBOX
 val config = AdjustConfig(this, appToken, environment)
@@ -227,7 +227,7 @@ Adjust.initSdk(config)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {4}
+```java
 String appToken = "{YourAppToken}";
 String environment = AdjustConfig.ENVIRONMENT_SANDBOX;
 AdjustConfig config = new AdjustConfig(this, appToken, environment);
@@ -239,7 +239,7 @@ Adjust.onCreate(config);
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {4}
+```js
 var yourAppToken = yourAppToken;
 var environment = AdjustConfig.EnvironmentSandbox;
 var adjustConfig = new AdjustConfig(yourAppToken, environment);
@@ -267,19 +267,28 @@ The content provider method makes use of a read-only content provider. The SDK u
 
 To set the permissions, add the following to your `AndroidManifest.xml` file.
 
-```xml title="AndroidManifest.xml"
+<CodeBlock title="AndroidManifest.xml">
+
+```xml
 <uses-permission android:name="com.adjust.preinstall.READ_PERMISSION"/>
 ```
 
+</CodeBlock>
+
 To access a list of preinstalled apps on the device, add the following to your `AndroidManifest.xml` file.
 
-```xml title="AndroidManifest.xml"
+<CodeBlock title="AndroidManifest.xml">
+
+```xml
 <queries>
    <intent>
        <action android:name="com.attribution.REFERRAL_PROVIDER"/>
    </intent>
 </queries>
+
 ```
+
+</CodeBlock>
 
 ## [System installer receiver](system-installer-receiver)
 
@@ -287,13 +296,18 @@ The system installer method uses a broadcast receiver. The system installer broa
 
 To set up the receiver, add the following to your `AndroidManifest.xml` file.
 
-```xml title="AndroidManifest.xml"
+<CodeBlock title="AndroidManifest.xml">
+
+```xml
 <receiver android:name="com.adjust.sdk.AdjustPreinstallReferrerReceiver">
    <intent-filter>
       <action android:name="com.attribution.SYSTEM_INSTALLER_REFERRER" />
    </intent-filter>
 </receiver>
+
 ```
+
+</CodeBlock>
 
 ## [World-readable directory](world-readable-directory)
 
@@ -304,7 +318,7 @@ Pass the file path at which your preinstall information can be found to the `set
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {4}
+```kotlin
 val appToken = "{YourAppToken}"
 val environment = AdjustConfig.ENVIRONMENT_SANDBOX
 val config = AdjustConfig(this, appToken, environment)
@@ -316,7 +330,7 @@ Adjust.onCreate(config)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {4}
+```java
 String appToken = "{YourAppToken}";
 String environment = AdjustConfig.ENVIRONMENT_SANDBOX;
 AdjustConfig config = new AdjustConfig(this, appToken, environment);
@@ -328,7 +342,7 @@ Adjust.onCreate(config);
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {4}
+```js
 var yourAppToken = yourAppToken;
 var environment = AdjustConfig.EnvironmentSandbox;
 var adjustConfig = new AdjustConfig(yourAppToken, environment);
@@ -344,7 +358,7 @@ Configuring a default link token enables you to attribute all preinstalls to a p
 
 1. [Create a new campaign link in Campaign Lab](https://help.adjust.com/en/article/links).
 
-   ```text "{token}"
+   ```text
    https://app.adjust.com/{token}
    ```
 
@@ -353,7 +367,7 @@ Configuring a default link token enables you to attribute all preinstalls to a p
 <Tabs>
 <Tab title="Kotlin" sync="kotlin">
 
-```kotlin {4}
+```kotlin
 val appToken = "{YourAppToken}"
 val environment = AdjustConfig.ENVIRONMENT_SANDBOX
 val config = AdjustConfig(this, appToken, environment)
@@ -365,7 +379,7 @@ Adjust.onCreate(config)
 </Tab>
 <Tab title="Java" sync="java">
 
-```java {4}
+```java
 String appToken = "{YourAppToken}";
 String environment = AdjustConfig.ENVIRONMENT_SANDBOX;
 AdjustConfig config = new AdjustConfig(this, appToken, environment);
@@ -377,7 +391,7 @@ Adjust.onCreate(config);
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {4}
+```js
 var yourAppToken = yourAppToken;
 var environment = AdjustConfig.EnvironmentSandbox;
 var adjustConfig = new AdjustConfig(yourAppToken, environment);

--- a/src/content/docs/sdk/cocos2dx/configuration.mdx
+++ b/src/content/docs/sdk/cocos2dx/configuration.mdx
@@ -10,11 +10,16 @@ Use the methods in this document to configure the behavior of the Adjust SDK.
 
 ## Instantiate your config object
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 ADJConfig2dx(std::string appToken, std::string environment, bool allowSuppressLogLevel, std::string sdkPrefix) {
    initConfig(appToken, environment, allowSuppressLogLevel, sdkPrefix);
 }
+
 ```
+
+</CodeBlock>
 
 To configure the Adjust SDK, you need to instantiate an `AdjustConfig2dx` object. This object contains the **read-only** configuration options that you need to pass to the Adjust SDK.
 
@@ -24,7 +29,7 @@ To instantiate your config object, create a new `AdjustConfig2dx` instance and p
 -  `environment` (**String**): The environment you want to run the SDK in. Pass `AdjustEnvironmentSandbox2dx` to run the SDK in sandbox mode for testing. Pass `AdjustEnvironmentProduction2dx` to run the SDK in production mode for release.
 -  `allowSuppressLogLevel` (**Boolean**): Whether to suppress all logging. Set to `true` to suppress logging or `false` to enable logging.
 
-```cpp {6}
+```cpp
 #include "Adjust/Adjust2dx.h"
 // ...
 std::string appToken = "{YourAppToken}";
@@ -40,9 +45,13 @@ Adjust2dx::start(adjustConfig);
 
 ### Set your logging level
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void setLogLevel(ADJLogLevel2dx logLevel);
 ```
+
+</CodeBlock>
 
 The Adjust SDK provides configurable log levels to return different amounts of information. The following log levels are available:
 
@@ -64,7 +73,7 @@ You can set your log level by calling the `setLogLevel` method on your `AdjustCo
 
 -  `logLevel` (**ADJLogLevel2dx**): The log level you want to use.
 
-```cpp {5}
+```cpp
 std::string appToken = "{YourAppToken}";
 std::string environment = AdjustEnvironmentSandbox2dx;
 
@@ -75,9 +84,13 @@ Adjust2dx::start(adjustConfig);
 
 ### Set external device identifier
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void setExternalDeviceId(std::string externalDeviceId);
 ```
+
+</CodeBlock>
 
 An external device identifier is a custom value that you can assign to a device or user. They help you recognize users across sessions and platforms. They can also help you deduplicate installs by user so that a user isn't counted as duplicate new installs. Contact your Adjust representative to get started with external device IDs.
 
@@ -91,7 +104,7 @@ See the [External device identifiers article](https://help.adjust.com/en/article
 
 </Callout>
 
-```cpp {2}
+```cpp
 AdjustConfig2dx adjustConfig = AdjustConfig2dx(appToken, environment);
 adjustConfig.setExternalDeviceId("{Your-External-Device-Id}");
 Adjust2dx::start(adjustConfig);
@@ -103,15 +116,19 @@ You can import existing external device IDs into Adjust. This ensures that the A
 
 ### Set default link token
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void setDefaultTracker(std::string defaultTracker);
 ```
+
+</CodeBlock>
 
 You can configure a default link token if your app is preinstalled on a device. When a user opens the preinstalled app for the first time, the install is attributed to the default link token. To set your default link token, call the `setDefaultTracker` method with the following argument:
 
 -  `defaultTracker` (**String**): The [Adjust link token](https://help.adjust.com/en/article/links#adjust-link-token) you want to record preinstalled installs against.
 
-```cpp {2}
+```cpp
 AdjustConfig2dx adjustConfig = AdjustConfig2dx(appToken, environment);
 adjustConfig.setDefaultTracker("{TrackerToken}");
 Adjust2dx::adjustConfig(config);
@@ -119,9 +136,13 @@ Adjust2dx::adjustConfig(config);
 
 ### Enable cost data sending
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void setNeedsCost(bool needsCost);
 ```
+
+</CodeBlock>
 
 By default, the Adjust SDK doesn't send cost data as part of a user's attribution. You can configure the SDK to send this data by enabling cost data sending. To enable cost data sending, call the `setNeedsCost` method on your config instance with the following parameter:
 
@@ -129,7 +150,7 @@ By default, the Adjust SDK doesn't send cost data as part of a user's attributio
 
 Cost data is accessible in the user's [attribution information](/en/sdk/cocos2dx/features/attribution).
 
-```cpp {2}
+```cpp
 AdjustConfig2dx adjustConfig = AdjustConfig2dx(appToken, environment);
 adjustConfig.setNeedsCost(true);
 Adjust2dx::adjustConfig(config);
@@ -137,15 +158,19 @@ Adjust2dx::adjustConfig(config);
 
 ### Enable background recording
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void setSendInBackground(bool isEnabled);
 ```
+
+</CodeBlock>
 
 By default, the Adjust SDK pauses the sending of requests when your app is running in the background. You can configure the SDK to send requests in the background by enabling the background recording. To enable background recording, call the `setSendInBackground` method on your config instance with the following parameter:
 
 -  `isEnabled` (**Boolean**): Set to `true` to enable background sending or `false` to disable background sending.
 
-```cpp {6}
+```cpp
 std::string appToken = "{YourAppToken}";
 std::string environment = AdjustEnvironmentSandbox2dx;
 
@@ -157,9 +182,13 @@ Adjust2dx::start(adjustConfig);
 
 ### Enable event buffering
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void setEventBufferingEnabled(bool isEnabled);
 ```
+
+</CodeBlock>
 
 The Adjust SDK sends event information as soon as a user triggers an event in your app. You can send event information on a schedule by enabling event buffering. Event buffering stores events in a local buffer on the device and sends all requests once per minute.
 
@@ -167,7 +196,7 @@ Your config object contains a boolean `eventBufferingEnabled` property that cont
 
 -  `isEnabled` (**Boolean**): Set to `true` to enable event buffering or `false` to disable event buffering.
 
-```cpp {6}
+```cpp
 std::string appToken = "{YourAppToken}";
 std::string environment = AdjustEnvironmentSandbox2dx;
 
@@ -179,9 +208,13 @@ Adjust2dx::start(adjustConfig);
 
 ### Delay the start of the SDK
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void setDelayStart(double delayStart);
 ```
+
+</CodeBlock>
 
 By default, the Adjust SDK starts as soon as your app opens. If you want to send data that's not available at launch in [session parameters](/en/sdk/cocos2dx/features/session-parameters), you can delay the start of the SDK. This can be helpful if you are sending information such as unique identifiers.
 
@@ -189,7 +222,7 @@ To configure a startup delay, call the `setDelayStart` method with the following
 
 -  `delayStart` (**Double**): The time (in seconds) by which to delay the start of the SDK. You can delay the start of the SDK by up to **10 seconds**.
 
-```cpp {6}
+```cpp
 std::string appToken = "{YourAppToken}";
 std::string environment = AdjustEnvironmentSandbox2dx;
 
@@ -205,9 +238,13 @@ Adjust2dx::start(adjustConfig);
 
 ### Toggle offline mode
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 static void setOfflineMode(bool isOffline);
 ```
+
+</CodeBlock>
 
 <Callout type="important">
 
@@ -227,9 +264,13 @@ Adjust2dx::setOfflineMode(true);
 
 ### Set push tokens
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 static void setDeviceToken(std::string deviceToken);
 ```
+
+</CodeBlock>
 
 Push tokens are used for [Audiences](https://help.adjust.com/en/article/audiences) and client callbacks. They're also required for [Uninstall and reinstall tracking](https://help.adjust.com/en/article/uninstalls-reinstalls).
 
@@ -249,9 +290,13 @@ You can only call this method after the first session. This setting persists bet
 
 </Callout>
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 static void setEnabled(bool isEnabled);
 ```
+
+</CodeBlock>
 
 The Adjust SDK runs by default when your app is open. You can disable and re-enable the Adjust SDK to pause and resume recording. When you disable the Adjust SDK, it doesn't send any data to Adjust's servers.
 
@@ -265,9 +310,13 @@ Adjust2dx::setEnabled(false);
 
 #### Check enabled status
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 static bool isEnabled();
 ```
+
+</CodeBlock>
 
 You can check if the Adjust SDK is enabled at any time by calling the `isEnabled` method. This method returns a **boolean** value indicating if the SDK is **enabled** (`true`) or **disabled** (`false`).
 

--- a/src/content/docs/sdk/cocos2dx/features/ad-revenue.mdx
+++ b/src/content/docs/sdk/cocos2dx/features/ad-revenue.mdx
@@ -14,9 +14,13 @@ You need to perform some extra setup steps in your Adjust dashboard to measure a
 
 ## Instantiate an AdjustAdRevenue object
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void AdjustAdRevenue2dx::initAdRevenue(std::string source);
 ```
+
+</CodeBlock>
 
 To send ad revenue information with the Adjust SDK, you need to instantiate an `AdjustAdRevenue` object. This object contains variables that are sent to Adjust when ad revenue is recorded in your app.
 
@@ -40,29 +44,37 @@ To instantiate an ad revenue object, create a new `AdjustAdRevenue` instance and
 
 </Table>
 
-```cpp {1}
+```cpp
 AdjustAdRevenue2dx adjustAdRevenue = AdjustAdRevenue2dx(AdjustConfig2dx::AdjustAdRevenueSourceAppLovinMAX);
 Adjust2dx::trackAdRevenueNew(adjustAdRevenue);
 ```
 
 ## Send ad revenue
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 static void trackAdRevenueNew(AdjustAdRevenue2dx adRevenue);
 ```
 
+</CodeBlock>
+
 To send ad revenue to Adjust, call the `trackAdRevenueNew` method with your ad revenue instance as an argument.
 
-```cpp {2}
+```cpp
 AdjustAdRevenue2dx adjustAdRevenue = AdjustAdRevenue2dx(AdjustConfig2dx::AdjustAdRevenueSourceAppLovinMAX);
 Adjust2dx::trackAdRevenueNew(adjustAdRevenue);
 ```
 
 ## Record ad revenue amount
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void AdjustAdRevenue2dx::setRevenue(double amount, std::string currency);
 ```
+
+</CodeBlock>
 
 To send the ad revenue amount, call the `setRevenue` method and pass the following arguments:
 
@@ -75,7 +87,7 @@ Check the [guide to tracking purchases in different currencies](https://help.adj
 
 </Callout>
 
-```cpp {2}
+```cpp
 AdjustAdRevenue2dx adjustAdRevenue = AdjustAdRevenue2dx(AdjustConfig2dx::AdjustAdRevenueSourceAppLovinMAX);
 adjustAdRevenue.setRevenue(0.01, "EUR");
 Adjust2dx::trackAdRevenueNew(adjustAdRevenue);
@@ -87,15 +99,19 @@ The `AdjustAdRevenue` class contains properties you can use to report on your ad
 
 ### Ad impressions
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void AdjustAdRevenue2dx::setAdImpressionsCount(int adImpressionsCount);
 ```
+
+</CodeBlock>
 
 To send the number of recorded ad impressions, call the `setAdImpressionsCount` method and pass the following arguments:
 
 -  `adImpressionsCount` (**Integer**): The number of ad impressions.
 
-```cpp {2}
+```cpp
 AdjustAdRevenue2dx adjustAdRevenue = AdjustAdRevenue2dx(AdjustConfig2dx::AdjustAdRevenueSourceAppLovinMAX);
 adjustAdRevenue.setAdImpressionsCount(10);
 Adjust2dx::trackAdRevenueNew(adjustAdRevenue);
@@ -103,15 +119,19 @@ Adjust2dx::trackAdRevenueNew(adjustAdRevenue);
 
 ### Ad revenue network
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void AdjustAdRevenue2dx::setAdRevenueNetwork(std::string adRevenueNetwork);
 ```
+
+</CodeBlock>
 
 To send the ad revenue network, call the `setAdRevenueNetwork` method and pass the following arguments:
 
 -  `adRevenueNetwork` (**String**): The network name.
 
-```cpp {2}
+```cpp
 AdjustAdRevenue2dx adjustAdRevenue = AdjustAdRevenue2dx(AdjustConfig2dx::AdjustAdRevenueSourceAppLovinMAX);
 adjustAdRevenue.setAdImpressionsCount("network1");
 Adjust2dx::trackAdRevenueNew(adjustAdRevenue);
@@ -119,15 +139,19 @@ Adjust2dx::trackAdRevenueNew(adjustAdRevenue);
 
 ### Ad revenue unit
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void AdjustAdRevenue2dx::setAdRevenueUnit(std::string adRevenueUnit);
 ```
+
+</CodeBlock>
 
 To send the ad revenue unit, call the `setAdRevenueUnit` method and pass the following arguments:
 
 -  `adRevenueUnit` (**String**): The ad unit.
 
-```cpp {2}
+```cpp
 AdjustAdRevenue2dx adjustAdRevenue = AdjustAdRevenue2dx(AdjustConfig2dx::AdjustAdRevenueSourceAppLovinMAX);
 adjustAdRevenue.setAdImpressionsCount("unit1");
 Adjust2dx::trackAdRevenueNew(adjustAdRevenue);
@@ -135,15 +159,19 @@ Adjust2dx::trackAdRevenueNew(adjustAdRevenue);
 
 ### Ad revenue placement
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void AdjustAdRevenue2dx::setAdRevenuePlacement(std::string adRevenuePlacement);
 ```
+
+</CodeBlock>
 
 To send the ad revenue placement, call the `setAdRevenuePlacement` method and pass the following arguments:
 
 -  `adRevenuePlacement` (**String**): The ad placement.
 
-```cpp {2}
+```cpp
 AdjustAdRevenue2dx adjustAdRevenue = AdjustAdRevenue2dx(AdjustConfig2dx::AdjustAdRevenueSourceAppLovinMAX);
 adjustAdRevenue.setAdRevenuePlacement("banner");
 Adjust2dx::trackAdRevenueNew(adjustAdRevenue);
@@ -151,9 +179,13 @@ Adjust2dx::trackAdRevenueNew(adjustAdRevenue);
 
 ## Add callback parameters
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void AdjustAdRevenue2dx::addCallbackParameter(std::string key, std::string value);
 ```
+
+</CodeBlock>
 
 If you [register a callback URL](https://help.adjust.com/en/article/recommended-placeholders-callbacks) in the Adjust dashboard, the SDK sends a GET request to your callback URL when it records an event.
 
@@ -163,9 +195,13 @@ Add callback parameters to your event by calling the `addCallbackParameter` meth
 
 The Adjust SDK measures the event and sends a request to your URL with the callback parameters. For example, if you register the URL `https://www.mydomain.com/callback`, your callback looks like this:
 
-```http "key=value" "foo=bar"
+<CodeBlock highlight="key=value, foo=bar">
+
+```http
 https://www.mydomain.com/callback?key=value&foo=bar
 ```
+
+</CodeBlock>
 
 <Callout type="note">
 
@@ -183,7 +219,7 @@ You can read more about using URL callbacks, including a full list of available 
 
 </Callout>
 
-```cpp {2}
+```cpp
 AdjustAdRevenue2dx adjustAdRevenue = AdjustAdRevenue2dx(AdjustConfig2dx::AdjustAdRevenueSourceAppLovinMAX);
 adjustAdRevenue.addCallbackParameter("key", "value");
 adjustAdRevenue.addCallbackParameter("foo", "bar");
@@ -192,9 +228,13 @@ Adjust2dx::trackAdRevenueNew(adjustAdRevenue);
 
 ## Add partner parameters
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void AdjustAdRevenue2dx::addPartnerParameter(std::string key, std::string value);
 ```
+
+</CodeBlock>
 
 You can send extra information to your network partners by adding [partner parameters](https://help.adjust.com/en/article/data-sharing-ad-network#map-parameters).
 
@@ -208,7 +248,7 @@ Partner parameters don't appear in raw data by default. You can add the `{partne
 
 Add partner parameters to your event by calling the `addPartnerParameter` method with **string** key-value arguments. You can add multiple parameters by calling this method multiple times.
 
-```cpp {2}
+```cpp
 AdjustAdRevenue2dx adjustAdRevenue = AdjustAdRevenue2dx(AdjustConfig2dx::AdjustAdRevenueSourceAppLovinMAX);
 adjustAdRevenue.addPartnerParameter("key", "value");
 adjustAdRevenue.addPartnerParameter("foo", "bar");

--- a/src/content/docs/sdk/cocos2dx/features/att.mdx
+++ b/src/content/docs/sdk/cocos2dx/features/att.mdx
@@ -27,9 +27,13 @@ You might receive a status code of `-1` if the SDK is unable to retrieve the ATT
 
 ## App-tracking authorization wrapper
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 static void requestTrackingAuthorizationWithCompletionHandler(void (*trackingStatusCallback)(int status));
 ```
+
+</CodeBlock>
 
 The Adjust SDK contains a wrapper around [Apple's `requestTrackingAuthorizationWithCompletionHandler` method](https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanager/3547037-requesttrackingauthorizationwith). You can use this wrapper if you don't want to customize the ATT prompt.
 
@@ -93,9 +97,13 @@ Adjust2dx::requestTrackingAuthorizationWithCompletionHandler(authorizationStatus
 
 ## Get current authorization status
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 static int getAppTrackingAuthorizationStatus();
 ```
+
+</CodeBlock>
 
 You can retrieve a user's current authorization status at any time. Call the `getAppTrackingAuthorizationStatus` method to return the authorization status code as an **integer**.
 
@@ -114,9 +122,13 @@ Adjust2dx::addSessionPartnerParameter("status", authorizationStatus);
 
 ## Check for authorization status changes
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 static void checkForNewAttStatus();
 ```
+
+</CodeBlock>
 
 If you use a custom ATT prompt, you need to inform the Adjust SDK of changes to the user's authorization status. Call the `checkForNewAttStatus` method to send the authorization status to Adjust's servers.
 

--- a/src/content/docs/sdk/cocos2dx/features/attribution.mdx
+++ b/src/content/docs/sdk/cocos2dx/features/attribution.mdx
@@ -41,9 +41,13 @@ The following values can only be accessed if the [`needsCost` property on your `
 
 ## Trigger a function when attribution changes
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void setAttributionCallback(void(*attributionCallback)(AdjustAttribution2dx attribution));
 ```
+
+</CodeBlock>
 
 The SDK can listen for attribution changes and call a function when it detects an update. To configure your callback function, call the `setAttributionCallback` method with your function name as an argument.
 
@@ -53,7 +57,7 @@ You must call the `setAttributionCallback` method **before** initializing the Ad
 
 </Callout>
 
-```cpp {3}
+```cpp
 AdjustConfig2dx adjustConfig = AdjustConfig2dx(appToken, environment);
 adjustConfig.setLogLevel(AdjustLogLevel2dxVerbose);
 adjustConfig.setAttributionCallback(attributionCallbackMethod);
@@ -62,9 +66,13 @@ Adjust2dx::start(adjustConfig);
 
 ## Get current attribution information
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 static AdjustAttribution2dx getAttribution();
 ```
+
+</CodeBlock>
 
 When a user installs your app, Adjust attributes the install to a campaign. The Adjust SDK gives you access to campaign attribution details for your install. To return this information, call the `getAttribution` method to return the attribution information as an `AdjustAttribution2dx` object.
 

--- a/src/content/docs/sdk/cocos2dx/features/callbacks.mdx
+++ b/src/content/docs/sdk/cocos2dx/features/callbacks.mdx
@@ -32,13 +32,17 @@ Session callbacks have access to a response data object. You can use its propert
 
 ### Success callbacks
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void setSessionSuccessCallback(void(*sessionSuccessCallback)(AdjustSessionSuccess2dx sessionSuccess));
 ```
 
+</CodeBlock>
+
 Set up success callbacks to trigger functions when the SDK records a session.
 
-```cpp {3-5, 13}
+```cpp
 #include "Adjust/Adjust2dx.h"
 
 static void sessionSuccessCallbackMethod(AdjustSessionSuccess2dx sessionSuccess) {
@@ -80,13 +84,17 @@ bool AppDelegate::applicationDidFinishLaunching() {
 
 ### Failure callbacks
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void setSessionFailureCallback(void(*sessionFailureCallback)(AdjustSessionFailure2dx sessionFailure));
 ```
 
+</CodeBlock>
+
 Set up failure callbacks to trigger functions when the SDK fails to record a session.
 
-```cpp {3-5, 13}
+```cpp
 #include "Adjust/Adjust2dx.h"
 
 static void sessionFailureCallbackMethod(AdjustSessionFailure2dx sessionFailure) {
@@ -148,13 +156,17 @@ Event callbacks have access to a response data object. You can use its propertie
 
 ### Success callbacks
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void setEventSuccessCallback(void(*eventSuccessCallback)(AdjustEventSuccess2dx eventSuccess));
 ```
 
+</CodeBlock>
+
 Set up success callbacks to trigger functions when the SDK records an event.
 
-```cpp {3-5, 13}
+```cpp
 #include "Adjust/Adjust2dx.h"
 
 static void eventSuccessCallbackMethod(AdjustEventSuccess2dx eventSuccess) {
@@ -196,13 +208,17 @@ bool AppDelegate::applicationDidFinishLaunching() {
 
 ### Failure callbacks
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void setEventFailureCallback(void(*eventFailureCallback)(AdjustEventFailure2dx eventFailure));
 ```
 
+</CodeBlock>
+
 Set up failure callbacks to trigger functions when the SDK fails to record an event.
 
-```cpp {3-5, 13}
+```cpp
 #include "Adjust/Adjust2dx.h"
 
 static void eventFailureCallbackMethod(AdjustEventFailure2dx eventFailure) {

--- a/src/content/docs/sdk/cocos2dx/features/deep-links.mdx
+++ b/src/content/docs/sdk/cocos2dx/features/deep-links.mdx
@@ -7,8 +7,8 @@ slug: en/sdk/cocos2dx/features/deep-links
 
 You can create deep links to take users to specific pages in your app. The Adjust SDK uses different logic depending on if the user already has your app installed on their device:
 
-- Direct deep linking: occurs if the user already has your app installed. The link takes the user to the page specified in the link
-- Deferred deep linking: occurs if the user doesn't have your app installed. The link takes the user to a storefront to install your app first. After the user installs the app, it opens to the page specified in the link.
+-  Direct deep linking: occurs if the user already has your app installed. The link takes the user to the page specified in the link
+-  Deferred deep linking: occurs if the user doesn't have your app installed. The link takes the user to a storefront to install your app first. After the user installs the app, it opens to the page specified in the link.
 
 The SDK can read deep link data after a user opens your app from a link.
 
@@ -16,20 +16,26 @@ The SDK can read deep link data after a user opens your app from a link.
 
 Direct deep linking must be set up at the platform level. It isn't possible to set it up in your Cocos2d-x C++ code. Follow the instructions for setting up deep linking for your target platform:
 
-- [iOS](/en/sdk/ios/features/deep-links/direct)
-- [Android](/en/sdk/android/features/deep-links)
+-  [iOS](/en/sdk/ios/features/deep-links/direct)
+-  [Android](/en/sdk/android/features/deep-links)
 
 ## Deferred deep linking
 
 ### Set up a deferred deep link callback
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void AdjustConfig2dx::setDeferredDeeplinkCallback(bool(*deferredDeeplinkCallback)(std::string deeplink));
 ```
 
+</CodeBlock>
+
 You can configure the Adjust SDK to call a callback function when it receives a deferred deep link. This callback function receives the deep link as a **string** argument.
 
-```cpp {3-5, 15}
+<CodeBlock highlight="{range: 3-5}, {range: 15}">
+
+```cpp
 #include "Adjust/Adjust2dx.h"
 
 static bool deferredDeeplinkCallbackMethod(std::string deeplink) {
@@ -48,6 +54,8 @@ bool AppDelegate::applicationDidFinishLaunching() {
     Adjust2dx::start(adjustConfig);
 }
 ```
+
+</CodeBlock>
 
 ### Example
 

--- a/src/content/docs/sdk/cocos2dx/features/device-info.mdx
+++ b/src/content/docs/sdk/cocos2dx/features/device-info.mdx
@@ -8,9 +8,13 @@ The Adjust SDK contains helper methods that return device information. Use these
 
 ## Adjust device identifier
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 static std::string getAdid();
 ```
+
+</CodeBlock>
 
 Adjust generates a unique Adjust Device ID (ADID) for each device. Call the `getAdid` method to return this ID as a **string**.
 
@@ -20,9 +24,13 @@ std::string adid = Adjust2dx::getAdid();
 
 ## ID For Advertisers
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 static std::string getIdfa();
 ```
+
+</CodeBlock>
 
 The ID for Advertisers (IDFA) is a device-specific identifier for Apple devices. Call the `getIdfa` method to return this ID as a **string**.
 
@@ -32,9 +40,13 @@ std::string idfa = Adjust2dx::getIdfa();
 
 ## Google Play Services Advertising ID
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 static void getGoogleAdId(void (*adIdCallback)(std::string adId));
 ```
+
+</CodeBlock>
 
 The Google Play Services Advertising ID (GPS ADID) is a device-specific identifier for Android devices.
 
@@ -55,9 +67,13 @@ Adjust2dx::getGoogleAdId(adIdCallbackMethod);
 
 ## Amazon Advertiser ID
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 static std::string getAmazonAdId();
 ```
+
+</CodeBlock>
 
 The Amazon Advertising ID (Amazon Ad ID) is a device-specific identifier for Android devices. Call the `getAmazonAdId` method to return this ID as a **string**.
 

--- a/src/content/docs/sdk/cocos2dx/features/events.mdx
+++ b/src/content/docs/sdk/cocos2dx/features/events.mdx
@@ -8,9 +8,13 @@ The Adjust SDK provides an `AdjustEvent2dx` object which can be used to structur
 
 ## Instantiate an AdjustEvent2dx object
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 AdjustEvent2dx(std::string eventToken);
 ```
+
+</CodeBlock>
 
 To send event information with the Adjust SDK, you need to instantiate an `AdjustEvent2dx` object. This object contains variables that are sent to Adjust when an event occurs in your app.
 
@@ -18,23 +22,27 @@ To instantiate an event object, create a new `AdjustEvent2dx` instance and pass 
 
 -  `eventToken` (**String**): Your Adjust [event token](https://help.adjust.com/en/article/add-events#manage-your-events).
 
-```cpp {1}
+```cpp
 AdjustEvent2dx adjustEvent = AdjustEvent2dx("abc123");
 Adjust2dx::trackEvent(adjustEvent);
 ```
 
 ## Send an event
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 static void trackEvent(AdjustEvent2dx event);
 ```
+
+</CodeBlock>
 
 You can associate your [Adjust event tokens](https://help.adjust.com/en/article/add-events#add-event) to actions in your app to record them. To record an event:
 
 -  Create a new Adjust event instance and pass your event token as a string argument.
 -  Call the `trackEvent` method with your event instance as an argument.
 
-```cpp {2}
+```cpp
 AdjustEvent2dx adjustEvent = AdjustEvent2dx("abc123");
 Adjust2dx::trackEvent(adjustEvent);
 ```
@@ -63,7 +71,9 @@ void HelloWorld::onTrackEvent(cocos2d::Ref *pSender) {
 }
 ```
 
-```txt collapse={6-46} title="Event log"
+<CodeBlock title="Event log" collapse="6-46">
+
+```txt
 Path:      /event
 ClientSdk: cocos2d-x4.38.0
 Parameters:
@@ -110,13 +120,20 @@ Parameters:
   time_spent       23
   tracking_enabled 1
   ui_mode          1
+
 ```
+
+</CodeBlock>
 
 ## Record event revenue
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void setRevenue(double amount, std::string currency);
 ```
+
+</CodeBlock>
 
 You can record revenue associated with an event by setting the revenue and currency properties on your event instance. Use this feature to record revenue-generating actions in your app.
 
@@ -165,7 +182,9 @@ void HelloWorld::onTrackRevenueEvent(cocos2d::Ref *pSender) {
 }
 ```
 
-```txt title="Event log" {7,8}
+<CodeBlock title="Event log" highlight="{range: 7-8}">
+
+```txt
 Path:      /event
 ClientSdk: cocos2d-x4.38.0
 Parameters:
@@ -175,6 +194,8 @@ Parameters:
   revenue          0.25
   currency         EUR
 ```
+
+</CodeBlock>
 
 ### Purchase verification
 
@@ -225,9 +246,13 @@ Adjust2dx::trackEvent(adjustEvent);
 
 ## Set a unique order ID
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void setTransactionId(std::string transactionId);
 ```
+
+</CodeBlock>
 
 You can pass an optional identifier to avoid recording duplicate events. The SDK stores the last ten identifiers and skips revenue events with duplicate transaction IDs.
 
@@ -268,7 +293,9 @@ void HelloWorld::onTrackUniqueEvent(cocos2d::Ref *pSender) {
 }
 ```
 
-```txt title="Event log" {7}
+<CodeBlock title="Event log" highlight="{range: 7}">
+
+```txt
 Path:      /event
 ClientSdk: cocos2d-x4.38.0
 Parameters:
@@ -278,11 +305,17 @@ Parameters:
   transaction_id   5e85484b-1ebc-4141-aab7-25b869e54c49
 ```
 
+</CodeBlock>
+
 ## Add callback parameters
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void addCallbackParameter(std::string key, std::string value);
 ```
+
+</CodeBlock>
 
 If you [register a callback URL](https://help.adjust.com/en/article/set-up-callbacks) in the Adjust dashboard, the SDK sends a GET request to your callback URL when it records an event.
 
@@ -290,7 +323,7 @@ You can configure callback parameters to send to your servers. Once you configur
 
 Add callback parameters to your event by calling the `addCallbackParameter` method with **string** key-value arguments. You can add multiple parameters by calling this method multiple times.
 
-```cpp {2,3}
+```cpp
 AdjustEvent2dx adjustEvent = AdjustEvent2dx("abc123");
 adjustEvent.addCallbackParameter("key", "value");
 adjustEvent.addCallbackParameter("foo", "bar");
@@ -299,9 +332,13 @@ Adjust2dx::trackEvent(adjustEvent);
 
 The Adjust SDK measures the event and sends a request to your URL with the callback parameters. For example, if you register the URL `https://www.mydomain.com/callback`, your callback looks like this:
 
-```http "key=value" "foo=bar"
+<CodeBlock highlight="key=value, foo=bar">
+
+```http
 https://www.mydomain.com/callback?key=value&foo=bar
 ```
+
+</CodeBlock>
 
 <Callout type="note">
 
@@ -328,9 +365,13 @@ This example shows how to record an event with the token `g3mfiw` whenever a use
 
 The resulting callback URL looks like this:
 
-```http "event_token=g3mfiw" "revenue_amount=0.05"
+<CodeBlock highlight="event_token=g3mfiw, revenue_amount=0.05">
+
+```http
 http://www.mydomain.com/callback?event_token=g3mfiw&revenue_amount=0.05
 ```
+
+</CodeBlock>
 
 ```cpp
 bool HelloWorld::init() {
@@ -359,7 +400,9 @@ void HelloWorld::onTrackCallbackEvent(cocos2d::Ref *pSender) {
 
 You can check the parameters were sent to Adjust by checking for `callback_params` in your logs.
 
-```txt {4} title="Event log"
+<CodeBlock title="Event log">
+
+```txt
 Path:      /event
 ClientSdk: cocos2d-x4.38.0
 Parameters:
@@ -367,13 +410,20 @@ Parameters:
   environment      sandbox
   event_count      1
   event_token      g3mfiw
+
 ```
+
+</CodeBlock>
 
 ## Add partner parameters
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void addPartnerParameter(std::string key, std::string value);
 ```
+
+</CodeBlock>
 
 You can send extra information to your network partners by adding [partner parameters](https://help.adjust.com/en/article/data-sharing-ad-network#map-parameters).
 
@@ -387,7 +437,7 @@ Partner parameters don't appear in raw data by default. You can add the `{partne
 
 Add partner parameters to your event by calling the `addPartnerParameter` method with **string** key-value arguments. You can add multiple parameters by calling this method multiple times.
 
-```cpp {2,3}
+```cpp
 AdjustEvent2dx adjustEvent = AdjustEvent2dx("abc123");
 adjustEvent.addPartnerParameter("key", "value");
 adjustEvent.addPartnerParameter("foo", "bar");
@@ -428,7 +478,9 @@ void HelloWorld::onTrackPartnerEvent(cocos2d::Ref *pSender) {
 
 You can check the parameters were sent to Adjust by checking for `partner_params` in your logs.
 
-```txt title="Event log" {4}
+<CodeBlock title="Event log" highlight="{range: 4}">
+
+```txt
 Path:      /event
 ClientSdk: cocos2d-x4.38.0
 Parameters:
@@ -438,17 +490,23 @@ Parameters:
   event_token      g3mfiw
 ```
 
+</CodeBlock>
+
 ## Add a callback identifier
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void setCallbackId(std::string callbackId);
 ```
+
+</CodeBlock>
 
 You can add a custom string identifier to each event you want to measure. Adjust's servers can report on this identifier in event callbacks. This enables you to keep track of which events have been successfully measured.
 
 Set up this identifier by calling the `setCallbackId` method with your ID as a **string** argument.
 
-```cpp {2}
+```cpp
 AdjustEvent2dx adjustEvent = AdjustEvent2dx("abc123");
 adjustEvent.setCallbackId("Your-Custom-Id");
 Adjust2dx::trackEvent(adjustEvent);
@@ -481,7 +539,9 @@ void HelloWorld::onTrackCallbackIdEvent(cocos2d::Ref *pSender) {
 }
 ```
 
-```txt title="Event log" {7}
+<CodeBlock title="Event log" highlight="{range: 7}">
+
+```txt
 Path:      /event
 ClientSdk: cocos2d-x4.38.0
 Parameters:
@@ -490,3 +550,5 @@ Parameters:
   event_token      g3mfiw
   callback_id      f2e728d8-271b-49ab-80ea-27830a215147
 ```
+
+</CodeBlock>

--- a/src/content/docs/sdk/cocos2dx/features/privacy.mdx
+++ b/src/content/docs/sdk/cocos2dx/features/privacy.mdx
@@ -8,9 +8,13 @@ The Adjust SDK contains features that you can use to handle user privacy in your
 
 ## Send right to be forgotten request
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 static void gdprForgetMe();
 ```
+
+</CodeBlock>
 
 Article 17 of the European Union's General Data Protection Regulation (GDPR) grants users the right to be forgotten. When Adjust's servers receive a Right to be Forgotten (RTBF) request, Adjust erases the user's data. The SDK also stops sending requests from the device for the app in question.
 
@@ -26,9 +30,13 @@ You can use the Adjust SDK to record when a user changes their third-party shari
 
 ### Instantiate an AdjustThirdPartySharing2dx object
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 AdjustThirdPartySharing2dx(bool isEnabled)
 ```
+
+</CodeBlock>
 
 To enable or disable third party sharing with the Adjust SDK, you need to instantiate an `AdjustThirdPartySharing2dx` object. This object contains variables that control how third party sharing is handled by Adjust.
 
@@ -36,7 +44,7 @@ To instantiate a third party sharing object, create a new `AdjustThirdPartyShari
 
 -  `isEnabled` (**Boolean**): Whether third party sharing is enabled. Pass `true` to enable third party sharing or `false` to disable third party sharing
 
-```cpp {1}
+```cpp
 AdjustThirdPartySharing2dx adjustThirdPartySharing = new AdjustThirdPartySharing2dx(true);
 Adjust2dx::trackThirdPartySharing(adjustThirdPartySharing);
 ```
@@ -49,16 +57,20 @@ If you set the `isEnabled` property to `false`, Adjust stops sharing the user's 
 
 Once you've instantiated your `AdjustThirdPartySharing2dx` object, you can send the information to Adjust by calling the `Adjust2dx::trackThirdPartySharing` method with your `AdjustThirdPartySharing2dx` instance as an argument.
 
-```cpp {2}
+```cpp
 AdjustThirdPartySharing2dx adjustThirdPartySharing = new AdjustThirdPartySharing2dx(false);
 Adjust2dx::trackThirdPartySharing(adjustThirdPartySharing);
 ```
 
 ### Send granular information
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void addGranularOption(std::string partnerName, std::string key, std::string value);
 ```
+
+</CodeBlock>
 
 You can attach granular information when a user updates their third-party sharing preferences. Use this information to communicate more detail about a user's decision. To do this, call the `addGranularOption` method with the following parameters:
 
@@ -85,7 +97,7 @@ The following partners are available:
 
 </Table>
 
-```cpp {2}
+```cpp
 AdjustThirdPartySharing2dx adjustThirdPartySharing = new AdjustThirdPartySharing2dx(true);
 adjustThirdPartySharing.addGranularOption("PartnerA", "foo", "bar");
 Adjust2dx::trackThirdPartySharing(adjustThirdPartySharing);
@@ -119,7 +131,7 @@ If you call this method with a `0` value for **either** `data_processing_options
 
 </Callout>
 
-```cpp {2,3}
+```cpp
 AdjustThirdPartySharing2dx adjustThirdPartySharing = new AdjustThirdPartySharing2dx(true);
 adjustThirdPartySharing.addGranularOption("facebook", "data_processing_options_country", "1");
 adjustThirdPartySharing.addGranularOption("facebook", "data_processing_options_state", "1000");
@@ -146,7 +158,7 @@ To comply with the EU's Digital Markets Act (DMA), Google Ads and the Google Mar
 
 </Table>
 
-```cpp {2-4}
+```cpp
 AdjustThirdPartySharing2dx adjustThirdPartySharing = new AdjustThirdPartySharing2dx(true);
 adjustThirdPartySharing.addGranularOption('google_dma', 'eea', '1');
 adjustThirdPartySharing.addGranularOption('google_dma', 'ad_personalization', '1');
@@ -250,9 +262,13 @@ Adjust2dx::trackThirdPartySharing(adjustThirdPartySharing);
 
 ## Disable third-party sharing
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 static void disableThirdPartySharing();
 ```
+
+</CodeBlock>
 
 To disable third-party sharing for all users, call the `disableThirdPartySharing` method. When Adjust's servers receive this information, Adjust stops sharing the user's data with third-parties. The Adjust SDK continues to work as expected.
 
@@ -262,9 +278,13 @@ Adjust2dx::disableThirdPartySharing;
 
 ## Set URL strategy
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void setUrlStrategy(std::string urlStrategy);
 ```
+
+</CodeBlock>
 
 The URL strategy feature allows you to set either:
 
@@ -290,7 +310,7 @@ To set your country of data residency, call the `setUrlStrategy` method on your 
 
 </Table>
 
-```cpp {2}
+```cpp
 AdjustConfig2dx adjustConfig = AdjustConfig2dx(appToken, environment);
 adjustConfig.setUrlStrategy(AdjustDataResidencyEU);
 Adjust2dx::start(adjustConfig);
@@ -298,9 +318,13 @@ Adjust2dx::start(adjustConfig);
 
 ## Consent measurement for specific users
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 static void trackMeasurementConsent(bool measurementConsent);
 ```
+
+</CodeBlock>
 
 If you're using [Data Privacy settings](https://help.adjust.com/en/article/manage-data-collection-and-retention) in your Adjust dashboard, you need to set up the Adjust SDK to work with them. This includes settings such as consent expiry period and user data retention period.
 
@@ -322,24 +346,32 @@ The Adjust SDK includes the `com.google.android.gms.permission.AD_ID` permission
 
 </MinorVersion>
 
-```xml title="AndroidManifest.xml" 'tools:node="remove"'
+<CodeBlock title="AndroidManifest.xml" highlight={"tools:node=\"remove\""}>
+
+```xml
 <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
 ```
+
+</CodeBlock>
 
 See Google's [`AdvertisingIdClient.Info documentation`](https://developers.google.com/android/reference/com/google/android/gms/ads/identifier/AdvertisingIdClient.Info#public-string-getid) for more information about this permission.
 
 ### COPPA compliance
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void setCoppaCompliantEnabled(bool isEnabled);
 ```
+
+</CodeBlock>
 
 If you need your app to be compliant with the Children's Online Privacy Protection Act (COPPA), call the `setCoppaCompliantEnabled` method. This method performs the following actions:
 
 1. Disables third-party sharing **before** the user launches their first `session`.
 2. Prevents the SDK from reading device and advertising IDs (for example: `gps_adid` and `android_id`).
 
-```cpp {2}
+```cpp
 AdjustConfig2dx adjustConfig = AdjustConfig2dx(appToken, environment);
 adjustConfig.setCoppaCompliantEnabled(true);
 Adjust2dx::start(adjustConfig);
@@ -355,9 +387,13 @@ Disabling COPPA compliance **doesn't** re-enable third-party sharing. You need t
 
 ### Play Store Kids Apps (Android only)
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void setPlayStoreKidsAppEnabled(bool isEnabled);
 ```
+
+</CodeBlock>
 
 If your app targets users under the age of 13, and the install region **isn't** the USA, you need to mark it as a Kids App. This prevents the SDK from reading device and advertising IDs (for example: `gps_adid` and `android_id`).
 
@@ -365,7 +401,7 @@ To mark your app as a Kids App, call the `setPlayStoreKidsAppEnabled` method wit
 
 -  `playStoreKidsAppEnabled` (**Boolean**): set to `true` to mark the app as a Kids App, or `false` to mark the app as a non-Kids App.
 
-```cpp {2}
+```cpp
 AdjustConfig2dx adjustConfig = AdjustConfig2dx(appToken, environment);
 adjustConfig.setPlayStoreKidsAppEnabled(true);
 Adjust2dx::start(adjustConfig);

--- a/src/content/docs/sdk/cocos2dx/features/session-parameters.mdx
+++ b/src/content/docs/sdk/cocos2dx/features/session-parameters.mdx
@@ -18,9 +18,13 @@ You can configure callback parameters to your servers. Once you configure parame
 
 ### Add session callback parameters
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 static void addSessionCallbackParameter(std::string key, std::string value);
 ```
+
+</CodeBlock>
 
 Add callback parameters to your event by calling the `addSessionCallbackParameter` method with **string** key-value arguments. You can add multiple parameters by calling this method multiple times.
 
@@ -30,9 +34,13 @@ Adjust2dx::addSessionCallbackParameter("foo", "bar");
 
 ### Remove session callback parameters
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 static void removeSessionCallbackParameter(std::string key);
 ```
+
+</CodeBlock>
 
 You can remove specific session callback parameters if they're no longer required. To do this, pass the parameter `key` to the `removeSessionCallbackParameter` method.
 
@@ -42,9 +50,13 @@ Adjust2dx::removeSessionCallbackParameter("foo");
 
 ### Reset session callback parameters
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 static void resetSessionCallbackParameters();
 ```
+
+</CodeBlock>
 
 You can remove all session parameters if they're no longer required. To do this, call the `resetSessionCallbackParameters` method.
 
@@ -66,9 +78,13 @@ Partner parameters don't appear in raw data by default. You can add the `{partne
 
 ### Add session partner parameters
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 static void addSessionPartnerParameter(std::string key, std::string value);
 ```
+
+</CodeBlock>
 
 Send partner parameters with your session by calling the `addSessionPartnerParameter` method with **string** key-value arguments. You can add multiple parameters by calling this method multiple times.
 
@@ -78,9 +94,13 @@ Adjust2dx::addSessionPartnerParameter("foo", "bar");
 
 ### Remove session partner parameters
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 static void removeSessionPartnerParameter(std::string key);
 ```
+
+</CodeBlock>
 
 You can remove specific session partner parameters if they're no longer required. To do this, pass the parameter key to the `removeSessionPartnerParameter` method.
 
@@ -90,9 +110,13 @@ Adjust2dx::removeSessionPartnerParameter("foo");
 
 ### Reset session partner parameters
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 static void resetSessionPartnerParameter();
 ```
+
+</CodeBlock>
 
 You can remove all session partner parameters if they're no longer required. To do this, call the `resetSessionPartnerParameters` method.
 
@@ -110,7 +134,7 @@ You can delay the startup of the SDK by up to **10 seconds**.
 
 The Adjust SDK starts as soon as your app opens. If you want to send data that's not available at launch in session parameters, you can delay the start of the SDK. To do this, pass the delay time in seconds to the [`setDelayStart` method](/en/sdk/cocos2dx/configuration#delay-the-start-of-the-sdk) on your config object.
 
-```cpp {3}
+```cpp
 AdjustConfig2dx adjustConfig = AdjustConfig2dx(appToken, environment);
 adjustConfig.setLogLevel(AdjustLogLevel2dxVerbose);
 adjustConfig.setDelayStart(5.5);

--- a/src/content/docs/sdk/cocos2dx/features/skad.mdx
+++ b/src/content/docs/sdk/cocos2dx/features/skad.mdx
@@ -18,9 +18,13 @@ StoreKit Ad Network (SKAdNetwork) is Apple's attribution framework for app insta
 
 ## Disable SKAdNetwork communication
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void deactivateSkAdNetworkHandling();
 ```
+
+</CodeBlock>
 
 <MinorVersion added="v4.23.0">
 
@@ -36,7 +40,7 @@ You must call the `deactivateSKAdNetworkHandling` method _before_ initializing t
 
 </Callout>
 
-```cpp {2}
+```cpp
 AdjustConfig2dx adjustConfig = AdjustConfig2dx(appToken, environment, false);
 adjustConfig.deactivateSKAdNetworkHandling();
 Adjust2dx::start(adjustConfig);
@@ -44,9 +48,13 @@ Adjust2dx::start(adjustConfig);
 
 ## Update conversion values
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 static void updateConversionValue(int conversionValue);
 ```
+
+</CodeBlock>
 
 Conversion values are a mechanism used to track user behavior in SKAdNetwork. You can map 64 conditions to values from 0 through 63 and send this integer value to SKAdNetwork on user install. This gives you insight into how your users interact with your app in the first few days.
 
@@ -78,13 +86,17 @@ void HelloWorld::onUpdateCv(cocos2d::Ref *pSender) {
 
 ## Listen for changes to conversion values
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void setConversionValueUpdatedCallback(void(*callbackMethod)(int conversionValue));
 ```
 
+</CodeBlock>
+
 If you use Adjust to manage conversion values, the Adjust's servers send conversion value updates to the SDK. You can set up a callback function to listen for these changes using the `setConversionValueUpdatedCallback` method. Pass your function as an argument.
 
-```cpp {2}
+```cpp
 AdjustConfig2dx adjustConfig = AdjustConfig2dx(appToken, environment, false);
 adjustConfig.setConversionValueUpdatedCallback(conversionValueUpdatedCallbackMethod);
 Adjust2dx::start(adjustConfig);

--- a/src/content/docs/sdk/cocos2dx/features/subscriptions.mdx
+++ b/src/content/docs/sdk/cocos2dx/features/subscriptions.mdx
@@ -19,9 +19,13 @@ To get started, you need to create a subscription object containing details of t
 <Tabs>
 <Tab title="App Store" sync="appstore" icon="PlatformIos">
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 public: AdjustAppStoreSubscription2dx(std::string price, std::string currency, std::string transactionId, std::string receipt)
 ```
+
+</CodeBlock>
 
 Create an `AdjustAppStoreSubscription2dx` object with the following properties:
 
@@ -48,9 +52,13 @@ AdjustAppStoreSubscription2dx subscription = AdjustAppStoreSubscription2dx(
 </Tab>
 <Tab title="Play Store" sync="playstore" icon="PlatformGooglePlay">
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 public: AdjustPlayStoreSubscription2dx(std::string price, std::string currency, std::string sku, std::string orderId, std::string signature, std::string purchaseToken);
 ```
+
+</CodeBlock>
 
 Create an `AdjustPlayStoreSubscription2dx` object with the following properties:
 
@@ -88,13 +96,17 @@ You can record the date on which the user purchased a subscription. The SDK retu
 <Tabs>
 <Tab title="App Store" sync="appstore" icon="PlatformIos">
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void setTransactionDate(std::string transactionDate);
 ```
 
+</CodeBlock>
+
 Call the `setTransactionDate` method on your subscription object to record the timestamp of the subscription.
 
-```cpp {7}
+```cpp
 AdjustAppStoreSubscription2dx subscription = AdjustAppStoreSubscription2dx(
     price,
     currency,
@@ -107,13 +119,17 @@ subscription.setTransactionDate(transactionDate);
 </Tab>
 <Tab title="Play Store" sync="playstore" icon="PlatformGooglePlay">
 
-```cpp title="Methdo signature"
+<CodeBlock title="Methdo signature">
+
+```cpp
 void setPurchaseTime(std::string purchaseTime);
 ```
 
+</CodeBlock>
+
 Call the `setPurchaseTime` method on your subscription object to record the timestamp of the subscription.
 
-```cpp {9}
+```cpp
 AdjustPlayStoreSubscription2dx subscription = AdjustPlayStoreSubscription2dx(
     price,
     currency,
@@ -130,13 +146,17 @@ subscription.setPurchaseTime(purchaseTime);
 
 ### Record the purchase region (iOS only)
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void setSalesRegion(std::string salesRegion);
 ```
 
+</CodeBlock>
+
 You can record the region in which the user purchased a subscription. To do this, call the `setSalesRegion` method on your subscription object and pass the country code as a **string**. This needs to be formatted as the [`countryCode`](https://developer.apple.com/documentation/foundation/nslocale/1643060-countrycode?language=swift) of the [`priceLocale`](https://developer.apple.com/documentation/storekit/skproduct/1506145-pricelocale?language=swift) object.
 
-```cpp {7}
+```cpp
 AdjustAppStoreSubscription2dx subscription = AdjustAppStoreSubscription2dx(
     price,
     currency,
@@ -153,11 +173,15 @@ You can add callback parameters to your subscription object. The SDK appends the
 <Tabs>
 <Tab title="App Store" sync="appstore" icon="PlatformIos">
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void addCallbackParameter(std::string key, std::string value);
 ```
 
-```cpp {7-8}
+</CodeBlock>
+
+```cpp
 AdjustAppStoreSubscription2dx subscription = AdjustAppStoreSubscription2dx(
     price,
     currency,
@@ -171,11 +195,15 @@ subscription.addCallbackParameter("key2", "value2");
 </Tab>
 <Tab title="Play Store" sync="playstore" icon="PlatformGooglePlay">
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void addCallbackParameter(std::string key, std::string value);
 ```
 
-```cpp {9-10}
+</CodeBlock>
+
+```cpp
 AdjustPlayStoreSubscription2dx subscription = AdjustPlayStoreSubscription2dx(
     price,
     currency,
@@ -198,11 +226,15 @@ You can add partner parameters to your subscription object. The SDK sends these 
 <Tabs>
 <Tab title="App Store" sync="appstore" icon="PlatformIos">
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void addPartnerParameter(std::string key, std::string value);
 ```
 
-```cpp {7-8}
+</CodeBlock>
+
+```cpp
 AdjustAppStoreSubscription2dx subscription = AdjustAppStoreSubscription2dx(
     price,
     currency,
@@ -216,11 +248,15 @@ subscription.addPartnerParameter("key2", "value2");
 </Tab>
 <Tab title="Play Store" sync="playstore" icon="PlatformGooglePlay">
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 void addPartnerParameter(std::string key, std::string value);
 ```
 
-```cpp {9-10}
+</CodeBlock>
+
+```cpp
 AdjustPlayStoreSubscription2dx subscription = AdjustPlayStoreSubscription2dx(
     price,
     currency,
@@ -243,13 +279,17 @@ Once you have set up your subscription object, you can record it using the Adjus
 <Tabs>
 <Tab title="App Store" sync="appstore" icon="PlatformIos">
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 static void trackAppStoreSubscription(AdjustAppStoreSubscription2dx subscription);
 ```
 
+</CodeBlock>
+
 Pass your subscription object to the `trackAppStoreSubscription` method to record the user's subscription purchase.
 
-```cpp {13}
+```cpp
 AdjustAppStoreSubscription2dx subscription = AdjustAppStoreSubscription2dx(
     price,
     currency,
@@ -268,13 +308,17 @@ Adjust2dx::trackAppStoreSubscription(subscription);
 </Tab>
 <Tab title="Play Store" sync="playstore" icon="PlatformGooglePlay">
 
-```cpp title="Method signature"
+<CodeBlock title="Method signature">
+
+```cpp
 static void trackPlayStoreSubscription(AdjustPlayStoreSubscription2dx subscription);
 ```
 
+</CodeBlock>
+
 Pass your subscription object to the `trackPlayStoreSubscription` method to record the user's subscription purchase.
 
-```cpp {14}
+```cpp
 AdjustPlayStoreSubscription2dx subscription = AdjustPlayStoreSubscription2dx(
     price,
     currency,

--- a/src/content/docs/sdk/cocos2dx/index.mdx
+++ b/src/content/docs/sdk/cocos2dx/index.mdx
@@ -26,7 +26,9 @@ To add the SDK to your project:
 2. Copy the C++ files from the `dist` directory and add them to your Cocos2d-x project
 3. (**Android only**): add the paths of the C++ files to the `LOCAL_SRC_FILES` section of your `Android.mk` file.
 
-   ```text title="Android.mk"
+   <CodeBlock title="Android.mk">
+
+   ```text
    $(LOCAL_PATH)/../../../Classes/Adjust/AdjustConfig2dx.cpp \
    $(LOCAL_PATH)/../../../Classes/Adjust/AdjustAttribution2dx.cpp \
    $(LOCAL_PATH)/../../../Classes/Adjust/AdjustProxy2dx.cpp \
@@ -43,6 +45,8 @@ To add the SDK to your project:
    $(LOCAL_PATH)/../../../Classes/Adjust/AdjustAppStorePurchase2dx.cpp \
    $(LOCAL_PATH)/../../../Classes/Adjust/AdjustPlayStorePurchase2dx.cpp \
    ```
+
+   </CodeBlock>
 
 ## 3. Update your project settings
 
@@ -66,16 +70,24 @@ To give the Adjust SDK access to device information, you need to declare which p
 
 Add the following permissions to get access to online features:
 
-```xml title="AndroidManifest.xml"
+<CodeBlock title="AndroidManifest.xml">
+
+```xml
 <uses-permission android:name="android.permission.INTERNET"/>
 <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 ```
 
+</CodeBlock>
+
 If your app doesn't target the Google Play Store, add the following permission to access the device's network state:
 
-```xml title="AndroidManifest.xml"
+<CodeBlock title="AndroidManifest.xml">
+
+```xml
 <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 ```
+
+</CodeBlock>
 
 <MinorVersion changed="4.32.0">
 
@@ -83,15 +95,21 @@ The Adjust SDK includes the `com.google.android.gms.AD_ID` permission by default
 
 </MinorVersion>
 
-```xml title="AndroidManifest.xml" "tools:node="remove""
+<CodeBlock title="AndroidManifest.xml" highlight={"tools:node=\"remove\""}>
+
+```xml
 <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
 ```
+
+</CodeBlock>
 
 #### Set up Proguard
 
 If you're using Proguard to optimize your app, you must add rules to prevent Proguard from removing classes.
 
-```java title="Proguard.pro"
+<CodeBlock title="Proguard.pro">
+
+```java
 -keep class com.adjust.sdk.** { *; }
 -keep class com.google.android.gms.common.ConnectionResult {
    int SUCCESS;
@@ -104,13 +122,20 @@ If you're using Proguard to optimize your app, you must add rules to prevent Pro
    boolean isLimitAdTrackingEnabled();
 }
 -keep public class com.android.installreferrer.** { *; }
+
 ```
+
+</CodeBlock>
 
 If you're not publishing your app in the Google Play Store, add the following rule:
 
-```java title="Proguard.pro"
+<CodeBlock title="Proguard.pro">
+
+```java
 -keep public class com.adjust.sdk.** { *; }
 ```
+
+</CodeBlock>
 
 #### Set up install referrer
 
@@ -126,17 +151,26 @@ The Google Play Referrer API is available to apps that target the Google Play St
 
 To support the Google Play Referrer API, add the following to your `build.gradle` file:
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 dependencies {
    implementation 'com.android.installreferrer:installreferrer:2.2'
 }
+
 ```
+
+</CodeBlock>
 
 If you're using Proguard, remember to add a rule to prevent the dependency from being removed.
 
-```java title="Proguard.pro"
+<CodeBlock title="Proguard.pro">
+
+```java
 -keep public class com.android.installreferrer.** { *; }
 ```
+
+</CodeBlock>
 
 ##### Huawei Referrer API
 
@@ -157,7 +191,9 @@ The Adjust SDK supports the [Meta Install Referrer](https://developers.facebook.
 1. Find your Meta app ID in your [App Dashboard](https://developers.facebook.com/apps). See Meta's [App Dashboard documentation](https://developers.facebook.com/docs/development/create-an-app/app-dashboard) for more information.
 2. [Add the Meta apps to your `AndroidManifest.xml` file](https://developers.facebook.com/docs/app-ads/meta-install-referrer#step-1--add-the-meta-apps).
 
-   ```xml title="AndroidManifest.xml"
+   <CodeBlock title="AndroidManifest.xml">
+
+   ```xml
    <queries>
       <package android:name="com.facebook.katana" />
    </queries>
@@ -166,9 +202,12 @@ The Adjust SDK supports the [Meta Install Referrer](https://developers.facebook.
       <package android:name="com.instagram.android" />
    </queries>
    ```
-3. Pass your App ID as a __string__ argument to the `AdjustConfig2dx.setFbAppId` method.
 
-   ```cpp {2}
+   </CodeBlock>
+
+3. Pass your App ID as a **string** argument to the `AdjustConfig2dx.setFbAppId` method.
+
+   ```cpp
    AdjustConfig2dx adjustConfig = AdjustConfig2dx(appToken, environment, false);
    adjustConfig.setFbAppId("your-fb-app-id");
    Adjust2dx::start(adjustConfig);
@@ -240,21 +279,25 @@ To ensure the Adjust SDK can send session information on Android devices, you mu
 2. Add a call to the `onResume` method in the `applicationWillEnterForeground` method.
 3. Add a call to the `onPause` method in the `applicationDidEnterBackground` method.
 
-```cpp {5, 11}
-#include "Adjust/Adjust2dx.h"
+   <CodeBlock highlight="{range: 5}, {range: 11}">
 
-void AppDelegate::applicationDidEnterBackground() {
-   #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
-      Adjust2dx::onPause();
-   #endif
-}
+   ```cpp
+   #include "Adjust/Adjust2dx.h"
 
-void AppDelegate::applicationWillEnterForeground() {
-   #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
-      Adjust2dx::onResume();
-   #endif
-}
-```
+   void AppDelegate::applicationDidEnterBackground() {
+      #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
+         Adjust2dx::onPause();
+      #endif
+   }
+
+   void AppDelegate::applicationWillEnterForeground() {
+      #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
+         Adjust2dx::onResume();
+      #endif
+   }
+   ```
+
+   </CodeBlock>
 
 ## 6. Build your app
 

--- a/src/content/docs/sdk/flutter/configuration.mdx
+++ b/src/content/docs/sdk/flutter/configuration.mdx
@@ -9,12 +9,17 @@ Use the methods in this document to configure the behavior of the Adjust SDK.
 
 ## [Instantiate your config object](instantiate-your-config-object)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 AdjustConfig(this._appToken, this._environment) {
    _initCallbackHandlers();
    _skAdNetworkHandling = true;
 }
+
 ```
+
+</CodeBlock>
 
 To configure the Adjust SDK, you need to instantiate an `AdjustConfig` object. This object contains the **read-only** configuration options that you need to pass to the Adjust SDK.
 
@@ -23,7 +28,7 @@ To instantiate your config object, create a new `AdjustConfig` instance and pass
 -  `appToken` (`String`): Your [Adjust app token](https://help.adjust.com/en/article/app-token-and-reporting-currency#view-your-app-details).
 -  `environment` (`String`): The environment you want to run the SDK in. Pass `AdjustEnvironment.sandbox` to run the SDK in sandbox mode for testing. Pass `AdjustEnvironment.production` to run the SDK in production mode for release.
 
-```dart {1}
+```dart
 AdjustConfig adjustConfig = new AdjustConfig('{YourAppToken}', AdjustEnvironment.sandbox);
 //...
 Adjust.start(adjustConfig);
@@ -35,9 +40,13 @@ Adjust.start(adjustConfig);
 
 ### [Set your logging level](set-your-logging-level)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 AdjustLogLevel? logLevel;
 ```
+
+</CodeBlock>
 
 The Adjust SDK provides configurable log levels to return different amounts of information. The following log levels are available:
 
@@ -59,7 +68,7 @@ You can set your log level by assigning an `AdjustLogLevel` value to the `logLev
 
 -  `logLevel` (`AdjustLogLevel`): The log level you want to use.
 
-```dart {3}
+```dart
 AdjustConfig adjustConfig = new AdjustConfig('{YourAppToken}', AdjustEnvironment.Sandbox);
 //...
 adjustConfig.logLevel = AdjustLogLevel.verbose;
@@ -69,9 +78,13 @@ Adjust.start(adjustConfig);
 
 ### [Set external device identifier](set-external-device-identifier)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 String? externalDeviceId;
 ```
+
+</CodeBlock>
 
 An external device identifier is a custom value that you can assign to a device or user. They help you recognize users across sessions and platforms. They can also help you deduplicate installs by user so that a user isn't counted as duplicate new installs. Contact your Adjust representative to get started with external device IDs.
 
@@ -85,7 +98,7 @@ See the [External device identifiers article](https://help.adjust.com/en/article
 
 </Callout>
 
-```dart {3}
+```dart
 AdjustConfig adjustConfig = new AdjustConfig('{YourAppToken}', AdjustEnvironment.Sandbox);
 //...
 adjustConfig.externalDeviceId = '{Your-External-Device-Id}';
@@ -99,15 +112,19 @@ You can import existing external device IDs into Adjust. This ensures that the A
 
 ### [Set default link token](set-default-link-token)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 String? defaultTracker;
 ```
+
+</CodeBlock>
 
 You can configure a default link token if your app is preinstalled on a device. When a user opens the preinstalled app for the first time, the install is attributed to the default link token. Assign your default link token to the `defaultTracker` property of your config instance.
 
 -  `defaultTracker` (`String`): The [Adjust link token](https://help.adjust.com/en/article/links#adjust-link-token) you want to record preinstalled installs against.
 
-```dart {3}
+```dart
 AdjustConfig adjustConfig = new AdjustConfig('{YourAppToken}', AdjustEnvironment.Sandbox);
 //...
 adjustConfig.defaultTracker = '{TrackerToken}';
@@ -117,9 +134,13 @@ Adjust.start(adjustConfig);
 
 ### [Enable cost data sending](enable-cost-data-sending)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 bool? needsCost;
 ```
+
+</CodeBlock>
 
 By default, the Adjust SDK doesn't send cost data as part of a user's attribution. You can configure the SDK to send this data by enabling cost data sending. To enable cost data sending, assign a `bool` value to the `needsCost` property of your config instance.
 
@@ -127,7 +148,7 @@ By default, the Adjust SDK doesn't send cost data as part of a user's attributio
 
 Cost data is accessible in the user's [attribution information](/en/sdk/flutter/features/attribution).
 
-```dart {3}
+```dart
 AdjustConfig adjustConfig = new AdjustConfig('{YourAppToken}', AdjustEnvironment.Sandbox);
 //...
 adjustConfig.needsCost = true;
@@ -137,15 +158,19 @@ Adjust.start(adjustConfig);
 
 ### [Enable background recording](enable-background-recording)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 bool? sendInBackground;
 ```
+
+</CodeBlock>
 
 By default, the Adjust SDK pauses the sending of requests when your app is running in the background. You can configure the SDK to send requests in the background by enabling the background recording. To enable background recording, assign a `bool` value to the `sendInBackground` property of your config instance.
 
 -  `sendInBackground` (`bool`): Set to `true` to enable background sending or `false` to disable background sending.
 
-```dart {3}
+```dart
 AdjustConfig adjustConfig = new AdjustConfig('{YourAppToken}', AdjustEnvironment.Sandbox);
 //...
 adjustConfig.sendInBackground = true;
@@ -155,9 +180,13 @@ Adjust.start(adjustConfig);
 
 ### [Enable event buffering](enable-event-buffering)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 bool? eventBufferingEnabled;
 ```
+
+</CodeBlock>
 
 The Adjust SDK sends event information as soon as a user triggers an event in your app. You can send event information on a schedule by enabling event buffering. Event buffering stores events in a local buffer on the device and sends all requests once per minute.
 
@@ -165,7 +194,7 @@ Your config object contains a boolean `eventBufferingEnabled` property that cont
 
 -  `eventBufferingEnabled` (`bool`): Set to `true` to enable event buffering or `false` to disable event buffering.
 
-```dart {3}
+```dart
 AdjustConfig adjustConfig = new AdjustConfig('{YourAppToken}', AdjustEnvironment.Sandbox);
 //...
 adjustConfig.eventBufferingEnabled = true;
@@ -175,9 +204,13 @@ Adjust.start(adjustConfig);
 
 ### [Delay the start of the SDK](delay-the-start-of-the-sdk)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 double? delayStart;
 ```
+
+</CodeBlock>
 
 By default, the Adjust SDK starts as soon as your app opens. If you want to send data that isn't available at launch in [session parameters](/en/sdk/flutter/features/session-parameters), you can delay the start of the SDK. This can be helpful if you are sending information such as unique identifiers.
 
@@ -185,7 +218,7 @@ To configure a startup delay, assign a `double` value to the `delayStart` proper
 
 -  `delayStart` (`double`): The time (in seconds) by which to delay the start of the SDK. You can delay the start of the SDK by up to **10 seconds**.
 
-```dart {3}
+```dart
 AdjustConfig adjustConfig = new AdjustConfig('{YourAppToken}', AdjustEnvironment.Sandbox);
 //...
 adjustConfig.delayStart(5.5);
@@ -199,9 +232,13 @@ Adjust.start(adjustConfig);
 
 ### [Toggle offline mode](toggle-offline-mode)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 static void setOfflineMode(bool isOffline)
 ```
+
+</CodeBlock>
 
 <Callout type="important">
 
@@ -221,9 +258,13 @@ Adjust.setOfflineMode(true);
 
 ### [Set push tokens](set-push-tokens)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 static void setPushToken(String token)
 ```
+
+</CodeBlock>
 
 Push tokens are used for [Audiences](https://help.adjust.com/en/article/audiences) and client callbacks. They're also required for [Uninstall and reinstall measurement](https://help.adjust.com/en/article/uninstalls-reinstalls).
 
@@ -249,9 +290,13 @@ You can only call this method after the first session. This setting persists bet
 
 </Callout>
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 static void setEnabled(bool isEnabled)
 ```
+
+</CodeBlock>
 
 The Adjust SDK runs by default when your app is open. You can disable and re-enable the Adjust SDK to pause and resume recording. When you disable the Adjust SDK, it doesn't send any data to Adjust's servers.
 
@@ -265,9 +310,13 @@ Adjust.setEnabled(false);
 
 #### [Check enabled status](check-enabled-status)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 static Future<bool> isEnabled() async
 ```
+
+</CodeBlock>
 
 You can check if the Adjust SDK is enabled at any time by calling the `isEnabled` method. This method returns a `bool` value indicating if the SDK is **enabled** (`true`) or **disabled** (`false`).
 

--- a/src/content/docs/sdk/flutter/features/ad-revenue.mdx
+++ b/src/content/docs/sdk/flutter/features/ad-revenue.mdx
@@ -14,12 +14,17 @@ You need to perform some extra setup steps in your Adjust dashboard to measure a
 
 ## [Instantiate an AdjustAdRevenue object](instantiate-an-adjustadrevenue-object)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 AdjustAdRevenue(this._source) {
    _callbackParameters = new Map<String, String>();
    _partnerParameters = new Map<String, String>();
 }
+
 ```
+
+</CodeBlock>
 
 To send ad revenue information with the Adjust SDK, you need to instantiate an `AdjustAdRevenue` object. This object contains variables that are sent to Adjust when ad revenue is recorded in your app.
 
@@ -50,16 +55,21 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 ## [Send ad revenue](send-ad-revenue)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 static void trackAdRevenue(String source, String payload) {
    _channel
       .invokeMethod('trackAdRevenue', {'source': source, 'payload': payload});
 }
+
 ```
+
+</CodeBlock>
 
 To send ad revenue to Adjust, call the `trackAdRevenue` method with your ad revenue instance as an argument.
 
-```dart {3}
+```dart
 AdjustAdRevenue adjustAdRevenue = new AdjustAdRevenue("source");
 //...
 Adjust.trackAdRevenue(adjustAdRevenue);
@@ -67,12 +77,17 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 ## [Record ad revenue amount](record-ad-revenue-amount)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 void setRevenue(num revenue, String currency) {
    _revenue = revenue;
    _currency = currency;
 }
+
 ```
+
+</CodeBlock>
 
 To send the ad revenue amount, call the `setRevenue` method and pass the following arguments:
 
@@ -85,7 +100,7 @@ Check the [guide to recording purchases in different currencies](https://help.ad
 
 </Callout>
 
-```dart {3}
+```dart
 AdjustAdRevenue adjustAdRevenue = new AdjustAdRevenue("source");
 //...
 adjustAdRevenue.setRevenue(1.00, "EUR");
@@ -99,13 +114,17 @@ The `AdjustAdRevenue` class contains properties you can use to report on your ad
 
 ### [Ad impressions](ad-impressions)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 num? adImpressionsCount;
 ```
 
+</CodeBlock>
+
 To send the number of recorded ad impressions, assign a `num` value to the `adImpressionsCount` property of your ad revenue instance.
 
-```dart {3}
+```dart
 AdjustAdRevenue adjustAdRevenue = new AdjustAdRevenue("source");
 //...
 adjustAdRevenue.adImpressionsCount = 10;
@@ -115,13 +134,17 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 ### [Ad revenue network](ad-revenue-network)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 String? adRevenueNetwork;
 ```
 
+</CodeBlock>
+
 To send the ad revenue network, assign the network name as a `String` value to the `adRevenueNetwork` property of your ad revenue instance.
 
-```dart {3}
+```dart
 AdjustAdRevenue adjustAdRevenue = new AdjustAdRevenue("source");
 //...
 adjustAdRevenue.adRevenueNetwork = "network1";
@@ -131,13 +154,17 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 ### [Ad revenue unit](ad-revenue-unit)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 String? adRevenueUnit;
 ```
 
+</CodeBlock>
+
 To send the ad revenue unit, assign the unit as a `String` value to the `adRevenueUnit` property of your ad revenue instance.
 
-```dart {3}
+```dart
 AdjustAdRevenue adjustAdRevenue = new AdjustAdRevenue("source");
 //...
 adjustAdRevenue.adRevenueUnit = "unit1";
@@ -147,13 +174,17 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 ### [Ad revenue placement](ad-revenue-placement)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 String? adRevenuePlacement;
 ```
 
+</CodeBlock>
+
 To send the ad revenue placement, assign the placement as a `String` value to the `adRevenuePlacement` property of your ad revenue instance.
 
-```dart {3}
+```dart
 AdjustAdRevenue adjustAdRevenue = new AdjustAdRevenue("source");
 //...
 adjustAdRevenue.adRevenuePlacement = "banner";
@@ -163,11 +194,16 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 ## [Add callback parameters](add-callback-parameters)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 void addCallbackParameter(String key, String value) {
    _callbackParameters![key] = value;
 }
+
 ```
+
+</CodeBlock>
 
 If you [register a callback URL](https://help.adjust.com/en/article/recommended-placeholders-callbacks) in the Adjust dashboard, the SDK sends a GET request to your callback URL when it records an event.
 
@@ -177,9 +213,13 @@ Add callback parameters to your event by calling the `addCallbackParameter` meth
 
 The Adjust SDK measures the event and sends a request to your URL with the callback parameters. For example, if you register the URL `https://www.mydomain.com/callback`, your callback looks like this:
 
-```http "key=value" "foo=bar"
+<CodeBlock highlight="key=value, foo=bar">
+
+```http
 https://www.mydomain.com/callback?key=value&foo=bar
 ```
+
+</CodeBlock>
 
 <Callout type="note">
 
@@ -197,7 +237,7 @@ You can read more about using URL callbacks, including a full list of available 
 
 </Callout>
 
-```dart {3}
+```dart
 AdjustAdRevenue adjustAdRevenue = new AdjustAdRevenue("source");
 //...
 adjustAdRevenue.addCallbackParameter("key", "value")
@@ -207,11 +247,16 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 ## [Add partner parameters](add-partner-parameters)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 void addPartnerParameter(String key, String value) {
    _partnerParameters![key] = value;
 }
+
 ```
+
+</CodeBlock>
 
 You can send extra information to your network partners by adding [partner parameters](https://help.adjust.com/en/article/data-sharing-ad-network#map-parameters).
 
@@ -225,7 +270,7 @@ Partner parameters don't appear in raw data by default. You can add the `{partne
 
 Add partner parameters to your event by calling the `addPartnerParameter` method with `String` key-value arguments. You can add multiple parameters by calling this method multiple times.
 
-```dart {3}
+```dart
 AdjustAdRevenue adjustAdRevenue = new AdjustAdRevenue("source");
 //...
 adjustAdRevenue.addPartnerParameter("key", "value");

--- a/src/content/docs/sdk/flutter/features/att.mdx
+++ b/src/content/docs/sdk/flutter/features/att.mdx
@@ -27,9 +27,13 @@ You might receive a status code of `-1` if the SDK is unable to retrieve the ATT
 
 ## [ATT authorization wrapper](att-authorization-wrapper)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 static Future<num> requestTrackingAuthorizationWithCompletionHandler() async
 ```
+
+</CodeBlock>
 
 The Adjust SDK contains a wrapper around [Apple's `requestTrackingAuthorizationWithCompletionHandler` method](https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanager/3547037-requesttrackingauthorizationwith). You can use this wrapper if you don't want to customize the ATT prompt.
 
@@ -68,7 +72,9 @@ if (Platform.isIOS) {
 
 This example shows how to log a human-readable description of the user's authorization status when they interact with a prompt.
 
-```dart title="main.dart"
+<CodeBlock title="main.dart">
+
+```dart
 import 'package:adjust_sdk/adjust.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -103,13 +109,20 @@ Adjust.requestTrackingAuthorizationWithCompletionHandler().then((status) {
 
    Adjust.start(config);
 }
+
 ```
+
+</CodeBlock>
 
 ## [Get current authorization status](get-current-authorization-status)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 static Future<int> getAppTrackingAuthorizationStatus() async
 ```
+
+</CodeBlock>
 
 You can retrieve a user's current authorization status at any time. Call the `getAppTrackingAuthorizationStatus` method to return the authorization status code as an **integer**.
 
@@ -128,9 +141,13 @@ Adjust.addSessionPartnerParameter("status", authorizationStatus);
 
 ## [Check for authorization status changes](check-for-authorization-status-changes)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 static void checkForNewAttStatus()
 ```
+
+</CodeBlock>
 
 If you use a custom ATT prompt, you need to inform the Adjust SDK of changes to the user's authorization status. Call the `checkForNewAttStatus` method to send the authorization status to Adjust's servers.
 
@@ -140,9 +157,13 @@ Adjust.checkForNewAttStatus();
 
 ## [Custom prompt timing](custom-prompt-timing)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 num? attConsentWaitingInterval;
 ```
+
+</CodeBlock>
 
 If your app includes an onboarding process or a tutorial, you may want to delay sending your user's ATT consent status until after the user has completed this process. To do this, you can set the `attConsentWaitingInterval` property to delay the sending of data for **up to 120 seconds** to give the user time to complete the initial onboarding. After the timeout ends or the user sets their consent status, the SDK sends all information it has recorded during the delay to Adjust's servers along with the user's consent status.
 
@@ -152,7 +173,7 @@ If the user closes the app before the timeout ends, or before they select their 
 
 </Callout>
 
-```dart {3}
+```dart
 AdjustConfig adjustConfig = new AdjustConfig('{YourAppToken}', AdjustEnvironment.Sandbox);
 //...
 adjustConfig.attConsentWaitingInterval = 30;

--- a/src/content/docs/sdk/flutter/features/attribution.mdx
+++ b/src/content/docs/sdk/flutter/features/attribution.mdx
@@ -41,10 +41,15 @@ The following values can only be accessed if the [`needsCost` property on your `
 
 ## [Trigger a function when attribution changes](trigger-a-function-when-attribution-changes)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 typedef void AttributionCallback(AdjustAttribution attributionData);
 AttributionCallback? attributionCallback;
+
 ```
+
+</CodeBlock>
 
 The SDK can listen for attribution changes and call a function when it detects an update. To configure your callback function, assign your function to the `attributionCallback` property on your config instance.
 
@@ -54,7 +59,7 @@ You must call the `attributionCallback` method **before** initializing the Adjus
 
 </Callout>
 
-```dart {2-29}
+```dart
 AdjustConfig adjustConfig = new AdjustConfig(yourAppToken, environment);
 config.attributionCallback = (AdjustAttribution attributionChangedData) {
    print('[Adjust]: Attribution changed!');
@@ -89,9 +94,13 @@ Adjust.start(adjustConfig);
 
 ## [Get current attribution information](get-current-attribution-information)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 static Future<AdjustAttribution> getAttribution() async
 ```
+
+</CodeBlock>
 
 When a user installs your app, Adjust attributes the install to a campaign. The Adjust SDK gives you access to campaign attribution details for your install. To return this information, call the `getAttribution` method to return the attribution information as an `AdjustAttribution` object.
 

--- a/src/content/docs/sdk/flutter/features/callbacks.mdx
+++ b/src/content/docs/sdk/flutter/features/callbacks.mdx
@@ -32,10 +32,15 @@ Session callbacks have access to a response data object. You can use its propert
 
 ### [Success callbacks](success-callbacks)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 typedef void SessionSuccessCallback(AdjustSessionSuccess successData);
 SessionSuccessCallback? sessionSuccessCallback;
+
 ```
+
+</CodeBlock>
 
 Set up success callbacks to trigger functions when the SDK records a session.
 
@@ -66,7 +71,7 @@ Adjust.start(adjustConfig);
 
 This example shows how to register a `sessionSuccessCallback` that prints the timestamp at which the SDK sent the session data to Adjust.
 
-```dart {3-5}
+```dart
 AdjustConfig myConfig = new AdjustConfig('{Your App Token}', AdjustEnvironment.sandbox);
 //...
 myConfig.sessionSuccessCallback = (AdjustSessionSuccess sessionSuccessData) {
@@ -78,10 +83,15 @@ Adjust.start(myConfig);
 
 ### [Failure callbacks](failure-callbacks)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 typedef void SessionFailureCallback(AdjustSessionFailure failureData);
 SessionFailureCallback? sessionFailureCallback;
+
 ```
+
+</CodeBlock>
 
 Set up failure callbacks to trigger functions when the SDK fails to record a session.
 
@@ -115,7 +125,7 @@ Adjust.start(adjustConfig);
 
 This example shows how to register a `sessionFailureCallback` that prints the reason the SDK failed to send the session data.
 
-```dart {3-5}
+```dart
 AdjustConfig myConfig = new AdjustConfig('{Your App Token}', AdjustEnvironment.sandbox);
 //...
 myConfig.sessionFailureCallback = (AdjustSessionFailure sessionFailureData) {
@@ -147,10 +157,15 @@ Event callbacks have access to a response data object. You can use its propertie
 
 ### [Success callbacks](success-callbacks-1)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 typedef void EventSuccessCallback(AdjustEventSuccess successData);
 EventSuccessCallback? eventSuccessCallback;
+
 ```
+
+</CodeBlock>
 
 Set up success callbacks to trigger functions when the SDK records an event.
 
@@ -187,7 +202,7 @@ Adjust.start(adjustConfig);
 
 This example shows how to register a `eventSuccessCallback` that prints the timestamp at which the SDK sent the event data to Adjust.
 
-```dart {3-5}
+```dart
 AdjustConfig myConfig = new AdjustConfig('{Your App Token}', AdjustEnvironment.sandbox);
 //...
 myConfig.eventSuccessCallback = (AdjustEventSuccess eventSuccessData) {
@@ -199,10 +214,15 @@ Adjust.start(myConfig);
 
 ### [Failure callbacks](failure-callbacks-1)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 typedef void EventFailureCallback(AdjustEventFailure failureData);
 EventFailureCallback? eventFailureCallback;
+
 ```
+
+</CodeBlock>
 
 Set up failure callbacks to trigger functions when the SDK fails to record an event.
 
@@ -242,7 +262,7 @@ Adjust.start(adjustConfig);
 
 This example shows how to register a `eventFailureCallback` that prints the reason the SDK failed to send the event data.
 
-```dart {3-5}
+```dart
 AdjustConfig myConfig = new AdjustConfig('{Your App Token}', AdjustEnvironment.sandbox);
 //...
 myConfig.eventFailureCallback = (AdjustEventFailure eventFailureData) {

--- a/src/content/docs/sdk/flutter/features/deep-links.mdx
+++ b/src/content/docs/sdk/flutter/features/deep-links.mdx
@@ -34,9 +34,13 @@ To reattribute your user, you need to call the `appWillOpenUrl` method when the 
 <Tabs>
 <Tab title="iOS" sync="ios" icon="PlatformIos">
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (void)appWillOpenUrl:(nonnull NSURL *)url;
 ```
+
+</CodeBlock>
 
 To enable deep linking for iOS, call the `appWillOpenUrl` method with a `true` value inside your app delegate.
 
@@ -71,7 +75,7 @@ class AppDelegate {
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 #import "Adjust.h"
 
 @implementation AppDelegate
@@ -102,9 +106,13 @@ class AppDelegate {
 </Tab>
 <Tab title="Android" sync="android" icon="PlatformAndroid">
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public static void appWillOpenUrl(Uri url, Context context)
 ```
+
+</CodeBlock>
 
 To enable deep linking for Android, call the `appWillOpenUrl` method with a `true` value inside your main activity.
 
@@ -175,13 +183,17 @@ public class MainActivity extends FlutterActivity {
 
 ## [Deferred deep linking](deferred-deep-linking)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 bool? launchDeferredDeeplink;
 ```
 
+</CodeBlock>
+
 The SDK opens deferred deep links by default. No additional setup is required. You can disable this by setting the `launchDeferredDeeplink` property on your config instance to **false**.
 
-```dart {3}
+```dart
 AdjustConfig adjustConfig = new AdjustConfig('{YourAppToken}', AdjustEnvironment.Sandbox);
 //...
 adjustConfig.launchDeferredDeeplink = false;
@@ -191,14 +203,19 @@ Adjust.start(adjustConfig);
 
 ### [Set up a deferred deep link callback](set-up-a-deferred-deep-link-callback)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 typedef void DeferredDeeplinkCallback(String? uri);
 DeferredDeeplinkCallback? deferredDeeplinkCallback;
+
 ```
+
+</CodeBlock>
 
 You can configure the Adjust SDK to call a function when it receives a deferred deep link by adding a function to the `deferredDeeplinkCallback` property on your config instance. This function receives the deep link as a `String` argument.
 
-```dart {2-4}
+```dart
 AdjustConfig adjustConfig = new AdjustConfig(yourAppToken, environment);
 adjustConfig.deferredDeeplinkCallback = (String uri) {
    print('[Adjust]: Received deferred deeplink: ' + uri);
@@ -229,9 +246,13 @@ initPlatformState() async {
 
 ### [Enable LinkMe](enable-linkme)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 bool? linkMeEnabled
 ```
+
+</CodeBlock>
 
 The Adjust SDK lets you copy deep link information from the device pasteboard. When combined with Adjust’s LinkMe solution, this feature enables deferred deep linking on devices running iOS 15 and above.
 
@@ -245,7 +266,7 @@ When a user clicks on a LinkMe URL they have the option to copy the link informa
 
 To enable pasteboard checking in your app, set the `linkMeEnabled` property to `true` on your config object:
 
-```dart {3}
+```dart
 AdjustConfig adjustConfig = new AdjustConfig('{YourAppToken}', AdjustEnvironment.Sandbox);
 //...
 adjustConfig.linkMeEnabled = true;

--- a/src/content/docs/sdk/flutter/features/device-info.mdx
+++ b/src/content/docs/sdk/flutter/features/device-info.mdx
@@ -8,9 +8,13 @@ The Adjust SDK contains helper methods that return device information. Use these
 
 ## [Adjust device identifier](adjust-device-identifier)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 static Future<String?> getAdid() async
 ```
+
+</CodeBlock>
 
 Adjust generates a unique Adjust Device ID (ADID) for each device. Call the `getAdid` method to return this ID as a `String`.
 
@@ -22,9 +26,13 @@ Adjust.getAdid().then((adid) {
 
 ## [ID For Advertisers](id-for-advertisers)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 static Future<String?> getIdfa() async
 ```
+
+</CodeBlock>
 
 The ID for Advertisers (IDFA) is a device-specific identifier for Apple devices. Call the `getIdfa` method to return this ID as a `String`.
 
@@ -36,9 +44,13 @@ Adjust.getIdfa().then((idfa) {
 
 ## [Google Play Services Advertising ID](google-play-services-advertising-id)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 static Future<String?> getGoogleAdId() async
 ```
+
+</CodeBlock>
 
 The Google Play Services Advertising ID (GPS ADID) is a device-specific identifier for Android devices.
 
@@ -54,9 +66,13 @@ Adjust.getGoogleAdId().then((googleAdId) {
 
 ## [Amazon Advertiser ID](amazon-advertiser-id)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 static Future<String?> getAmazonAdId() async
 ```
+
+</CodeBlock>
 
 The Amazon Advertising ID (Amazon Ad ID) is a device-specific identifier for Android devices. Call the `getAmazonAdId` method to return this ID as a `String`.
 

--- a/src/content/docs/sdk/flutter/features/events.mdx
+++ b/src/content/docs/sdk/flutter/features/events.mdx
@@ -8,9 +8,13 @@ The Adjust SDK provides an `AdjustEvent` object which can be used to structure a
 
 ## [Instantiate an AdjustEvent object](instantiate-an-adjustevent-object)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 AdjustEvent(string eventToken)
 ```
+
+</CodeBlock>
 
 To send event information with the Adjust SDK, you need to instantiate an `AdjustEvent` object. This object contains variables that are sent to Adjust when an event occurs in your app.
 
@@ -18,7 +22,7 @@ To instantiate an event object, create a new `AdjustEvent` instance and pass the
 
 -  `eventToken` (`String`): Your Adjust [event token](https://help.adjust.com/en/article/add-events#manage-your-events).
 
-```dart {1}
+```dart
 AdjustEvent myAdjustEvent = new AdjustEvent('abc123');
 //...
 Adjust.trackEvent(myAdjustEvent);
@@ -26,16 +30,20 @@ Adjust.trackEvent(myAdjustEvent);
 
 ## [Send an event](send-an-event)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 static void trackEvent(AdjustEvent event)
 ```
+
+</CodeBlock>
 
 You can associate your [Adjust event tokens](https://help.adjust.com/en/article/add-events#add-event) to actions in your app to record them. To record an event:
 
 -  Create a new Adjust event instance and pass your event token as a string argument.
 -  Call the `trackEvent` method with your event instance as an argument.
 
-```dart {3}
+```dart
 AdjustEvent myAdjustEvent = new AdjustEvent('abc123');
 //...
 Adjust.trackEvent(myAdjustEvent);
@@ -45,7 +53,9 @@ Adjust.trackEvent(myAdjustEvent);
 
 This example shows how to record an event with the token `g3mfiw` whenever a user interacts with a button.
 
-```dart title="util.dart"
+<CodeBlock title="util.dart">
+
+```dart
 import 'package:adjust_sdk/adjust_event.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -75,7 +85,11 @@ Util.buildCupertinoButton('Track Simple Event',
 const Padding(padding: const EdgeInsets.all(7.0))
 ```
 
-```txt collapse={6-46} title="Event log"
+</CodeBlock>
+
+<CodeBlock title="Event log" collapse="6-46">
+
+```txt
 Path:      /event
 ClientSdk: flutter$FLUTTER_VERSION
 Parameters:
@@ -124,11 +138,17 @@ Parameters:
   ui_mode          1
 ```
 
+</CodeBlock>
+
 ## [Record event revenue](record-event-revenue)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 void setRevenue(Num revenue, String currency)
 ```
+
+</CodeBlock>
 
 You can record revenue associated with an event by setting the revenue and currency properties on your event instance. Use this feature to record revenue-generating actions in your app.
 
@@ -143,7 +163,7 @@ Check the guide to [recording purchases in different currencies](https://help.ad
 
 </Callout>
 
-```dart {3}
+```dart
 AdjustEvent myAdjustEvent = new AdjustEvent('abc123');
 //...
 adjustEvent.setRevenue(0.01, 'EUR');
@@ -155,7 +175,9 @@ Adjust.trackEvent(myAdjustEvent);
 
 This example shows how to record an event with the token `g3mfiw` whenever a user interacts with a button. The function sets the `revenue` property of this event to _`0.25`_ and the `currency` property to _`EUR`_.
 
-```dart title="util.dart"
+<CodeBlock title="util.dart">
+
+```dart
 import 'package:adjust_sdk/adjust_event.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -187,9 +209,14 @@ import 'util.dart';
 Util.buildCupertinoButton('Send Revenue Event',
    () => Adjust.trackEvent(Util.myAdjustEvent())),
 const Padding(padding: const EdgeInsets.all(7.0))
+
 ```
 
-```txt title="Event log" {7,8}
+</CodeBlock>
+
+<CodeBlock title="Event log" highlight="{range: 7-8}">
+
+```txt
 Path:      /event
 ClientSdk: flutter$FLUTTER_VERSION
 Parameters:
@@ -200,17 +227,23 @@ Parameters:
   currency         EUR
 ```
 
+</CodeBlock>
+
 ## [Deduplicate revenue events](deduplicate-revenue-events)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 String? transactionId;
 ```
+
+</CodeBlock>
 
 You can pass an optional identifier to avoid recording duplicate events. The SDK stores the last ten identifiers and skips revenue events with duplicate transaction IDs.
 
 To set the identifier, assign your transaction ID to the `setTransactionId` property of your event instance.
 
-```dart {3}
+```dart
 AdjustEvent myAdjustEvent = new AdjustEvent('abc123');
 //...
 myAdjustEvent.transactionId = '{TransactionId}';
@@ -222,7 +255,9 @@ Adjust.trackEvent(myAdjustEvent);
 
 This example shows how to record an event with the token `g3mfiw` whenever a user interacts with a button. The function sets the `uniqueId` to `5e85484b-1ebc-4141-aab7-25b869e54c49` using the `setTransactionId` method.
 
-```dart title="util.dart"
+<CodeBlock title="util.dart">
+
+```dart
 import 'package:adjust_sdk/adjust_event.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -255,9 +290,14 @@ import 'util.dart';
 Util.buildCupertinoButton('Send Revenue Event',
    () => Adjust.trackEvent(Util.myAdjustEvent())),
 const Padding(padding: const EdgeInsets.all(7.0))
+
 ```
 
-```txt title="Event log" {7}
+</CodeBlock>
+
+<CodeBlock title="Event log" highlight="{range: 7}">
+
+```txt
 Path:      /event
 ClientSdk: flutter$FLUTTER_VERSION
 Parameters:
@@ -267,11 +307,17 @@ Parameters:
   transaction_id   5e85484b-1ebc-4141-aab7-25b869e54c49
 ```
 
+</CodeBlock>
+
 ## [Add callback parameters](add-callback-parameters)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 void addCallbackParameter(String key, String value)
 ```
+
+</CodeBlock>
 
 If you [register a callback URL](https://help.adjust.com/en/article/set-up-callbacks) in the Adjust dashboard, the SDK sends a GET request to your callback URL when it records an event.
 
@@ -279,7 +325,7 @@ You can configure callback parameters to send to your servers. Once you configur
 
 Add callback parameters to your event by calling the `addCallbackParameter` method with `String` key-value arguments. You can add multiple parameters by calling this method multiple times.
 
-```dart {3}
+```dart
 AdjustEvent myAdjustEvent = new AdjustEvent('abc123');
 //...
 adjustEvent.addCallbackParameter('key', 'value');
@@ -318,11 +364,17 @@ This example shows how to record an event with the token `g3mfiw` whenever a use
 
 The resulting callback URL looks like this:
 
-```http "event_token=g3mfiw" "revenue_amount=0.05"
+<CodeBlock highlight="event_token=g3mfiw, revenue_amount=0.05">
+
+```http
 http://www.mydomain.com/callback?event_token=g3mfiw&revenue_amount=0.05
 ```
 
-```dart title="util.dart"
+</CodeBlock>
+
+<CodeBlock title="util.dart">
+
+```dart
 import 'package:adjust_sdk/adjust_event.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -357,7 +409,11 @@ Util.buildCupertinoButton('Send Callback Event',
 const Padding(padding: const EdgeInsets.all(7.0))
 ```
 
-```txt {4} title="Event log"
+</CodeBlock>
+
+<CodeBlock title="Event log" highlight="{range: 4}">
+
+```txt
 Path:      /event
 ClientSdk: flutter$FLUTTER_VERSION
 Parameters:
@@ -367,11 +423,17 @@ Parameters:
   event_token      g3mfiw
 ```
 
+</CodeBlock>
+
 ## [Add partner parameters](add-partner-parameters)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 void addPartnerParameter(String key, String value)
 ```
+
+</CodeBlock>
 
 You can send extra information to your network partners by adding [partner parameters](https://help.adjust.com/en/article/data-sharing-ad-network#map-parameters).
 
@@ -385,7 +447,7 @@ Partner parameters don't appear in raw data by default. You can add the `{partne
 
 Add partner parameters to your event by calling the `addPartnerParameter` method with `String` key-value arguments. You can add multiple parameters by calling this method multiple times.
 
-```dart {3}
+```dart
 AdjustEvent myAdjustEvent = new AdjustEvent('abc123');
 //...
 adjustEvent.addPartnerParameter('key', 'value');
@@ -400,7 +462,9 @@ This example shows how to record an event with the token `g3mfiw` whenever a use
 -  The `product_id` of the associated product
 -  The `user_id` of the user who triggered the event
 
-```dart title="util.dart"
+<CodeBlock title="util.dart">
+
+```dart
 import 'package:adjust_sdk/adjust_event.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -435,7 +499,11 @@ Util.buildCupertinoButton('Send Partner Event',
 const Padding(padding: const EdgeInsets.all(7.0))
 ```
 
-```txt title="Event log" {4}
+</CodeBlock>
+
+<CodeBlock title="Event log" highlight="{range: 4}">
+
+```txt
 Path:      /event
 ClientSdk: flutter$FLUTTER_VERSION
 Parameters:
@@ -445,17 +513,23 @@ Parameters:
   event_token      g3mfiw
 ```
 
+</CodeBlock>
+
 ## [Add a callback identifier](add-a-callback-identifier)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 String? callbackId;
 ```
+
+</CodeBlock>
 
 You can add a custom string identifier to each event you want to measure. Adjust's servers can report on this identifier in event callbacks. This enables you to keep track of which events have been successfully measured.
 
 Set up this identifier by assigning your ID to the `callbackId` property on your event instance.
 
-```dart {3}
+```dart
 AdjustEvent myAdjustEvent = new AdjustEvent('abc123');
 //...
 myAdjustEvent.callbackId = '{your_callback_id}';
@@ -467,7 +541,11 @@ Adjust.trackEvent(myAdjustEvent);
 
 This example shows how to record an event with the token `g3mfiw` whenever a user interacts with a button. In this example, the `callbackId` is set to `f2e728d8-271b-49ab-80ea-27830a215147`.
 
-```dart title="util.dart"
+<CodeBlock title="util.dart">
+
+<CodeBlock title="util.dart">
+
+```dart
 import 'package:adjust_sdk/adjust_event.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -497,9 +575,16 @@ import 'util.dart';
 Util.buildCupertinoButton('Send Callback Event',
    () => Adjust.trackEvent(Util.myAdjustEvent())),
 const Padding(padding: const EdgeInsets.all(7.0))
+
 ```
 
-```txt title="Event log" {7}
+</CodeBlock>
+
+</CodeBlock>
+
+<CodeBlock title="Event log" highlight="{range: 7}">
+
+```txt
 Path:      /event
 ClientSdk: flutter$FLUTTER_VERSION
 Parameters:
@@ -508,3 +593,5 @@ Parameters:
   event_token      g3mfiw
   callback_id      f2e728d8-271b-49ab-80ea-27830a215147
 ```
+
+</CodeBlock>

--- a/src/content/docs/sdk/flutter/features/preinstalled.mdx
+++ b/src/content/docs/sdk/flutter/features/preinstalled.mdx
@@ -8,7 +8,7 @@ You can use the Adjust SDK to record activity from apps that came preinstalled o
 
 Your config object contains a `bool` `preinstallTrackingEnabled` property that controls this feature. To enable preinstall measurement, assign a `bool` value to the `preinstallTrackingEnabled` property of your config object.
 
-```dart {3}
+```dart
 AdjustConfig adjustConfig = new AdjustConfig('{YourAppToken}', AdjustEnvironment.Sandbox);
 //...
 adjustConfig.preinstallTrackingEnabled = true;
@@ -22,13 +22,13 @@ Configuring a default link token enables you to attribute all preinstalls to a p
 
 1. [Create a new campaign link in Campaign Lab](https://help.adjust.com/en/article/links).
 
-   ```text "{token}"
+   ```text
    https://app.adjust.com/{token}
    ```
 
 2. Copy this token and assign it to the [`defaultTracker` property](/en/sdk/flutter/configuration#set-default-link-token) of your config object.
 
-   ```dart {3}
+   ```dart
    AdjustConfig adjustConfig = new AdjustConfig('{YourAppToken}', AdjustEnvironment.Sandbox);
    //...
    adjustConfig.defaultTracker = '{TrackerToken}';

--- a/src/content/docs/sdk/flutter/features/privacy.mdx
+++ b/src/content/docs/sdk/flutter/features/privacy.mdx
@@ -8,9 +8,13 @@ The Adjust SDK contains features that you can use to handle user privacy in your
 
 ## [Send erasure request](send-erasure-request)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 static void gdprForgetMe()
 ```
+
+</CodeBlock>
 
 The EU’s General Data Protection Regulation (GDPR) and similar privacy laws worldwide (CCPA, LGPD, etc.) grant data subjects comprehensive rights when it comes to the processing of their personal data. These rights include, among others, the right to erasure (see [Art. 17 GDPR](https://gdpr.eu/article-17-right-to-be-forgotten/))([1](https://help.adjust.com/en/article/gdpr#ref-1)). As a data processor, Adjust is obliged to support you (the data controller) in the processing of such requests from your (app) users.
 
@@ -29,9 +33,13 @@ You can use the Adjust SDK to record when a user changes their third-party shari
 
 ### [Instantiate an AdjustThirdPartySharing object](instantiate-an-adjustthirdpartysharing-object)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 AdjustThirdPartySharing(bool? _isEnabled)
 ```
+
+</CodeBlock>
 
 To enable or disable third party sharing with the Adjust SDK, you need to instantiate an `AdjustThirdPartySharing` object. This object contains variables that control how third party sharing is handled by Adjust.
 
@@ -39,7 +47,7 @@ To instantiate a third party sharing object, create a new `AdjustThirdPartyShari
 
 -  `isEnabled` (`bool`): Whether third party sharing is enabled. Pass `true` to enable third party sharing or `false` to disable third party sharing
 
-```dart {1}
+```dart
 AdjustThirdPartySharing adjustThirdPartySharing = new AdjustThirdPartySharing(true);
 //...
 Adjust.trackThirdPartySharing(adjustThirdPartySharing);
@@ -53,7 +61,7 @@ If you set the `isEnabled` property to `false`, Adjust stops sharing the user's 
 
 Once you've instantiated your `AdjustThirdPartySharing` object, you can send the information to Adjust by calling the `Adjust.trackThirdPartySharing` method with your `AdjustThirdPartySharing` instance as an argument.
 
-```dart {3}
+```dart
 AdjustThirdPartySharing adjustThirdPartySharing = new AdjustThirdPartySharing(false);
 //...
 Adjust.trackThirdPartySharing(adjustThirdPartySharing);
@@ -61,9 +69,13 @@ Adjust.trackThirdPartySharing(adjustThirdPartySharing);
 
 ### [Send granular information](send-granular-information)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 void addGranularOption(String partnerName, String key, String value)
 ```
+
+</CodeBlock>
 
 You can attach granular information when a user updates their third-party sharing preferences. Use this information to communicate more detail about a user's decision. To do this, call the `addGranularOption` method with the following parameters:
 
@@ -90,7 +102,7 @@ The following partners are available:
 
 </Table>
 
-```dart {3}
+```dart
 AdjustThirdPartySharing adjustThirdPartySharing = new AdjustThirdPartySharing(null);
 //...
 adjustThirdPartySharing.addGranularOption("PartnerA", "key", "value");
@@ -126,7 +138,7 @@ If you call this method with a `0` value for **either** `data_processing_options
 
 </Callout>
 
-```dart {3,4}
+```dart
 AdjustThirdPartySharing adjustThirdPartySharing = new AdjustThirdPartySharing(null);
 //...
 adjustThirdPartySharing.addGranularOption("facebook", "data_processing_options_country", "1");
@@ -263,9 +275,13 @@ Adjust.trackThirdPartySharing(adjustThirdPartySharing);
 
 ## [Disable third-party sharing](disable-third-party-sharing)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 static void disableThirdPartySharing()
 ```
+
+</CodeBlock>
 
 To disable third-party sharing for all users, call the `disableThirdPartySharing` method. When Adjust's servers receive this information, Adjust stops sharing the user's data with third-parties. The Adjust SDK continues to work as expected.
 
@@ -275,9 +291,13 @@ Adjust.disableThirdPartySharing();
 
 ## [Set URL strategy](set-url-strategy)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 String? urlStrategy;
 ```
+
+</CodeBlock>
 
 The URL strategy feature allows you to set either:
 
@@ -301,7 +321,7 @@ To set your country of data residency, assign one of the following URL strategie
 
 </Table>
 
-```dart {3}
+```dart
 AdjustConfig adjustConfig = new AdjustConfig('{YourAppToken}', AdjustEnvironment.Sandbox);
 //...
 adjustConfig.urlStrategy = AdjustConfig.DataResidencyEU;
@@ -311,9 +331,13 @@ Adjust.start(adjustConfig);
 
 ## [Consent measurement for specific users](consent-measurement-for-specific-users)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 static void trackMeasurementConsent(bool measurementConsent)
 ```
+
+</CodeBlock>
 
 If you're using [Data Privacy settings](https://help.adjust.com/en/article/manage-data-collection-and-retention) in your Adjust dashboard, you need to set up the Adjust SDK to work with them. This includes settings such as consent expiry period and user data retention period.
 
@@ -335,24 +359,32 @@ The Adjust SDK includes the `com.google.android.gms.permission.AD_ID` permission
 
 </MinorVersion>
 
-```xml title="AndroidManifest.xml" 'tools:node="remove"'
+<CodeBlock title="AndroidManifest.xml" highlight={"tools:node=\"remove\""}>
+
+```xml
 <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
 ```
+
+</CodeBlock>
 
 See Google's [`AdvertisingIdClient.Info documentation`](https://developers.google.com/android/reference/com/google/android/gms/ads/identifier/AdvertisingIdClient.Info#public-string-getid) for more information about this permission.
 
 ### [COPPA compliance](coppa-compliance)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 bool? coppaCompliantEnabled
 ```
+
+</CodeBlock>
 
 If you need your app to be compliant with the Children's Online Privacy Protection Act (COPPA), assign a `bool` value to the `coppaCompliantEnabled` property on your config instance. Setting this property to `true`:
 
 1. Disables third-party sharing **before** the user launches their first `session`.
 2. Prevents the SDK from reading device and advertising IDs (for example: `gps_adid` and `android_id`).
 
-```dart {3}
+```dart
 AdjustConfig adjustConfig = new AdjustConfig('{YourAppToken}', AdjustEnvironment.Sandbox);
 //...
 adjustConfig.coppaCompliantEnabled = true;
@@ -370,15 +402,19 @@ Disabling COPPA compliance **doesn't** re-enable third-party sharing. You need t
 
 ### [Play Store Kids Apps (Android only)](play-store-kids-apps-android-only)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 bool? playStoreKidsAppEnabled
 ```
+
+</CodeBlock>
 
 If your app targets users under the age of 13, and the install region **isn't** the USA, you need to mark it as a Kids App. This prevents the SDK from reading device and advertising IDs (for example: `gps_adid` and `android_id`).
 
 To mark your app as a Kids App, assign a `bool` value to the `playStoreKidsAppEnabled` property on your config instance. Set to `true` to mark the app as a Kids App, or `false` to mark the app as a non-Kids App.
 
-```dart {3}
+```dart
 AdjustConfig adjustConfig = new AdjustConfig('{YourAppToken}', AdjustEnvironment.Sandbox);
 //...
 adjustConfig.playStoreKidsAppEnabled = true;

--- a/src/content/docs/sdk/flutter/features/session-parameters.mdx
+++ b/src/content/docs/sdk/flutter/features/session-parameters.mdx
@@ -18,9 +18,13 @@ You can configure callback parameters to your servers. Once you configure parame
 
 ### [Add session callback parameters](add-session-callback-parameters)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 static void addSessionCallbackParameter(String key, String value)
 ```
+
+</CodeBlock>
 
 Add callback parameters to your event by calling the `addSessionCallbackParameter` method with `String` key-value arguments. You can add multiple parameters by calling this method multiple times.
 
@@ -30,9 +34,13 @@ Adjust.addSessionCallbackParameter('key', 'value');
 
 ### [Remove session callback parameters](remove-session-callback-parameters)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 static void removeSessionCallbackParameter(String key)
 ```
+
+</CodeBlock>
 
 You can remove specific session callback parameters if they're no longer required. To do this, pass the parameter `key` to the `removeSessionCallbackParameter` method.
 
@@ -42,9 +50,13 @@ Adjust.removeSessionCallbackParameter('key');
 
 ### [Reset session callback parameters](reset-session-callback-parameters)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 static void resetSessionCallbackParameters()
 ```
+
+</CodeBlock>
 
 You can remove all session parameters if they're no longer required. To do this, call the `resetSessionCallbackParameters` method.
 
@@ -66,9 +78,13 @@ Partner parameters don't appear in raw data by default. You can add the `{partne
 
 ### [Add session partner parameters](add-session-partner-parameters)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 static void addSessionPartnerParameter(String key, String value)
 ```
+
+</CodeBlock>
 
 Send partner parameters with your session by calling the `addSessionPartnerParameter` method with `String` key-value arguments. You can add multiple parameters by calling this method multiple times.
 
@@ -78,9 +94,13 @@ Adjust.addSessionPartnerParameter('key', 'value');
 
 ### [Remove session partner parameters](remove-session-partner-parameters)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 static void removeSessionPartnerParameter(String key)
 ```
+
+</CodeBlock>
 
 You can remove specific session partner parameters if they're no longer required. To do this, pass the parameter key to the `removeSessionPartnerParameter` method.
 
@@ -90,9 +110,13 @@ Adjust.removeSessionPartnerParameter('key');
 
 ### [Reset session partner parameters](reset-session-partner-parameters)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 static void resetSessionPartnerParameters()
 ```
+
+</CodeBlock>
 
 You can remove all session partner parameters if they're no longer required. To do this, call the `resetSessionPartnerParameters` method.
 
@@ -110,7 +134,7 @@ You can delay the startup of the SDK by up to **10 seconds**.
 
 The Adjust SDK starts as soon as your app opens. If you want to send data that's not available at launch in session parameters, you can delay the start of the SDK. To do this, assign a delay time in seconds to the [`delayStart` property](/en/sdk/flutter/configuration#delay-the-start-of-the-sdk) on your config object.
 
-```dart {3}
+```dart
 AdjustConfig adjustConfig = new AdjustConfig('{YourAppToken}', AdjustEnvironment.Sandbox);
 //...
 adjustConfig.delayStart(5.5);

--- a/src/content/docs/sdk/flutter/features/skad.mdx
+++ b/src/content/docs/sdk/flutter/features/skad.mdx
@@ -18,9 +18,13 @@ StoreKit Ad Network (SKAdNetwork) is Apple's attribution framework for app insta
 
 ## [Disable SKAdNetwork communication](disable-skadnetwork-communication)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 void deactivateSKAdNetworkHandling()
 ```
+
+</CodeBlock>
 
 <MinorVersion added="v4.23.0">
 
@@ -36,7 +40,7 @@ You must call the `deactivateSKAdNetworkHandling` method _before_ initializing t
 
 </Callout>
 
-```dart {3}
+```dart
 AdjustConfig adjustConfig = new AdjustConfig('{YourAppToken}', AdjustEnvironment.Sandbox, true);
 //...
 adjustConfig.deactivateSKAdNetworkHandling();
@@ -46,9 +50,13 @@ Adjust.start(adjustConfig);
 
 ## [Update conversion values](update-conversion-values)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 static void updateConversionValue(int conversionValue)
 ```
+
+</CodeBlock>
 
 Conversion values are a mechanism used to measure user behavior in SKAdNetwork. You can map 64 conditions to values from `0` through `63` and send this integer value to SKAdNetwork on user install. This gives you insight into how your users interact with your app in the first few days.
 
@@ -60,13 +68,17 @@ Adjust.updateConversionValue(6);
 
 ## [Listen for changes to conversion values](listen-for-changes-to-conversion-values)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 typedef void ConversionValueUpdatedCallback(num? conversionValue);
 ```
 
+</CodeBlock>
+
 If you use Adjust to manage conversion values, the Adjust's servers send conversion value updates to the SDK. You can set up a delegate function to listen for these changes using the `conversionValueUpdatedCallback` method. Pass your function as an argument.
 
-```dart {2-4}
+```dart
 AdjustConfig adjustConfig = new AdjustConfig(yourAppToken, environment);
 config.conversionValueUpdatedCallback = (num? conversionValue) {
    print('[Adjust]: Received conversion value update: ' + conversionValue!.toString());
@@ -81,7 +93,9 @@ This example shows how to log the following when the conversion value updates:
 -  A message confirming the conversion value update
 -  The new conversion value
 
-```dart title="main.dart"
+<CodeBlock title="main.dart">
+
+```dart
 import 'package:adjust_sdk/adjust.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -100,4 +114,7 @@ config.conversionValueUpdatedCallback = (num? conversionValue) {
 Adjust.start(config);
 
 }
+
 ```
+
+</CodeBlock>

--- a/src/content/docs/sdk/flutter/features/subscriptions.mdx
+++ b/src/content/docs/sdk/flutter/features/subscriptions.mdx
@@ -19,9 +19,13 @@ To get started, you need to create a subscription object containing details of t
 <Tabs>
 <Tab title="App Store" sync="appstore" icon="PlatformIos">
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 AdjustAppStoreSubscription(String _price, String _currency, String _transactionId, String _receipt)
 ```
+
+</CodeBlock>
 
 Create an `AdjustAppStoreSubscription` object with the following properties:
 
@@ -47,9 +51,13 @@ AdjustAppStoreSubscription subscription = new AdjustAppStoreSubscription(
 </Tab>
 <Tab title="Play Store" sync="playstore" icon="PlatformGooglePlay">
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 AdjustPlayStoreSubscription(String _price, String _currency, String _sku, String _orderId, String _signature, String _purchaseToken)
 ```
+
+</CodeBlock>
 
 Create an `AdjustPlayStoreSubscription` object with the following properties:
 
@@ -86,13 +94,17 @@ You can record the date on which the user purchased a subscription. The SDK retu
 <Tabs>
 <Tab title="App Store" sync="appstore" icon="PlatformIos">
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 void setTransactionDate(String _transactionDate)
 ```
 
+</CodeBlock>
+
 Call the `setTransactionDate` method on your subscription object to record the timestamp of the subscription.
 
-```dart {7}
+```dart
 AdjustAppStoreSubscription subscription = new AdjustAppStoreSubscription(
    price,
    currency,
@@ -105,13 +117,17 @@ subscription.setTransactionDate(transactionDate);
 </Tab>
 <Tab title="Play Store" sync="playstore" icon="PlatformGooglePlay">
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 void setPurchaseTime(String purchaseTime)
 ```
 
+</CodeBlock>
+
 Call the `setPurchaseTime` method on your subscription object to record the timestamp of the subscription.
 
-```dart {8}
+```dart
 AdjustPlayStoreSubscription subscription = new AdjustPlayStoreSubscription(
    price,
    currency,
@@ -127,13 +143,17 @@ subscription.setPurchaseTime(purchaseTime);
 
 ### [Record the purchase region (iOS only)](record-the-purchase-region-ios-only)
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 void setSalesRegion(String _salesRegion)
 ```
 
+</CodeBlock>
+
 You can record the region in which the user purchased a subscription. To do this, call the `setSalesRegion` method on your subscription object and pass the country code as a `String`. This needs to be formatted as the [`countryCode`](https://developer.apple.com/documentation/foundation/nslocale/1643060-countrycode?language=swift) of the [`priceLocale`](https://developer.apple.com/documentation/storekit/skproduct/1506145-pricelocale?language=swift) object.
 
-```dart {7}
+```dart
 AdjustAppStoreSubscription subscription = new AdjustAppStoreSubscription(
    price,
    currency,
@@ -150,11 +170,15 @@ You can add callback parameters to your subscription object. The SDK appends the
 <Tabs>
 <Tab title="App Store" sync="appstore" icon="PlatformIos">
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 void addCallbackParameter(String key, String value)
 ```
 
-```dart {7-8}
+</CodeBlock>
+
+```dart
 AdjustAppStoreSubscription subscription = new AdjustAppStoreSubscription(
    price,
    currency,
@@ -168,11 +192,15 @@ subscription.addCallbackParameter('key2', 'value2');
 </Tab>
 <Tab title="Play Store" sync="playstore" icon="PlatformGooglePlay">
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 void addCallbackParameter(String key, String value)
 ```
 
-```dart {9-10}
+</CodeBlock>
+
+```dart
 AdjustPlayStoreSubscription subscription = new AdjustPlayStoreSubscription(
    price,
    currency,
@@ -195,11 +223,15 @@ You can add partner parameters to your subscription object. The SDK sends these 
 <Tabs>
 <Tab title="App Store" sync="appstore" icon="PlatformIos">
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 void addPartnerParameter(String key, String value)
 ```
 
-```dart {7-8}
+</CodeBlock>
+
+```dart
 AdjustAppStoreSubscription subscription = new AdjustAppStoreSubscription(
    price,
    currency,
@@ -213,11 +245,15 @@ subscription.addPartnerParameter('key2', 'value2');
 </Tab>
 <Tab title="Play Store" sync="playstore" icon="PlatformGooglePlay">
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 void addPartnerParameter(String key, String value)
 ```
 
-```dart {9-10}
+</CodeBlock>
+
+```dart
 AdjustPlayStoreSubscription subscription = new AdjustPlayStoreSubscription(
    price,
    currency,
@@ -240,13 +276,17 @@ Once you have set up your subscription object, you can record it using the Adjus
 <Tabs>
 <Tab title="App Store" sync="appstore" icon="PlatformIos">
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 static void trackAppStoreSubscription(AdjustAppStoreSubscription subscription)
 ```
 
+</CodeBlock>
+
 Pass your subscription object to the `trackAppStoreSubscription` method to record the user's subscription purchase.
 
-```dart {13}
+```dart
 AdjustAppStoreSubscription subscription = new AdjustAppStoreSubscription(
    price,
    currency,
@@ -265,13 +305,17 @@ Adjust.trackAppStoreSubscription(subscription);
 </Tab>
 <Tab title="Play Store" sync="playstore" icon="PlatformGooglePlay">
 
-```dart title="Method signature"
+<CodeBlock title="Method signature">
+
+```dart
 static void trackPlayStoreSubscription(AdjustPlayStoreSubscription subscription)
 ```
 
+</CodeBlock>
+
 Pass your subscription object to the `trackPlayStoreSubscription` method to record the user's subscription purchase.
 
-```dart {14}
+```dart
 AdjustPlayStoreSubscription subscription = new AdjustPlayStoreSubscription(
    price,
    currency,

--- a/src/content/docs/sdk/flutter/index.mdx
+++ b/src/content/docs/sdk/flutter/index.mdx
@@ -22,10 +22,14 @@ To import the Adjust SDK to your Flutter project, follow these steps:
 
 1. Add the following to your `pubspec.yaml` file:
 
-```yaml title="pubspec.yaml"
+<CodeBlock title="pubspec.yaml">
+
+```yaml
 dependencies:
    adjust_sdk: ^$FLUTTER_VERSION
 ```
+
+</CodeBlock>
 
 2. Navigate to your project and run the following command. Visual Studio automatically runs this command after you edit the `pubspec.yaml` file.
 
@@ -39,9 +43,13 @@ $ flutter packages get
 
 Apps that target the Google Play Store must use the [Google Advertising ID](https://support.google.com/googleplay/android-developer/answer/6048248?hl=en) (`gps_adid`) to identify devices. To do this, add the following dependency to the `dependencies` section of your `build.gradle` file.
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
 ```
+
+</CodeBlock>
 
 <Callout type="note">
 
@@ -53,10 +61,15 @@ The Adjust SDK isn't tied to any version of the `play-services-ads-identifier` d
 
 The Adjust SDK requires the following permissions. Add them to your `AndroidManifest.xml` file if they're not already present:
 
-```xml title="AndroidManifest.xml"
+<CodeBlock title="AndroidManifest.xml">
+
+```xml
 <uses-permission android:name="android.permission.INTERNET"/>
 <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+
 ```
+
+</CodeBlock>
 
 <MinorVersion changed="v4.32.0">
 
@@ -64,9 +77,13 @@ The Adjust SDK includes the `com.google.android.gms.AD_ID` permission by default
 
 </MinorVersion>
 
-```xml title="AndroidManifest.xml"
+<CodeBlock title="AndroidManifest.xml">
+
+```xml
 <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
 ```
+
+</CodeBlock>
 
 <Callout type="seealso">
 
@@ -78,7 +95,9 @@ See Google's [`AdvertisingIdClient.Info documentation`](https://developers.googl
 
 If you are using Proguard, add the following rules to your [custom Proguard file](https://docs.unity3d.com/Manual/class-PlayerSettingsAndroid.html#build).
 
-```java title="proguard.pro"
+<CodeBlock title="proguard.pro">
+
+```java
 -keep public class com.adjust.sdk.** { *; }
 -keep class com.google.android.gms.common.ConnectionResult {
    int SUCCESS;
@@ -91,13 +110,20 @@ If you are using Proguard, add the following rules to your [custom Proguard file
    boolean isLimitAdTrackingEnabled();
 }
 -keep public class com.android.installreferrer.** { *; }
+
 ```
+
+</CodeBlock>
 
 If you aren't publishing your app in the Google Play Store, add the following rule to your Proguard file.
 
-```java title="proguard.pro"
+<CodeBlock title="proguard.pro">
+
+```java
 -keep public class com.adjust.sdk.** { *; }
 ```
+
+</CodeBlock>
 
 ### [Set up install referrer](set-up-install-referrer)
 
@@ -116,15 +142,23 @@ The install referrer is a unique identifier which you can use to attribute an ap
 
 To support the Google Play Referrer API, add the following in your `build.gradle` file:
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 implementation 'com.android.installreferrer:installreferrer:2.2'
 ```
 
+</CodeBlock>
+
 If you are using Proguard, make sure you have added the following setting in your Proguard file:
 
-```java title="proguard.pro"
+<CodeBlock title="proguard.pro">
+
+```java
 -keep public class com.android.installreferrer.** { *; }
 ```
+
+</CodeBlock>
 
 #### [Huawei Referrer API](huawei-referrer-api)
 
@@ -151,7 +185,7 @@ The Adjust SDK supports the [Meta Install Referrer](https://developers.facebook.
 1. Find your Meta app ID in your [App Dashboard](https://developers.facebook.com/apps). See Meta's [App Dashboard documentation](https://developers.facebook.com/docs/development/create-an-app/app-dashboard) for more information.
 2. Assign your App ID to the `fbAppId` property on your `AdjustConfig` instance.
 
-   ```dart {2}
+   ```dart
    AdjustConfig config = new AdjustConfig('{YourAppToken}', AdjustEnvironment.sandbox);
    config.fbAppId = "<FB_APP_ID_STRING>";
    ```

--- a/src/content/docs/sdk/ios/configuration.mdx
+++ b/src/content/docs/sdk/ios/configuration.mdx
@@ -51,7 +51,7 @@ let adjustConfig = ADJConfig(
 
 <CodeBlock highlight="{range: 3-4}">
 
-```objective-c
+```objc
 NSString *yourAppToken = @"{YourAppToken}";
  ADJConfig *adjustConfig = [[ADJConfig alloc] initWithAppToken:yourAppToken
                                                    andEnvironment:environment];
@@ -64,7 +64,7 @@ NSString *yourAppToken = @"{YourAppToken}";
 
 <CodeBlock highlight="{range: 4}">
 
-```javascript
+```js
 setupWebViewJavascriptBridge(function (bridge) {
    var yourAppToken = yourAppToken;
    var environment = AdjustConfig.EnvironmentSandbox;
@@ -133,7 +133,7 @@ adjustConfig?.logLevel = ADJLogLevelVerbose
 
 <CodeBlock highlight="{range: 6}">
 
-```objective-c
+```objc
 NSString *yourAppToken = @"{YourAppToken}";
 NSString *environment = ADJEnvironmentSandbox;
  ADJConfig *adjustConfig = [[ADJConfig alloc] initWithAppToken:yourAppToken
@@ -149,7 +149,7 @@ NSString *environment = ADJEnvironmentSandbox;
 
 <CodeBlock highlight="{range: 6}">
 
-```javascript
+```js
 setupWebViewJavascriptBridge(function (bridge) {
    // ...
    var yourAppToken = yourAppToken;
@@ -278,7 +278,7 @@ Adjust.initSdk(adjustConfig)
 
 <CodeBlock highlight="{range: 3}">
 
-```objective-c
+```objc
 ADJConfig *adjustConfig = [[ADJConfig alloc] initWithAppToken:appToken
                                                    andEnvironment:environment];
 [adjustConfig setDefaultTracker:@"{Token}"];
@@ -292,7 +292,7 @@ ADJConfig *adjustConfig = [[ADJConfig alloc] initWithAppToken:appToken
 
 <CodeBlock highlight="{range: 5}">
 
-```javascript
+```js
 setupWebViewJavascriptBridge(function (bridge) {
    var yourAppToken = yourAppToken;
    var environment = AdjustConfig.EnvironmentSandbox;
@@ -359,7 +359,7 @@ NSString *environment = ADJEnvironmentSandbox;
 
 <CodeBlock highlight="{range: 5}">
 
-```js {5}
+```js
 setupWebViewJavascriptBridge(function (bridge) {
    var yourAppToken = yourAppToken;
    var environment = AdjustConfig.EnvironmentSandbox;
@@ -599,11 +599,16 @@ Use the methods in this document to configure the behavior of the Adjust SDK.
 
 ## [Instantiate your config object](instantiate-your-config-object)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (nullable ADJConfig *)configWithAppToken:(nonnull NSString *)appToken
                                environment:(nonnull NSString *)environment
                      allowSuppressLogLevel:(BOOL)allowSuppressLogLevel;
+
 ```
+
+</CodeBlock>
 
 To configure the Adjust SDK, you need to instantiate an `ADJConfig` object. This object contains the **read-only** configuration options that you need to pass to the Adjust SDK.
 
@@ -616,7 +621,7 @@ To instantiate your config object, create a new `ADJConfig` instance and pass th
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {3-5}
+```swift
 let yourAppToken = "{YourAppToken}"
 let environment = ADJEnvironmentSandbox as? String
 let adjustConfig = ADJConfig(
@@ -627,7 +632,7 @@ let adjustConfig = ADJConfig(
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c {3-4}
+```objc
 NSString *yourAppToken = @"{YourAppToken}";
 NSString *environment = ADJEnvironmentSandbox;
 *adjustConfig = [ADJConfig configWithAppToken:yourAppToken
@@ -637,7 +642,7 @@ NSString *environment = ADJEnvironmentSandbox;
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```javascript {4}
+```js
 setupWebViewJavascriptBridge(function (bridge) {
    var yourAppToken = yourAppToken;
    var environment = AdjustConfig.EnvironmentSandbox;
@@ -654,9 +659,13 @@ setupWebViewJavascriptBridge(function (bridge) {
 
 ### [Set your logging level](set-your-logging-level)
 
-```objc title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```objc
 @property (nonatomic, assign) ADJLogLevel logLevel;
 ```
+
+</CodeBlock>
 
 The Adjust SDK provides configurable log levels to return different amounts of information. The following log levels are available:
 
@@ -681,7 +690,7 @@ You can set your log level by assigning an `ADJLogLevel` value to the `logLevel`
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {7}
+```swift
 let yourAppToken = "{YourAppToken}"
 let environment = ADJEnvironmentSandbox as? String
 let adjustConfig = ADJConfig(
@@ -694,7 +703,7 @@ adjustConfig?.logLevel = ADJLogLevelVerbose
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c {6}
+```objc
 NSString *yourAppToken = @"{YourAppToken}";
 NSString *environment = ADJEnvironmentSandbox;
 *adjustConfig = [ADJConfig configWithAppToken:yourAppToken
@@ -706,7 +715,7 @@ NSString *environment = ADJEnvironmentSandbox;
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```javascript {6}
+```js
 setupWebViewJavascriptBridge(function (bridge) {
    // ...
    var yourAppToken = yourAppToken;
@@ -721,9 +730,13 @@ setupWebViewJavascriptBridge(function (bridge) {
 
 ### [Set external device identifier](set-external-device-identifier)
 
-```objc title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```objc
 @property (nonatomic, copy, nullable) NSString *externalDeviceId;
 ```
+
+</CodeBlock>
 
 An external device identifier is a custom value that you can assign to a device or user. They help you recognize users across sessions and platforms. They can also help you deduplicate installs by user so that a user isn't counted as duplicate new installs. Contact your Adjust representative to get started with external device IDs.
 
@@ -740,7 +753,7 @@ See the [External device identifiers article](https://help.adjust.com/en/article
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {7}
+```swift
 let yourAppToken = "{YourAppToken}"
 let environment = ADJEnvironmentSandbox as? String
 let adjustConfig = ADJConfig(
@@ -753,7 +766,7 @@ adjustConfig?.externalDeviceId = "yourExternalDeviceId"
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {6}
+```objc
 NSString *yourAppToken = @"{YourAppToken}";
 NSString *environment = ADJEnvironmentSandbox;
 *adjustConfig = [ADJConfig configWithAppToken:yourAppToken
@@ -765,7 +778,7 @@ NSString *environment = ADJEnvironmentSandbox;
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {5}
+```js
 setupWebViewJavascriptBridge(function (bridge) {
    var yourAppToken = yourAppToken;
    var environment = AdjustConfig.EnvironmentSandbox;
@@ -783,9 +796,13 @@ You can import existing external device IDs into Adjust. This ensures that the A
 
 ### [Set default link token](set-default-link-token)
 
-```objc title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```objc
 @property (nonatomic, copy, nullable) NSString *defaultTracker;
 ```
+
+</CodeBlock>
 
 You can configure a default link token if your app is preinstalled on a device. When a user opens the preinstalled app for the first time, the install is attributed to the default link token. Assign your default link token to the `defaultTracker` property of your config instance.
 
@@ -794,7 +811,7 @@ You can configure a default link token if your app is preinstalled on a device. 
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {6}
+```swift
 let yourAppToken = "{YourAppToken}"
 let environment = ADJEnvironmentSandbox as? String
 let adjustConfig = ADJConfig(
@@ -807,7 +824,7 @@ Adjust.appDidLaunch(adjustConfig)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c {3}
+```objc
 *adjustConfig = [ADJConfig configWithAppToken:@"{YourAppToken}"
                                  environment:ADJEnvironmentSandbox];
 [adjustConfig setDefaultTracker:@"{Token}"];
@@ -817,7 +834,7 @@ Adjust.appDidLaunch(adjustConfig)
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```javascript {5}
+```js
 setupWebViewJavascriptBridge(function (bridge) {
    var yourAppToken = yourAppToken;
    var environment = AdjustConfig.EnvironmentSandbox;
@@ -831,9 +848,13 @@ setupWebViewJavascriptBridge(function (bridge) {
 
 ### [Enable cost data sending](enable-cost-data-sending)
 
-```objc title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```objc
 @property (nonatomic, assign) BOOL needsCost;
 ```
+
+</CodeBlock>
 
 By default, the Adjust SDK doesn't send cost data as part of a user's attribution. You can configure the SDK to send this data by enabling cost data sending. To enable cost data sending, assign a **Boolean** value to the `needsCost` property of your config instance.
 
@@ -844,7 +865,7 @@ Cost data is accessible in the user's [attribution information](/en/sdk/ios/feat
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {7}
+```swift
 let yourAppToken = "{YourAppToken}"
 let environment = ADJEnvironmentSandbox as? String
 let adjustConfig = ADJConfig(
@@ -857,7 +878,7 @@ adjustConfig?.needsCost = true
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {6}
+```objc
 NSString *yourAppToken = @"{YourAppToken}";
 NSString *environment = ADJEnvironmentSandbox;
 *adjustConfig = [ADJConfig configWithAppToken:yourAppToken
@@ -869,7 +890,7 @@ NSString *environment = ADJEnvironmentSandbox;
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {5}
+```js
 setupWebViewJavascriptBridge(function (bridge) {
    var yourAppToken = yourAppToken;
    var environment = AdjustConfig.EnvironmentSandbox;
@@ -883,9 +904,13 @@ setupWebViewJavascriptBridge(function (bridge) {
 
 ### [Enable background recording](enable-background-recording)
 
-```objc title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```objc
 @property (nonatomic, assign) BOOL sendInBackground;
 ```
+
+</CodeBlock>
 
 By default, the Adjust SDK pauses the sending of requests when your app is running in the background. You can configure the SDK to send requests in the background by enabling the background recording. To enable background recording, assign a **Boolean** value to the `sendInBackground` property of your config instance.
 
@@ -894,7 +919,7 @@ By default, the Adjust SDK pauses the sending of requests when your app is runni
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {7}
+```swift
 let yourAppToken = "{YourAppToken}"
 let environment = ADJEnvironmentSandbox as? String
 let adjustConfig = ADJConfig(
@@ -907,7 +932,7 @@ adjustConfig?.sendInBackground = true
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {6}
+```objc
 NSString *yourAppToken = @"{YourAppToken}";
 NSString *environment = ADJEnvironmentSandbox;
 *adjustConfig = [ADJConfig configWithAppToken:yourAppToken
@@ -919,7 +944,7 @@ NSString *environment = ADJEnvironmentSandbox;
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {6}
+```js
 setupWebViewJavascriptBridge(function (bridge) {
    // ...
    var yourAppToken = yourAppToken;
@@ -934,9 +959,13 @@ setupWebViewJavascriptBridge(function (bridge) {
 
 ### [Enable event buffering](enable-event-buffering)
 
-```objc title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```objc
 @property (nonatomic, assign) BOOL eventBufferingEnabled;
 ```
+
+</CodeBlock>
 
 The Adjust SDK sends event information as soon as a user triggers an event in your app. You can send event information on a schedule by enabling event buffering. Event buffering stores events in a local buffer on the device and sends all requests once per minute.
 
@@ -947,7 +976,7 @@ Your config object contains a boolean `eventBufferingEnabled` property that cont
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {6}
+```swift
 let yourAppToken = "{YourAppToken}"
 let environment = ADJEnvironmentSandbox as? String
 let adjustConfig = ADJConfig(
@@ -960,7 +989,7 @@ Adjust.appDidLaunch(adjustConfig)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {3}
+```objc
 *adjustConfig = [ADJConfig configWithAppToken:@"{YourAppToken}"
                                  environment:ADJEnvironmentSandbox];
 [adjustConfig setEventBufferingEnabled:YES];
@@ -970,7 +999,7 @@ Adjust.appDidLaunch(adjustConfig)
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {5}
+```js
 setupWebViewJavascriptBridge(function (bridge) {
    var yourAppToken = yourAppToken;
    var environment = AdjustConfig.EnvironmentSandbox;
@@ -984,9 +1013,13 @@ setupWebViewJavascriptBridge(function (bridge) {
 
 ### [Delay the start of the SDK](delay-the-start-of-the-sdk)
 
-```objc title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```objc
 @property (nonatomic, assign) double delayStart;
 ```
+
+</CodeBlock>
 
 By default, the Adjust SDK starts as soon as your app opens. If you want to send data that's not available at launch in [session parameters](/en/sdk/ios/features/session-parameters), you can delay the start of the SDK. This can be helpful if you are sending information such as unique identifiers.
 
@@ -997,7 +1030,7 @@ To configure a startup delay, assign a `double` value to the `delayStart` proper
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {6}
+```swift
 let yourAppToken = "{YourAppToken}"
 let environment = ADJEnvironmentSandbox as? String
 let adjustConfig = ADJConfig(
@@ -1011,7 +1044,7 @@ Adjust.appDidLaunch(adjustConfig)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {3}
+```objc
 *adjustConfig = [ADJConfig configWithAppToken:@"{YourAppToken}"
                                  environment:ADJEnvironmentSandbox];
 [adjustConfig setDelayStart:5.5];
@@ -1022,7 +1055,7 @@ Adjust.appDidLaunch(adjustConfig)
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {5}
+```js
 setupWebViewJavascriptBridge(function (bridge) {
    var yourAppToken = yourAppToken;
    var environment = AdjustConfig.EnvironmentSandbox;
@@ -1040,9 +1073,13 @@ setupWebViewJavascriptBridge(function (bridge) {
 
 ### [Toggle offline mode](toggle-offline-mode)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (void)setOfflineMode:(BOOL)enabled;
 ```
+
+</CodeBlock>
 
 <Callout type="important">
 
@@ -1083,9 +1120,13 @@ Adjust.setOfflineMode(true);
 
 ### [Set push tokens](set-push-tokens)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (void)setDeviceToken:(nonnull NSData *)deviceToken;
 ```
+
+</CodeBlock>
 
 Push tokens are used for [Audiences](https://help.adjust.com/en/article/audiences) and client callbacks. They're also required for [Uninstall and reinstall measurement](https://help.adjust.com/en/article/uninstalls-reinstalls).
 
@@ -1102,7 +1143,7 @@ If you have access to the push token from the web view, you can call the `setPus
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {2}
+```swift
 func application(_ app: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
     Adjust.setDeviceToken(deviceToken)
 }
@@ -1111,7 +1152,7 @@ func application(_ app: UIApplication, didRegisterForRemoteNotificationsWithDevi
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {2}
+```objc
 - (void)application:(UIApplication *)app didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
     [Adjust setDeviceToken:deviceToken];
 }
@@ -1135,9 +1176,13 @@ You can only call this method after the first session. This setting persists bet
 
 </Callout>
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (void)setEnabled:(BOOL)enabled;
 ```
+
+</CodeBlock>
 
 The Adjust SDK runs by default when your app is open. You can disable and re-enable the Adjust SDK to pause and resume recording. When you disable the Adjust SDK, it doesn't send any data to Adjust's servers.
 
@@ -1171,9 +1216,13 @@ Adjust.setEnabled(false);
 
 #### [Check enabled status](check-enabled-status)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (BOOL)isEnabled;
 ```
+
+</CodeBlock>
 
 You can check if the Adjust SDK is enabled at any time by calling the `isEnabled` method. This method returns a `BOOL` value indicating if the SDK is **enabled** (`true`) or **disabled** (`false`).
 

--- a/src/content/docs/sdk/ios/features/ad-revenue.mdx
+++ b/src/content/docs/sdk/ios/features/ad-revenue.mdx
@@ -434,7 +434,7 @@ Adjust.trackAdRevenue(adRevenue)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 ADJAdRevenue *adRevenue = [[ADJAdRevenue alloc]
                               initWithSource:@"applovin_max_sdk"];
 [adRevenue setRevenue:1 currency:@"EUR"];
@@ -464,9 +464,13 @@ You need to perform some extra setup steps in your Adjust dashboard to measure a
 
 ## [Instantiate an ADJAdRevenue object](instantiate-an-adjadrevenue-object)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 - (nullable id)initWithSource:(nonnull NSString *)source;
 ```
+
+</CodeBlock>
 
 To send ad revenue information with the Adjust SDK, you need to instantiate an `ADJAdRevenue` object. This object contains variables that are sent to Adjust when ad revenue is recorded in your app.
 
@@ -493,7 +497,7 @@ To instantiate an ad revenue object, create a new `ADJAdRevenue` instance and pa
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {1}
+```swift
 let adRevenue = ADJAdRevenue(source: source);
 //...
 Adjust.trackAdRevenue(adRevenue);
@@ -502,7 +506,7 @@ Adjust.trackAdRevenue(adRevenue);
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {1}
+```objc
 ADJAdRevenue *adRevenue = [[ADJAdRevenue alloc] initWithSource:source];
 //...
 [Adjust trackAdRevenue:adRevenue];
@@ -513,9 +517,13 @@ ADJAdRevenue *adRevenue = [[ADJAdRevenue alloc] initWithSource:source];
 
 ## [Send ad revenue](send-ad-revenue)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (void)trackAdRevenue:(nonnull NSString *)source payload:(nonnull NSData *)payload;
 ```
+
+</CodeBlock>
 
 To send ad revenue to Adjust, call the `trackAdRevenue` method with your ad revenue instance as an argument.
 
@@ -541,9 +549,13 @@ ADJAdRevenue *adRevenue = [[ADJAdRevenue alloc] initWithSource:source];
 
 ## [Record ad revenue amount](record-ad-revenue-amount)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 - (void)setRevenue:(double)amount currency:(nonnull NSString *)currency;
 ```
+
+</CodeBlock>
 
 To send the ad revenue amount, call the `setRevenue` method and pass the following arguments:
 
@@ -559,7 +571,7 @@ Check the [guide to recording purchases in different currencies](https://help.ad
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {2}
+```swift
 let adRevenue = ADJAdRevenue(source: source);
 adRevenue.setRevenue(1.6, currency: "USD");
 Adjust.trackAdRevenue(adRevenue);
@@ -568,7 +580,7 @@ Adjust.trackAdRevenue(adRevenue);
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {2}
+```objc
 ADJAdRevenue *adRevenue = [[ADJAdRevenue alloc] initWithSource:source];
 [adRevenue setRevenue:1.6 currency:@"USD"];
 [Adjust trackAdRevenue:adRevenue];
@@ -583,9 +595,13 @@ The `ADJAdRevenue` class contains properties you can use to report on your ad ca
 
 ### [Ad impressions](ad-impressions)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 - (void)setAdImpressionsCount:(int)adImpressionsCount;
 ```
+
+</CodeBlock>
 
 To send the number of recorded ad impressions, call the `setAdImpressionsCount` method and pass the following arguments:
 
@@ -594,7 +610,7 @@ To send the number of recorded ad impressions, call the `setAdImpressionsCount` 
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {2}
+```swift
 let adRevenue = ADJAdRevenue(source: source);
 adRevenue?.adImpressionsCount = 1;
 Adjust.trackAdRevenue(adRevenue);
@@ -603,7 +619,7 @@ Adjust.trackAdRevenue(adRevenue);
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {2}
+```objc
 ADJAdRevenue *adRevenue = [[ADJAdRevenue alloc] initWithSource:source];
 [adRevenue setAdImpressionsCount:1];
 [Adjust trackAdRevenue:adRevenue];
@@ -614,9 +630,13 @@ ADJAdRevenue *adRevenue = [[ADJAdRevenue alloc] initWithSource:source];
 
 ### [Ad revenue network](ad-revenue-network)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 - (void)setAdRevenueNetwork:(nonnull NSString *)adRevenueNetwork;
 ```
+
+</CodeBlock>
 
 To send the ad revenue network, call the `setAdRevenueNetwork` method and pass the following arguments:
 
@@ -625,7 +645,7 @@ To send the ad revenue network, call the `setAdRevenueNetwork` method and pass t
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {2}
+```swift
 let adRevenue = ADJAdRevenue(source: source);
 adRevenue?.adRevenueNetwork = "network1";
 Adjust.trackAdRevenue(adRevenue);
@@ -634,7 +654,7 @@ Adjust.trackAdRevenue(adRevenue);
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {2}
+```objc
 ADJAdRevenue *adRevenue = [[ADJAdRevenue alloc] initWithSource:source];
 [adRevenue setAdRevenueNetwork:@"network1"];
 [Adjust trackAdRevenue:adRevenue];
@@ -645,9 +665,13 @@ ADJAdRevenue *adRevenue = [[ADJAdRevenue alloc] initWithSource:source];
 
 ### [Ad revenue unit](ad-revenue-unit)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 - (void)setAdRevenueUnit:(nonnull NSString *)adRevenueUnit;
 ```
+
+</CodeBlock>
 
 To send the ad revenue unit, call the `setAdRevenueUnit` method and pass the following arguments:
 
@@ -656,7 +680,7 @@ To send the ad revenue unit, call the `setAdRevenueUnit` method and pass the fol
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {2}
+```swift
 let adRevenue = ADJAdRevenue(source: source);
 adRevenue?.adRevenueUnit = "unit1";
 Adjust.trackAdRevenue(adRevenue);
@@ -665,7 +689,7 @@ Adjust.trackAdRevenue(adRevenue);
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {2}
+```objc
 ADJAdRevenue *adRevenue = [[ADJAdRevenue alloc] initWithSource:source];
 [adRevenue setAdRevenueUnit:@"unit1"];
 [Adjust trackAdRevenue:adRevenue];
@@ -676,9 +700,13 @@ ADJAdRevenue *adRevenue = [[ADJAdRevenue alloc] initWithSource:source];
 
 ### [Ad revenue placement](ad-revenue-placement)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 - (void)setAdRevenuePlacement:(nonnull NSString *)adRevenuePlacement;
 ```
+
+</CodeBlock>
 
 To send the ad revenue placement, call the `setAdRevenuePlacement` method and pass the following arguments:
 
@@ -687,7 +715,7 @@ To send the ad revenue placement, call the `setAdRevenuePlacement` method and pa
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {2}
+```swift
 let adRevenue = ADJAdRevenue(source: source);
 adRevenue?.adRevenuePlacement = "banner";
 Adjust.trackAdRevenue(adRevenue);
@@ -696,7 +724,7 @@ Adjust.trackAdRevenue(adRevenue);
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {2}
+```objc
 ADJAdRevenue *adRevenue = [[ADJAdRevenue alloc] initWithSource:source];
 [adRevenue setAdRevenuePlacement:@"banner"];
 [Adjust trackAdRevenue:adRevenue];
@@ -707,9 +735,13 @@ ADJAdRevenue *adRevenue = [[ADJAdRevenue alloc] initWithSource:source];
 
 ## [Add callback parameters](add-callback-parameters)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 - (void)addCallbackParameter:(nonnull NSString *)key value:(nonnull NSString *)value;
 ```
+
+</CodeBlock>
 
 If you [register a callback URL](https://help.adjust.com/en/article/recommended-placeholders-callbacks) in the Adjust dashboard, the SDK sends a GET request to your callback URL when it records an event.
 
@@ -719,9 +751,13 @@ Add callback parameters to your event by calling the `addCallbackParameter` meth
 
 The Adjust SDK measures the event and sends a request to your URL with the callback parameters. For example, if you register the URL `https://www.mydomain.com/callback`, your callback looks like this:
 
-```http "key=value" "foo=bar"
+<CodeBlock highlight="key=value, foo=bar">
+
+```http
 https://www.mydomain.com/callback?key=value&foo=bar
 ```
+
+</CodeBlock>
 
 <Callout type="note">
 
@@ -742,7 +778,7 @@ You can read more about using URL callbacks, including a full list of available 
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {2}
+```swift
 let adRevenue = ADJAdRevenue(source: source);
 adRevenue.addCallbackParameter(key, value: value);
 Adjust.trackAdRevenue(adRevenue);
@@ -751,7 +787,7 @@ Adjust.trackAdRevenue(adRevenue);
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {2}
+```objc
 ADJAdRevenue *adRevenue = [[ADJAdRevenue alloc] initWithSource:source];
 [adRevenue addCallbackParameter:key value:value];
 [Adjust trackAdRevenue:adRevenue];
@@ -762,9 +798,13 @@ ADJAdRevenue *adRevenue = [[ADJAdRevenue alloc] initWithSource:source];
 
 ## [Add partner parameters](add-partner-parameters)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 - (void)addPartnerParameter:(nonnull NSString *)key value:(nonnull NSString *)value;
 ```
+
+</CodeBlock>
 
 You can send extra information to your network partners by adding [partner parameters](https://help.adjust.com/en/article/data-sharing-ad-network#map-parameters).
 
@@ -781,7 +821,7 @@ Add partner parameters to your event by calling the `addPartnerParameter` method
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {2}
+```swift
 let adRevenue = ADJAdRevenue(source: source);
 adRevenue.addPartnerParameter(key, value: value);
 Adjust.trackAdRevenue(adRevenue);
@@ -790,7 +830,7 @@ Adjust.trackAdRevenue(adRevenue);
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {2}
+```objc
 ADJAdRevenue *adRevenue = [[ADJAdRevenue alloc] initWithSource:source];
 [adRevenue addPartnerParameter:key value:value];
 [Adjust trackAdRevenue:adRevenue];
@@ -830,7 +870,7 @@ Adjust.trackAdRevenue(adRevenue);
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 ADJAdRevenue *adRevenue = [[ADJAdRevenue alloc] initWithSource:ADJAdRevenueSourceAppLovinMAX];
 [adRevenue setRevenue:1 currency:@"EUR"];
 [adRevenue setAdImpressionsCount:10];

--- a/src/content/docs/sdk/ios/features/att.mdx
+++ b/src/content/docs/sdk/ios/features/att.mdx
@@ -30,9 +30,13 @@ You might receive a status code of `-1` if the SDK is unable to retrieve the ATT
 
 ## [ATT authorization wrapper](att-authorization-wrapper)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (void)requestAppTrackingAuthorizationWithCompletionHandler:(void (^_Nullable)(NSUInteger status))completion;
 ```
+
+</CodeBlock>
 
 The Adjust SDK contains a wrapper around [Apple's `requestTrackingAuthorizationWithCompletionHandler` method](https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanager/3547037-requesttrackingauthorizationwith). You can use this wrapper if you don't want to customize the ATT prompt.
 
@@ -97,9 +101,13 @@ Adjust.requestAppTrackingAuthorization() { status in
 
 ## [Get current authorization status](get-current-authorization-status)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (int)appTrackingAuthorizationStatus;
 ```
+
+</CodeBlock>
 
 You can retrieve a user's current authorization status at any time. Call the `getAppTrackingAuthorizationStatus` method to return the authorization status code as an **integer**.
 
@@ -122,9 +130,13 @@ int authorizationStatus = [Adjust appTrackingAuthorizationStatus];
 
 ## [Custom prompt timing](custom-prompt-timing)
 
-```objc title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```objc
 @property (nonatomic, assign) NSUInteger attConsentWaitingInterval;
 ```
+
+</CodeBlock>
 
 If your app includes an onboarding process or a tutorial, you may want to delay sending your user's ATT consent status until after the user has completed this process. To do this, you can set the `attConsentWaitingInterval` property to delay the sending of data for **up to 120 seconds** to give the user time to complete the initial onboarding. After the timeout ends or the user sets their consent status, the SDK sends all information it has recorded during the delay to Adjust's servers along with the user's consent status.
 
@@ -137,7 +149,7 @@ If the user closes the app before the timeout ends, or before they select their 
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {7}
+```swift
 let yourAppToken = "{YourAppToken}"
 let environment = ADJEnvironmentSandbox
 let adjustConfig = ADJConfig(
@@ -152,7 +164,7 @@ Adjust.initSdk(adjustConfig)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {4}
+```objc
  ADJConfig *adjustConfig = [[ADJConfig alloc] initWithAppToken:@"{YourAppToken}"
                                                    andEnvironment:environment];
 //...
@@ -217,9 +229,13 @@ You might receive a status code of `-1` if the SDK is unable to retrieve the ATT
 
 ## [ATT authorization wrapper](att-authorization-wrapper)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (void)requestTrackingAuthorizationWithCompletionHandler:(void (^_Nullable)(NSUInteger status))completion;
 ```
+
+</CodeBlock>
 
 The Adjust SDK contains a wrapper around [Apple's `requestTrackingAuthorizationWithCompletionHandler` method](https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanager/3547037-requesttrackingauthorizationwith). You can use this wrapper if you don't want to customize the ATT prompt.
 
@@ -284,9 +300,13 @@ Adjust.requestTrackingAuthorization() { status in
 
 ## [Get current authorization status](get-current-authorization-status)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (int)appTrackingAuthorizationStatus;
 ```
+
+</CodeBlock>
 
 You can retrieve a user's current authorization status at any time. Call the `getAppTrackingAuthorizationStatus` method to return the authorization status code as an **integer**.
 
@@ -317,9 +337,13 @@ var authorizationStatus = Adjust.appTrackingAuthorizationStatus();
 
 ## [Custom prompt timing](custom-prompt-timing)
 
-```objc title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```objc
 @property (nonatomic, assign) NSUInteger attConsentWaitingInterval;
 ```
+
+</CodeBlock>
 
 If your app includes an onboarding process or a tutorial, you may want to delay sending your user's ATT consent status until after the user has completed this process. To do this, you can set the `attConsentWaitingInterval` property to delay the sending of data for **up to 120 seconds** to give the user time to complete the initial onboarding. After the timeout ends or the user sets their consent status, the SDK sends all information it has recorded during the delay to Adjust's servers along with the user's consent status.
 
@@ -332,7 +356,7 @@ If the user closes the app before the timeout ends, or before they select their 
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {7}
+```swift
 let yourAppToken = "{YourAppToken}"
 let environment = ADJEnvironmentSandbox as? String
 let adjustConfig = ADJConfig(
@@ -347,7 +371,7 @@ Adjust.appDidLaunch(adjustConfig)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {4}
+```objc
 *adjustConfig = [ADJConfig configWithAppToken:@"{YourAppToken}"
                                   environment:ADJEnvironmentSandbox];
 //...
@@ -361,9 +385,13 @@ Adjust.appDidLaunch(adjustConfig)
 
 ## [Check for authorization status changes](check-for-authorization-status-changes)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (void)checkForNewAttStatus;
 ```
+
+</CodeBlock>
 
 If you use a custom ATT prompt, you need to inform the Adjust SDK of changes to the user's authorization status. Call the `checkForNewAttStatus` method to send the authorization status to Adjust's servers.
 

--- a/src/content/docs/sdk/ios/features/attribution.mdx
+++ b/src/content/docs/sdk/ios/features/attribution.mdx
@@ -65,7 +65,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, AdjustDelegate {
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 @interface AppDelegate : UIResponder <UIApplicationDelegate, AdjustDelegate>
 ```
 
@@ -88,7 +88,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, AdjustDelegate {
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 - (void)adjustAttributionChanged:(ADJAttribution *)attribution {
    /// ...
 }
@@ -209,9 +209,13 @@ The following values can only be accessed if the `needsCost` property on your `A
 
 ## [Trigger a function when attribution changes](trigger-a-function-when-attribution-changes)
 
-```objc title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```objc
 @property (nonatomic, weak, nullable) NSObject<AdjustDelegate> *delegate;
 ```
+
+</CodeBlock>
 
 The SDK can listen for attribution changes and call a function when it detects an update. To configure your delegate function:
 
@@ -228,7 +232,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, AdjustDelegate {
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 @interface AppDelegate : UIResponder <UIApplicationDelegate, AdjustDelegate>
 ```
 
@@ -251,7 +255,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, AdjustDelegate {
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 - (void)adjustAttributionChanged:(ADJAttribution *)attribution {
    /// ...
 }
@@ -265,7 +269,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, AdjustDelegate {
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {6}
+```swift
 let yourAppToken = "{YourAppToken}"
 let environment = ADJEnvironmentSandbox as? String
 let adjustConfig = ADJConfig(
@@ -279,7 +283,7 @@ Adjust.appDidLaunch(adjustConfig)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {3}
+```objc
 *adjustConfig = [ADJConfig configWithAppToken:@"{YourAppToken}"
                                  environment:ADJEnvironmentSandbox];
 [adjustConfig setDelegate:self];
@@ -290,7 +294,9 @@ Adjust.appDidLaunch(adjustConfig)
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```javascript {5-15}
+<CodeBlock highlight="{range: 5-15}">
+
+```js
 setupWebViewJavascriptBridge(function (bridge) {
    var yourAppToken = yourAppToken;
    var environment = AdjustConfig.EnvironmentSandbox;
@@ -326,6 +332,8 @@ setupWebViewJavascriptBridge(function (bridge) {
 });
 ```
 
+</CodeBlock>
+
 </Tab>
 </Tabs>
 
@@ -333,9 +341,13 @@ Within your delegate function, you have access to the user's `Attribution` infor
 
 ## [Get current attribution information](get-current-attribution-information)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (nullable ADJAttribution *)attribution;
 ```
+
+</CodeBlock>
 
 When a user installs your app, Adjust attributes the install to a campaign. The Adjust SDK gives you access to campaign attribution details for your install. To return this information, call the `attribution` method to return the attribution information as an `ADJAttribution` object.
 

--- a/src/content/docs/sdk/ios/features/deep-links/deferred.mdx
+++ b/src/content/docs/sdk/ios/features/deep-links/deferred.mdx
@@ -61,7 +61,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, AdjustDelegate {
 
 <CodeBlock title="AppDelegate.h">
 
-```objective-c
+```objc
 @interface AppDelegate : UIResponder <UIApplicationDelegate, AdjustDelegate>
 ```
 
@@ -91,7 +91,7 @@ Adjust.initSdk(adjustConfig)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 ADJConfig *adjustConfig = [[ADJConfig alloc] initWithAppToken:@"{YourAppToken}"
                                                    andEnvironment:ADJEnvironmentSandbox];
 [adjustConfig setDelegate:self];
@@ -124,7 +124,7 @@ func adjustDeferredDeeplinkReceived(_ deeplink: URL?) -> Bool {
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 - (BOOL)adjustDeferredDeeplinkReceived:(NSURL *)deeplink {
       // add your code below to handle deep link
       // (for example, show onboarding screens, then open deep link content)
@@ -236,17 +236,25 @@ There are 2 approaches to set up deferred deep linking in your app:
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift title="AppDelegate.swift"
+<CodeBlock title="AppDelegate.swift">
+
+```swift
 class AppDelegate: UIResponder, UIApplicationDelegate, AdjustDelegate {
 }
 ```
 
+</CodeBlock>
+
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c title="AppDelegate.h"
+<CodeBlock title="AppDelegate.h">
+
+```objc
 @interface AppDelegate : UIResponder <UIApplicationDelegate, AdjustDelegate>
 ```
+
+</CodeBlock>
 
 </Tab>
 </Tabs>
@@ -272,7 +280,7 @@ Adjust.appDidLaunch(adjustConfig)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 *adjustConfig = [ADJConfig configWithAppToken:@"{YourAppToken}"
                                  environment:ADJEnvironmentSandbox];
 [adjustConfig setDelegate:self];
@@ -305,7 +313,7 @@ func adjustDeeplinkResponse(_ deeplink: URL?) -> Bool {
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 - (BOOL)adjustDeeplinkResponse:(NSURL *)deeplink {
       // add your code below to handle deep link
       // (for example, show onboarding screens, then open deep link content)
@@ -320,9 +328,13 @@ func adjustDeeplinkResponse(_ deeplink: URL?) -> Bool {
 
 ## [Set up Adjust LinkMe](set-up-adjust-linkme)
 
-```objc title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```objc
 @property (nonatomic, assign) BOOL linkMeEnabled;
 ```
+
+</CodeBlock>
 
 <Callout type="note">
 
@@ -345,7 +357,7 @@ To enable pasteboard checking in your app, pass a `true` value to the `setLinkMe
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {7}
+```swift
 let yourAppToken = "{YourAppToken}"
 let environment = ADJEnvironmentSandbox as? String
 let adjustConfig = ADJConfig(
@@ -358,7 +370,7 @@ adjustConfig?.linkMeEnabled = true
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {6}
+```objc
 NSString *yourAppToken = @"{YourAppToken}";
 NSString *environment = ADJEnvironmentSandbox;
 *adjustConfig = [ADJConfig configWithAppToken:yourAppToken
@@ -370,7 +382,7 @@ NSString *environment = ADJEnvironmentSandbox;
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {6}
+```js
 setupWebViewJavascriptBridge(function (bridge) {
    // ...
    var yourAppToken = yourAppToken;

--- a/src/content/docs/sdk/ios/features/deep-links/direct.mdx
+++ b/src/content/docs/sdk/ios/features/deep-links/direct.mdx
@@ -118,7 +118,7 @@ func application(
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 - (BOOL)application:(UIApplication *)application
     continueUserActivity:(NSUserActivity *)userActivity
     restorationHandler:
@@ -185,7 +185,7 @@ func application(
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 - (BOOL)application:(UIApplication *)app
     openURL:(NSURL *)incomingURL
     options:(NSDictionary *)options {
@@ -276,7 +276,7 @@ func scene(
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 - (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session
     options:(UISceneConnectionOptions *)connectionOptions {
 
@@ -365,7 +365,7 @@ func scene(
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 - (void)scene:(UIScene *)scene
     openURLContexts:(nonnull NSSet<UIOpenURLContext *> *)URLContexts {
 
@@ -500,7 +500,7 @@ func application(
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 - (BOOL)application:(UIApplication *)application
     continueUserActivity:(NSUserActivity *)userActivity
     restorationHandler:
@@ -567,7 +567,7 @@ func application(
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 - (BOOL)application:(UIApplication *)app
     openURL:(NSURL *)incomingURL
     options:(NSDictionary *)options {
@@ -658,7 +658,7 @@ func scene(
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 - (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session
     options:(UISceneConnectionOptions *)connectionOptions {
 
@@ -747,7 +747,7 @@ func scene(
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 - (void)scene:(UIScene *)scene
     openURLContexts:(nonnull NSSet<UIOpenURLContext *> *)URLContexts {
 

--- a/src/content/docs/sdk/ios/features/deep-links/index.mdx
+++ b/src/content/docs/sdk/ios/features/deep-links/index.mdx
@@ -8,7 +8,7 @@ type: category
 
 You can create deep links to take users to specific pages in your app. The Adjust SDK uses different logic depending on if the user already has your app installed on their device:
 
-- Direct deep linking: occurs if the user already has your app installed. The link takes the user to the page specified in the link
-- Deferred deep linking: occurs if the user doesn't have your app installed. The link takes the user to a storefront to install your app first. After the user installs the app, it opens to the page specified in the link.
+-  Direct deep linking: occurs if the user already has your app installed. The link takes the user to the page specified in the link
+-  Deferred deep linking: occurs if the user doesn't have your app installed. The link takes the user to a storefront to install your app first. After the user installs the app, it opens to the page specified in the link.
 
 The SDK can read deep link data after a user opens your app from a link. Follow the steps in this section to get started.

--- a/src/content/docs/sdk/ios/features/deep-links/testing.mdx
+++ b/src/content/docs/sdk/ios/features/deep-links/testing.mdx
@@ -193,9 +193,13 @@ To test deferred deep linking on the test device, follow these steps.
 1. Install your app.
 2. Retrieve the ADID (Adjust device identifier) from your Xcode logs. Example:
 
-   ```text '"adid":"4446ab34861b99b78ee374c3bd38a350"'
+   <CodeBlock highlight={"\"adid\":\"4446ab34861b99b78ee374c3bd38a350\""}>
+
+   ```text
    2022-09-28 09:19:35.609913+0900 example[1619:241847] [Adjust]v: Response: {"app_token":"2eb2na2w54c3","adid":"4446ab34861b99b78ee374c3bd38a350","timestamp":"2022-09-28T00:19:35.841Z+0000","message":"Attribution found","attribution":{"tracker_token":"abc123","tracker_name":"Organic","network":"Organic"}}
    ```
+
+   </CodeBlock>
 
 3. Uninstall your app.
 4. Open the [Testing Console](https://help.adjust.com/en/article/testing-console), enter the Adjust ADID and select **View Device Data**. You should see the `TrackerName` as `Organic`.

--- a/src/content/docs/sdk/ios/features/device-info.mdx
+++ b/src/content/docs/sdk/ios/features/device-info.mdx
@@ -149,9 +149,13 @@ The Adjust SDK contains helper methods that return device information. Use these
 
 ## [Adjust device identifier](adjust-device-identifier)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (nullable NSString *)adid;
 ```
+
+</CodeBlock>
 
 Adjust generates a unique Adjust Device ID (ADID) for each device. Call the `adid` method to return this ID as an `NSString`.
 
@@ -181,9 +185,13 @@ var adid = Adjust.getAdid();
 
 ## [ID For Advertisers](id-for-advertisers)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (nullable NSString *)idfa;
 ```
+
+</CodeBlock>
 
 The IDFA (ID for Advertisers) is a device-specific identifier for Apple devices. Call the `idfa` method to return this ID as an `NSString`.
 

--- a/src/content/docs/sdk/ios/features/events.mdx
+++ b/src/content/docs/sdk/ios/features/events.mdx
@@ -28,7 +28,7 @@ To instantiate an event object, create a new `ADJEvent` instance and pass the fo
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift =
+```swift
 let event = ADJEvent(eventToken: "abc123")
 Adjust.trackEvent(event)
 ```
@@ -102,7 +102,7 @@ class ViewControllerSwift: UIViewController {
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 #import "Adjust.h"
 #import "Constants.h"
 #import "ViewControllerObjC.h"
@@ -242,7 +242,7 @@ class ViewControllerSwift: UIViewController {
 </Tab>
 <Tab sync="objc" title="Objective-C">
 
-```objective-c
+```objc
 #import "Adjust.h"
 #import "Constants.h"
 #import "ViewControllerObjC.h"
@@ -414,7 +414,7 @@ class ViewControllerSwift: UIViewController {
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 #import "Adjust.h"
 #import "Constants.h"
 #import "ViewControllerObjC.h"
@@ -549,7 +549,9 @@ class ViewControllerSwift: UIViewController {
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c title="ViewControllerObjC.m"
+<CodeBlock title="ViewControllerObjC.m">
+
+```objc
 
 #import "Adjust.h"
 #import "Constants.h"
@@ -571,7 +573,10 @@ class ViewControllerSwift: UIViewController {
 }
 
 @end
+
 ```
+
+</CodeBlock>
 
 </Tab>
 </Tabs>
@@ -664,7 +669,7 @@ class ViewControllerSwift: UIViewController {
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 #import "Adjust.h"
 #import "Constants.h"
 #import "ViewControllerObjC.h"
@@ -764,7 +769,7 @@ class ViewControllerSwift: UIViewController {
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 #import "Adjust.h"
 #import "Constants.h"
 #import "ViewControllerObjC.h"
@@ -811,9 +816,13 @@ The Adjust SDK provides an `ADJEvent` object which can be used to structure and 
 
 ## [Instantiate an ADJEvent object](instantiate-an-adjevent-object)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (nullable ADJEvent *)eventWithEventToken:(nonnull NSString *)eventToken;
 ```
+
+</CodeBlock>
 
 To send event information with the Adjust SDK, you need to instantiate an `ADJEvent` object. This object contains variables that are sent to Adjust when an event occurs in your app.
 
@@ -824,7 +833,7 @@ To instantiate an event object, create a new `ADJEvent` instance and pass the fo
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {1}
+```swift
 let event = ADJEvent(eventToken: "abc123")
 Adjust.trackEvent(event)
 ```
@@ -832,7 +841,7 @@ Adjust.trackEvent(event)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {1}
+```objc
 ADJEvent *event = [ADJEvent eventWithEventToken:@"abc123"];
 [Adjust trackEvent:event];
 ```
@@ -840,7 +849,7 @@ ADJEvent *event = [ADJEvent eventWithEventToken:@"abc123"];
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {1}
+```js
 var adjustEvent = new AdjustEvent("abc123");
 Adjust.trackEvent(adjustEvent);
 ```
@@ -850,9 +859,13 @@ Adjust.trackEvent(adjustEvent);
 
 ## [Send an event](send-an-event)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (void)trackEvent:(nullable ADJEvent *)event;
 ```
+
+</CodeBlock>
 
 You can associate your [Adjust event tokens](https://help.adjust.com/en/article/add-events#add-event) to actions in your app to record them. To record an event:
 
@@ -862,7 +875,7 @@ You can associate your [Adjust event tokens](https://help.adjust.com/en/article/
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {2}
+```swift
 let event = ADJEvent(eventToken: "abc123")
 Adjust.trackEvent(event)
 ```
@@ -870,7 +883,7 @@ Adjust.trackEvent(event)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {2}
+```objc
 ADJEvent *event = [ADJEvent eventWithEventToken:@"abc123"];
 [Adjust trackEvent:event];
 ```
@@ -878,7 +891,7 @@ ADJEvent *event = [ADJEvent eventWithEventToken:@"abc123"];
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {2}
+```js
 var adjustEvent = new AdjustEvent("abc123");
 Adjust.trackEvent(adjustEvent);
 ```
@@ -910,7 +923,7 @@ class ViewControllerSwift: UIViewController {
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 #import "Adjust.h"
 #import "Constants.h"
 #import "ViewControllerObjC.h"
@@ -965,7 +978,9 @@ class ViewControllerSwift: UIViewController {
 </Tab>
 </Tabs>
 
-```txt collapse={6-40} title="Event log"
+<CodeBlock title="Event log" collapse="6-40">
+
+```txt
 Path:      /event
 ClientSdk: ios$IOS_V4_VERSION
 Parameters:
@@ -1006,13 +1021,20 @@ Parameters:
   time_spent       23
   tracking_enabled 1
   ui_mode          1
+
 ```
+
+</CodeBlock>
 
 ## [Record event revenue](record-event-revenue)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 - (void)setRevenue:(double)amount currency:(nonnull NSString *)currency;
 ```
+
+</CodeBlock>
 
 You can record revenue associated with an event by setting the revenue and currency properties on your event instance. Use this feature to record revenue-generating actions in your app.
 
@@ -1030,7 +1052,7 @@ Check the guide to [recording purchases in different currencies](https://help.ad
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {2}
+```swift
 let event = ADJEvent(eventToken: "abc123")
 event?.setRevenue(0.01, currency: "EUR")
 Adjust.trackEvent(event)
@@ -1039,7 +1061,7 @@ Adjust.trackEvent(event)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {2}
+```objc
 ADJEvent *event = [ADJEvent eventWithEventToken:@"abc123"];
 [event setRevenue:0.01 currency:@"EUR"];
 [Adjust trackEvent:event];
@@ -1048,7 +1070,7 @@ ADJEvent *event = [ADJEvent eventWithEventToken:@"abc123"];
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {2}
+```js
 var adjustEvent = new AdjustEvent(eventToken);
 adjustEvent.setRevenue(0.01, "EUR");
 Adjust.trackEvent(adjustEvent);
@@ -1082,7 +1104,7 @@ class ViewControllerSwift: UIViewController {
 </Tab>
 <Tab sync="objc" title="Objective-C">
 
-```objective-c
+```objc
 #import "Adjust.h"
 #import "Constants.h"
 #import "ViewControllerObjC.h"
@@ -1138,7 +1160,9 @@ class ViewControllerSwift: UIViewController {
 </Tab>
 </Tabs>
 
-```txt title="Event log" {7}
+<CodeBlock title="Event log" highlight="{range: 7}">
+
+```txt
 Path:      /event
 ClientSdk: ios$IOS_V4_VERSION
 Parameters:
@@ -1148,6 +1172,8 @@ Parameters:
   currency         EUR
   revenue          0.25
 ```
+
+</CodeBlock>
 
 ### [Purchase verification](purchase-verification)
 
@@ -1195,9 +1221,13 @@ ADJEvent *event = [ADJEvent eventWithEventToken::@"your-event-token"];
 
 ## [Deduplicate revenue events](deduplicate-revenue-events)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 - (void)setTransactionId:(nonnull NSString *)transactionId;
 ```
+
+</CodeBlock>
 
 You can pass an optional identifier to avoid recording duplicate events. The SDK stores the last ten identifiers and skips revenue events with duplicate transaction IDs.
 
@@ -1206,7 +1236,7 @@ To set the identifier, assign your transaction ID to the `setTransactionId` prop
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {2}
+```swift
 let event = ADJEvent(eventToken: "abc123")
 event?.setTransactionId(transaction.transactionIdentifier)
 Adjust.trackEvent(event)
@@ -1215,7 +1245,7 @@ Adjust.trackEvent(event)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {2}
+```objc
 ADJEvent *event = [ADJEvent eventWithEventToken:@"abc123"];
 [event setTransactionId:transaction.transactionIdentifier];
 [Adjust trackEvent:event];
@@ -1224,7 +1254,7 @@ ADJEvent *event = [ADJEvent eventWithEventToken:@"abc123"];
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {2}
+```js
 var adjustEvent = new AdjustEvent(eventToken);
 adjustEvent.setTransactionId(orderId);
 Adjust.trackEvent(adjustEvent);
@@ -1258,7 +1288,7 @@ class ViewControllerSwift: UIViewController {
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 #import "Adjust.h"
 #import "Constants.h"
 #import "ViewControllerObjC.h"
@@ -1316,7 +1346,9 @@ class ViewControllerSwift: UIViewController {
 </Tab>
 </Tabs>
 
-```txt title="Event log" {7}
+<CodeBlock title="Event log" highlight="{range: 7}">
+
+```txt
 Path:      /event
 ClientSdk: ios$IOS_V4_VERSION
 Parameters:
@@ -1326,11 +1358,17 @@ Parameters:
   transaction_id   5e85484b-1ebc-4141-aab7-25b869e54c49
 ```
 
+</CodeBlock>
+
 ## [Add callback parameters](add-callback-parameters)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 - (void)addCallbackParameter:(nonnull NSString *)key value:(nonnull NSString *)value;
 ```
+
+</CodeBlock>
 
 If you [register a callback URL](https://help.adjust.com/en/article/set-up-callbacks) in the Adjust dashboard, the SDK sends a GET request to your callback URL when it records an event.
 
@@ -1428,8 +1466,9 @@ class ViewControllerSwift: UIViewController {
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c title="ViewControllerObjC.m"
+<CodeBlock title="ViewControllerObjC.m">
 
+```objc
 #import "Adjust.h"
 #import "Constants.h"
 #import "ViewControllerObjC.h"
@@ -1451,6 +1490,8 @@ class ViewControllerSwift: UIViewController {
 
 @end
 ```
+
+</CodeBlock>
 
 </Tab>
 <Tab title="Javascript" sync="js">
@@ -1489,7 +1530,9 @@ class ViewControllerSwift: UIViewController {
 </Tab>
 </Tabs>
 
-```txt {4} title="Event log"
+<CodeBlock title="Event log">
+
+```txt
 Path:      /event
 ClientSdk: ios$IOS_V4_VERSION
 Parameters:
@@ -1497,13 +1540,20 @@ Parameters:
   environment      sandbox
   event_count      1
   event_token      g3mfiw
+
 ```
+
+</CodeBlock>
 
 ## [Add partner parameters](add-partner-parameters)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 - (void)addPartnerParameter:(nonnull NSString *)key value:(nonnull NSString *)value;
 ```
+
+</CodeBlock>
 
 You can send extra information to your network partners by adding [partner parameters](https://help.adjust.com/en/article/data-sharing-ad-network#map-parameters).
 
@@ -1520,7 +1570,7 @@ Add partner parameters to your event by calling the `addPartnerParameter` method
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {2,3}
+```swift
 let event = ADJEvent(eventToken: "abc123")
 event?.addPartnerParameter("key", value: "value")
 event?.addPartnerParameter("foo", value: "bar")
@@ -1530,7 +1580,7 @@ Adjust.trackEvent(event)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {2,3}
+```objc
 ADJEvent *event = [ADJEvent eventWithEventToken:@"abc123"];
 [event addPartnerParameter:@"key" value:@"value"];
 [event addPartnerParameter:@"foo" value:@"bar"];
@@ -1540,7 +1590,7 @@ ADJEvent *event = [ADJEvent eventWithEventToken:@"abc123"];
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {2,3}
+```js
 var adjustEvent = new AdjustEvent(eventToken);
 adjustEvent.addPartnerParameter("key", "value");
 adjustEvent.addPartnerParameter("foo", "bar");
@@ -1579,7 +1629,7 @@ class ViewControllerSwift: UIViewController {
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 #import "Adjust.h"
 #import "Constants.h"
 #import "ViewControllerObjC.h"
@@ -1639,7 +1689,9 @@ class ViewControllerSwift: UIViewController {
 </Tab>
 </Tabs>
 
-```txt title="Event log" {4}
+<CodeBlock title="Event log" highlight="{range: 4}">
+
+```txt
 Path:      /event
 ClientSdk: ios$IOS_V4_VERSION
 Parameters:
@@ -1649,11 +1701,17 @@ Parameters:
   event_token      g3mfiw
 ```
 
+</CodeBlock>
+
 ## [Add a callback identifier](add-a-callback-identifier)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 - (void)setCallbackId:(nonnull NSString *)callbackId;
 ```
+
+</CodeBlock>
 
 You can add a custom string identifier to each event you want to measure. Adjust's servers can report on this identifier in event callbacks. This enables you to keep track of which events have been successfully measured.
 
@@ -1662,7 +1720,7 @@ Set up this identifier by calling the `setCallbackId` method with your ID as an 
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {2}
+```swift
 let event = ADJEvent(eventToken: "abc123")
 event?.setCallbackId("Your-Custom-ID")
 Adjust.trackEvent(event)
@@ -1671,7 +1729,7 @@ Adjust.trackEvent(event)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {2}
+```objc
 ADJEvent *event = [ADJEvent eventWithEventToken:@"abc123"];
 [event setCallbackId:@"Your-Custom-ID"];
 [Adjust trackEvent:event];
@@ -1680,7 +1738,7 @@ ADJEvent *event = [ADJEvent eventWithEventToken:@"abc123"];
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {2}
+```js
 var adjustEvent = new AdjustEvent("abc123");
 adjustEvent.setCallbackId("Your-Custom-ID");
 Adjust.trackEvent(adjustEvent);
@@ -1714,7 +1772,7 @@ class ViewControllerSwift: UIViewController {
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 #import "Adjust.h"
 #import "Constants.h"
 #import "ViewControllerObjC.h"
@@ -1772,7 +1830,9 @@ class ViewControllerSwift: UIViewController {
 </Tab>
 </Tabs>
 
-```txt title="Event log" {4}
+<CodeBlock title="Event log" highlight="{range: 4}">
+
+```txt
 Path:      /event
 ClientSdk: ios$IOS_V4_VERSION
 Parameters:
@@ -1781,5 +1841,7 @@ Parameters:
   event_count      1
   event_token      g3mfiw
 ```
+
+</CodeBlock>
 
 </SdkVersion>

--- a/src/content/docs/sdk/ios/features/preinstalled.mdx
+++ b/src/content/docs/sdk/ios/features/preinstalled.mdx
@@ -13,7 +13,7 @@ Configuring a default link token enables you to attribute all preinstalls to a p
 
 1. [Create a new campaign link in Campaign Lab](https://help.adjust.com/en/article/links).
 
-   ```text "{token}"
+   ```text
    https://app.adjust.com/{token}
    ```
 
@@ -35,7 +35,7 @@ Adjust.initSdk(adjustConfig)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 ADJConfig *adjustConfig = [[ADJConfig alloc] initWithAppToken:@"{YourAppToken}"
                                                    andEnvironment:ADJEnvironmentSandbox];
 [adjustConfig setDefaultTracker:@"{Token}"];
@@ -61,7 +61,7 @@ Configuring a default link token enables you to attribute all preinstalls to a p
 
 1. [Create a new campaign link in Campaign Lab](https://help.adjust.com/en/article/links).
 
-   ```text "{token}"
+   ```text
    https://app.adjust.com/{token}
    ```
 
@@ -70,7 +70,7 @@ Configuring a default link token enables you to attribute all preinstalls to a p
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {6}
+```swift
 let yourAppToken = "{YourAppToken}"
 let environment = ADJEnvironmentSandbox as? String
 let adjustConfig = ADJConfig(
@@ -83,7 +83,7 @@ Adjust.appDidLaunch(adjustConfig)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c {3}
+```objc
 *adjustConfig = [ADJConfig configWithAppToken:@"{YourAppToken}"
                                  environment:ADJEnvironmentSandbox];
 [adjustConfig setDefaultTracker:@"{Token}"];
@@ -93,7 +93,7 @@ Adjust.appDidLaunch(adjustConfig)
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```javascript {5}
+```js
 setupWebViewJavascriptBridge(function (bridge) {
    var yourAppToken = yourAppToken;
    var environment = AdjustConfig.EnvironmentSandbox;

--- a/src/content/docs/sdk/ios/features/privacy.mdx
+++ b/src/content/docs/sdk/ios/features/privacy.mdx
@@ -111,11 +111,15 @@ ADJThirdPartySharing *adjustThirdPartySharing = [[ADJThirdPartySharing alloc] in
 
 ### [Send granular information](send-granular-information)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 - (void)addGranularOption:(nonnull NSString *)partnerName
                       key:(nonnull NSString *)key
                     value:(nonnull NSString *)value;
 ```
+
+</CodeBlock>
 
 You can attach granular information when a user updates their third-party sharing preferences. Use this information to communicate more detail about a user's decision. To do this, call the `addGranularOption` method with the following parameters:
 
@@ -760,9 +764,13 @@ The Adjust SDK contains features that you can use to handle user privacy in your
 
 ## [Send erasure request](send-erasure-request)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (void)gdprForgetMe;
 ```
+
+</CodeBlock>
 
 The EU’s General Data Protection Regulation (GDPR) and similar privacy laws worldwide (CCPA, LGPD, etc.) grant data subjects comprehensive rights when it comes to the processing of their personal data. These rights include, among others, the right to erasure (see [Art. 17 GDPR](https://gdpr.eu/article-17-right-to-be-forgotten/))([1](https://help.adjust.com/en/article/gdpr#ref-1)). As a data processor, Adjust is obliged to support you (the data controller) in the processing of such requests from your (app) users.
 
@@ -801,9 +809,13 @@ You can use the Adjust SDK to record when a user changes their third-party shari
 
 ### [Instantiate an AdjustThirdPartySharing object](instantiate-an-adjustthirdpartysharing-object)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 - (nullable id)initWithIsEnabledNumberBool:(nullable NSNumber *)isEnabledNumberBool;
 ```
+
+</CodeBlock>
 
 To enable or disable third party sharing with the Adjust SDK, you need to instantiate an `AdjustThirdPartySharing` object. This object contains variables that control how third party sharing is handled by Adjust.
 
@@ -814,7 +826,7 @@ To instantiate a third party sharing object, create a new `AdjustThirdPartyShari
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {1}
+```swift
 let adjustThirdPartySharing = ADJThirdPartySharing.initWithIsEnabledNumberBool(1)
 Adjust.trackThirdPartySharing(adjustThirdPartySharing)
 ```
@@ -822,7 +834,7 @@ Adjust.trackThirdPartySharing(adjustThirdPartySharing)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {1}
+```objc
 ADJThirdPartySharing *adjustThirdPartySharing = [[ADJThirdPartySharing alloc] initWithIsEnabledNumberBool:1];
 [Adjust trackThirdPartySharing:adjustThirdPartySharing];
 ```
@@ -830,7 +842,7 @@ ADJThirdPartySharing *adjustThirdPartySharing = [[ADJThirdPartySharing alloc] in
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {2}
+```js
 var adjustThirdPartySharing = new AdjustThirdPartySharing(1);
 Adjust.trackThirdPartySharing(adjustThirdPartySharing);
 ```
@@ -849,7 +861,7 @@ Once you've instantiated your `AdjustThirdPartySharing` object, you can send the
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {2}
+```swift
 let adjustThirdPartySharing = ADJThirdPartySharing.initWithIsEnabledNumberBool(0)
 Adjust.trackThirdPartySharing(adjustThirdPartySharing)
 ```
@@ -857,7 +869,7 @@ Adjust.trackThirdPartySharing(adjustThirdPartySharing)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {2}
+```objc
 ADJThirdPartySharing *adjustThirdPartySharing = [[ADJThirdPartySharing alloc] initWithIsEnabledNumberBool:0];
 [Adjust trackThirdPartySharing:adjustThirdPartySharing];
 ```
@@ -865,7 +877,7 @@ ADJThirdPartySharing *adjustThirdPartySharing = [[ADJThirdPartySharing alloc] in
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {2}
+```js
 var adjustThirdPartySharing = new AdjustThirdPartySharing(0);
 Adjust.trackThirdPartySharing(adjustThirdPartySharing);
 ```
@@ -875,11 +887,15 @@ Adjust.trackThirdPartySharing(adjustThirdPartySharing);
 
 ### [Send granular information](send-granular-information)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 - (void)addGranularOption:(nonnull NSString *)partnerName
                       key:(nonnull NSString *)key
                     value:(nonnull NSString *)value;
 ```
+
+</CodeBlock>
 
 You can attach granular information when a user updates their third-party sharing preferences. Use this information to communicate more detail about a user's decision. To do this, call the `addGranularOption` method with the following parameters:
 
@@ -909,7 +925,7 @@ The following partners are available:
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {2}
+```swift
 let adjustThirdPartySharing = ADJThirdPartySharing.initWithIsEnabledNumberBool(nil)
 adjustThirdPartySharing.addGranularOption("PartnerA", key: "foo", value: "bar")
 Adjust.trackThirdPartySharing(adjustThirdPartySharing)
@@ -918,7 +934,7 @@ Adjust.trackThirdPartySharing(adjustThirdPartySharing)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {2}
+```objc
 ADJThirdPartySharing *adjustThirdPartySharing = [[ADJThirdPartySharing alloc] initWithIsEnabledNumberBool:nil];
 [adjustThirdPartySharing addGranularOption:@"PartnerA" key:@"foo" value:@"bar"];
 [Adjust trackThirdPartySharing:adjustThirdPartySharing];
@@ -927,7 +943,7 @@ ADJThirdPartySharing *adjustThirdPartySharing = [[ADJThirdPartySharing alloc] in
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {2}
+```js
 var adjustThirdPartySharing = new AdjustThirdPartySharing(null);
 adjustThirdPartySharing.addGranularOption("PartnerA", "foo", "bar");
 Adjust.trackThirdPartySharing(adjustThirdPartySharing);
@@ -967,7 +983,7 @@ If you call this method with a `0` value for **either** `data_processing_options
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {2,3}
+```swift
 let tps = ADJThirdPartySharing.initWithIsEnabledNumberBool(nil)
 tps.addGranularOption("facebook", key: "data_processing_options_country", value: "1")
 tps.addGranularOption("facebook", key: "data_processing_options_state", value: "1000")
@@ -977,7 +993,7 @@ Adjust.trackThirdPartySharing(tps)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {2,3}
+```objc
 ADJThirdPartySharing *tps = [[ADJThirdPartySharing alloc] initWithIsEnabledNumberBool:@YES];
 [tps addGranularOption:@"facebook" key:@"data_processing_options_country" value:@"1"];
 [tps addGranularOption:@"facebook" key:@"data_processing_options_state" value:@"1000"];
@@ -987,7 +1003,7 @@ ADJThirdPartySharing *tps = [[ADJThirdPartySharing alloc] initWithIsEnabledNumbe
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {2,3}
+```js
 var tps = new AdjustThirdPartySharing(null);
 tps.addGranularOption("facebook", "data_processing_options_country", "1");
 tps.addGranularOption("facebook", "data_processing_options_state", "1000");
@@ -1030,7 +1046,7 @@ To comply with the EU's Digital Markets Act (DMA), Google Ads and the Google Mar
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {2-4}
+```swift
 let adjustThirdPartySharing = ADJThirdPartySharing.initWithIsEnabledNumberBool(nil)
 adjustThirdPartySharing.addGranularOption("google_dma", key: "eea", value: "1")
 adjustThirdPartySharing.addGranularOption("google_dma", key: "ad_personalization", value: "1")
@@ -1041,7 +1057,7 @@ Adjust.trackThirdPartySharing(adjustThirdPartySharing)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {2-4}
+```objc
 ADJThirdPartySharing *adjustThirdPartySharing = [[ADJThirdPartySharing alloc] initWithIsEnabledNumberBool:nil];
 [adjustThirdPartySharing addGranularOption:@"google_dma" key:@"eea" value:@"1"];
 [adjustThirdPartySharing addGranularOption:@"google_dma" key:@"ad_personalization" value:@"1"];
@@ -1224,9 +1240,13 @@ Adjust.trackThirdPartySharing(adjustThirdPartySharing);
 
 ## [Disable third-party sharing](disable-third-party-sharing)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (void)disableThirdPartySharing;
 ```
+
+</CodeBlock>
 
 To disable third-party sharing for all users, call the `disableThirdPartySharing` method. When Adjust's servers receive this information, Adjust stops sharing the user's data with third-parties. The Adjust SDK continues to work as expected.
 
@@ -1256,9 +1276,13 @@ Adjust.disableThirdPartySharing();
 
 ## [Data residency](data-residency)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 @property (nonatomic, copy, readwrite, nullable) NSString *urlStrategy;
 ```
+
+</CodeBlock>
 
 The URL strategy feature allows you to set either:
 
@@ -1286,7 +1310,7 @@ To set your country of data residency, assign one of the following URL strategie
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {7}
+```swift
 let yourAppToken = "{YourAppToken}"
 let environment = ADJEnvironmentSandbox as? String
 let adjustConfig = ADJConfig(
@@ -1299,7 +1323,7 @@ adjustConfig?.urlStrategy = ADJDataResidencyEU
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c {6}
+```objc
 NSString *yourAppToken = @"{YourAppToken}";
 NSString *environment = ADJEnvironmentSandbox;
 *adjustConfig = [ADJConfig configWithAppToken:yourAppToken
@@ -1311,7 +1335,7 @@ NSString *environment = ADJEnvironmentSandbox;
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```javascript {6}
+```js
 setupWebViewJavascriptBridge(function (bridge) {
    // ...
    var yourAppToken = yourAppToken;
@@ -1326,9 +1350,13 @@ setupWebViewJavascriptBridge(function (bridge) {
 
 ## [Consent measurement for specific users](consent-measurement-for-specific-users)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (void)trackMeasurementConsent:(BOOL)enabled;
 ```
+
+</CodeBlock>
 
 If you're using [Data Privacy settings](https://help.adjust.com/en/article/manage-data-collection-and-retention) in your Adjust dashboard, you need to set up the Adjust SDK to work with them. This includes settings such as consent expiry period and user data retention period.
 
@@ -1364,9 +1392,13 @@ Adjust.trackMeasurementConsent(true);
 
 ## [COPPA compliance](coppa-compliance)
 
-```java title="Method signature"
+<CodeBlock title="Method signature">
+
+```java
 public void setCoppaCompliantEnabled(boolean coppaCompliantEnabled)
 ```
+
+</CodeBlock>
 
 If you need your app to be compliant with the Children's Online Privacy Protection Act (COPPA), call the `[ADJConfig setCoppaCompliantEnabled]` method. This method performs the following actions:
 
@@ -1376,7 +1408,7 @@ If you need your app to be compliant with the Children's Online Privacy Protecti
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {6}
+```swift
 let yourAppToken = "{YourAppToken}"
 let environment = ADJEnvironmentSandbox as? String
 let adjustConfig = ADJConfig(
@@ -1389,7 +1421,7 @@ Adjust.appDidLaunch(adjustConfig)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c {3}
+```objc
 *adjustConfig = [ADJConfig configWithAppToken:@"{YourAppToken}"
                                  environment:ADJEnvironmentSandbox];
 [adjustConfig coppaCompliantEnabled:YES];

--- a/src/content/docs/sdk/ios/features/session-parameters.mdx
+++ b/src/content/docs/sdk/ios/features/session-parameters.mdx
@@ -84,9 +84,13 @@ Adjust.removeGlobalCallbackParameterForKey("foo")
 
 ### [Remove all global callback parameters](remove-all-global-callback-parameters)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (void)removeGlobalCallbackParameters;
 ```
+
+</CodeBlock>
 
 You can remove all global parameters if they're no longer required. To do this, call the `[Adjust removeGlobalCallbackParameters]` method.
 
@@ -121,9 +125,13 @@ Partner parameters don't appear in raw data by default. You can add the `{partne
 
 ### [Add global partner parameters](add-global-partner-parameters)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (void)addGlobalPartnerParameter:(nonnull NSString *)param forKey:(nonnull NSString *)key;
 ```
+
+</CodeBlock>
 
 Send global partner parameters by calling the `[Adjust addGlobalPartnerParameter]` method with the following arguments:
 
@@ -225,9 +233,13 @@ You can configure callback parameters to your servers. Once you configure parame
 
 ### [Add session callback parameters](add-session-callback-parameters)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (void)addSessionCallbackParameter:(nonnull NSString *)key value:(nonnull NSString *)value;
 ```
+
+</CodeBlock>
 
 Add callback parameters to your event by calling the `addSessionCallbackParameter` method with `NSString` key-value arguments. You can add multiple parameters by calling this method multiple times.
 
@@ -257,9 +269,13 @@ Adjust.addSessionCallbackParameter("foo", "bar");
 
 ### [Remove session callback parameters](remove-session-callback-parameters)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (void)removeSessionCallbackParameter:(nonnull NSString *)key;
 ```
+
+</CodeBlock>
 
 You can remove specific session callback parameters if they're no longer required. To do this, pass the parameter `key` to the `removeSessionCallbackParameter` method.
 
@@ -289,9 +305,13 @@ Adjust.removeSessionCallbackParameter("foo");
 
 ### [Reset session callback parameters](reset-session-callback-parameters)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (void)resetSessionCallbackParameters;
 ```
+
+</CodeBlock>
 
 You can remove all session parameters if they're no longer required. To do this, call the `resetSessionCallbackParameters` method.
 
@@ -333,9 +353,13 @@ Partner parameters don't appear in raw data by default. You can add the `{partne
 
 ### [Add session partner parameters](add-session-partner-parameters)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (void)addSessionPartnerParameter:(nonnull NSString *)key value:(nonnull NSString *)value;
 ```
+
+</CodeBlock>
 
 Send partner parameters with your session by calling the `addSessionPartnerParameter` method with `NSString` key-value arguments. You can add multiple parameters by calling this method multiple times.
 
@@ -365,9 +389,13 @@ Adjust.addSessionPartnerParameter("foo", "bar");
 
 ### [Remove session partner parameters](remove-session-partner-parameters)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (void)removeSessionPartnerParameter:(nonnull NSString *)key;
 ```
+
+</CodeBlock>
 
 You can remove specific session partner parameters if they're no longer required. To do this, pass the parameter key to the `removeSessionPartnerParameter` method.
 
@@ -397,9 +425,13 @@ Adjust.removeSessionPartnerParameter("foo");
 
 ### [Reset session partner parameters](reset-session-partner-parameters)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (void)resetSessionPartnerParameters;
 ```
+
+</CodeBlock>
 
 You can remove all session partner parameters if they're no longer required. To do this, call the `resetSessionPartnerParameters` method.
 
@@ -440,7 +472,7 @@ The Adjust SDK starts as soon as your app opens. If you want to send data that's
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {6}
+```swift
 let yourAppToken = "{YourAppToken}"
 let environment = ADJEnvironmentSandbox as? String
 let adjustConfig = ADJConfig(
@@ -454,7 +486,7 @@ Adjust.appDidLaunch(adjustConfig)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {3}
+```objc
 *adjustConfig = [ADJConfig configWithAppToken:@"{YourAppToken}"
                                  environment:ADJEnvironmentSandbox];
 [adjustConfig setDelayStart:5.5];
@@ -465,7 +497,7 @@ Adjust.appDidLaunch(adjustConfig)
 </Tab>
 <Tab title="Javascript" sync="js">
 
-```js {5}
+```js
 setupWebViewJavascriptBridge(function (bridge) {
    var yourAppToken = yourAppToken;
    var environment = AdjustConfig.EnvironmentSandbox;

--- a/src/content/docs/sdk/ios/features/skad.mdx
+++ b/src/content/docs/sdk/ios/features/skad.mdx
@@ -57,7 +57,7 @@ Adjust.initSdk(adjustConfig)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 ADJConfig *adjustConfig = [[ADJConfig alloc] initWithAppToken:@"{YourAppToken}"
                                                    andEnvironment:ADJEnvironmentSandbox];
 [adjustConfig disableSkanAttribution];
@@ -148,7 +148,7 @@ func adjustSkanUpdated(withConversionData data: [String: String]) {
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 - (void)adjustSkanUpdatedWithConversionData:(NSDictionary<NSString *, NSString *> *)data {
     NSLog(@"Conversion value updated callback called!");
     NSLog(@"Conversion value dictionary: \n%@", data.description);
@@ -200,9 +200,13 @@ StoreKit Ad Network (SKAdNetwork) is Apple's attribution framework for app insta
 
 ## [Disable SKAdNetwork communication](disable-skadnetwork-communication)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 - (void)deactivateSKAdNetworkHandling;
 ```
+
+</CodeBlock>
 
 <MinorVersion added="v4.23.0">
 
@@ -221,7 +225,7 @@ You must call the `deactivateSKAdNetworkHandling` method _before_ initializing t
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {7}
+```swift
 let yourAppToken = "{YourAppToken}"
 let environment = ADJEnvironmentSandbox as? String
 let adjustConfig = ADJConfig(
@@ -236,7 +240,7 @@ Adjust.appDidLaunch(adjustConfig)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c {3}
+```objc
 *adjustConfig = [ADJConfig configWithAppToken:@"{YourAppToken}"
                                  environment:ADJEnvironmentSandbox];
 [adjustConfig.deactivateSKAdNetworkHandling];
@@ -249,9 +253,13 @@ Adjust.appDidLaunch(adjustConfig)
 
 ## [Update conversion values](update-conversion-values)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (void)updateConversionValue:(NSInteger)conversionValue;
 ```
+
+</CodeBlock>
 
 Conversion values are a mechanism used to measure user behavior in SKAdNetwork. You can map 64 conditions to values from `0` through `63` and send this integer value to SKAdNetwork on user install. This gives you insight into how your users interact with your app in the first few days.
 
@@ -290,7 +298,7 @@ func onButtonClick() {
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 - (void)onButtonClick {
    [Adjust updateConversionValue:10];
 }
@@ -342,7 +350,7 @@ if #available(iOS 16.1, *) {
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 if (@available(iOS 16.1, *)) {
   [Adjust updatePostbackConversionValue:1
                             coarseValue:SKAdNetworkCoarseConversionValueLow
@@ -379,7 +387,7 @@ func adjustConversionValueUpdated(_ conversionValue: NSNumber?) {
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 - (void)adjustConversionValueUpdated:(NSNumber *)conversionValue {
     NSLog(@"Conversion value: %@", conversionValue);
 }
@@ -420,7 +428,7 @@ func adjustConversionValueUpdated(_ fineValue: NSNumber?, coarseValue: String?, 
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 - (void)adjustConversionValueUpdated:(NSNumber *)fineValue coarseValue:(NSString *)coarseValue lockWindow:(NSNumber *)lockWindow {
     NSLog(@"Fine conversion value: %@", fineValue);
     NSLog(@"Coarse conversion value: %@", coarseValue);

--- a/src/content/docs/sdk/ios/features/subscriptions.mdx
+++ b/src/content/docs/sdk/ios/features/subscriptions.mdx
@@ -14,12 +14,17 @@ You can record App Store subscriptions and verify their validity with the Adjust
 
 ## [1. Instantiate a subscription object](1-instantiate-a-subscription-object)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 - (nullable id)initWithPrice:(nonnull NSDecimalNumber *)price
                     currency:(nonnull NSString *)currency
                transactionId:(nonnull NSString *)transactionId
                   andReceipt:(nonnull NSData *)receipt;
+
 ```
+
+</CodeBlock>
 
 To get started, you need to create a subscription object containing details of the subscription purchase. To do this, initialize an `ADJSubscription` object using the `initWithPrice` method. Pass the following arguments:
 
@@ -60,16 +65,20 @@ ADJSubscription *subscription = [[ADJSubscription alloc] initWithPrice:price
 
 ### [Record the purchase date](record-the-purchase-date)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 - (void)setTransactionDate:(nonnull NSDate *)transactionDate;
 ```
+
+</CodeBlock>
 
 You can record the date on which the user purchased a subscription. The SDK returns this data for you to report on. Call the `setTransactionDate` method with a timestamp to record this information.
 
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {7}
+```swift
 let subscription = ADJSubscription(
     price: price,
     currency: currency,
@@ -82,7 +91,7 @@ subscription.setTransactionDate(transactionDate)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {6}
+```objc
 ADJSubscription *subscription = [[ADJSubscription alloc] initWithPrice:price
                                                               currency:currency
                                                          transactionId:transactionId
@@ -96,16 +105,20 @@ ADJSubscription *subscription = [[ADJSubscription alloc] initWithPrice:price
 
 ### [Record the purchase region](record-the-purchase-region)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 - (void)setSalesRegion:(nonnull NSString *)salesRegion;
 ```
+
+</CodeBlock>
 
 You can record the region in which the user purchased a subscription. To do this, call the `setSalesRegion` method on your subscription object and pass the country code as an `NSString`. This needs to be formatted as the [`countryCode`](https://developer.apple.com/documentation/foundation/nslocale/1643060-countrycode?language=swift) of the [`priceLocale`](https://developer.apple.com/documentation/storekit/skproduct/1506145-pricelocale?language=swift) object.
 
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {7}
+```swift
 let subscription = ADJSubscription(
     price: price,
     currency: currency,
@@ -118,7 +131,7 @@ subscription.setSalesRegion(salesRegion)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {6}
+```objc
 ADJSubscription *subscription = [[ADJSubscription alloc] initWithPrice:price
                                                               currency:currency
                                                          transactionId:transactionId
@@ -132,16 +145,20 @@ ADJSubscription *subscription = [[ADJSubscription alloc] initWithPrice:price
 
 ### [Add callback parameters](add-callback-parameters)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 - (void)addCallbackParameter:(nonnull NSString *)key value:(nonnull NSString *)value;
 ```
+
+</CodeBlock>
 
 You can add callback parameters to your subscription object. The SDK appends these parameters to your callback URL. To add callback parameters, call the `addCallbackParameter` method on your subscription object. You can add multiple callback parameters by calling this method multiple times.
 
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {7,8}
+```swift
 let subscription = ADJSubscription(
     price: price,
     currency: currency,
@@ -155,7 +172,7 @@ subscription.addCallbackParameter("key2", value: "value2")
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {6,7}
+```objc
 ADJSubscription *subscription = [[ADJSubscription alloc] initWithPrice:price
                                                               currency:currency
                                                          transactionId:transactionId
@@ -170,16 +187,20 @@ ADJSubscription *subscription = [[ADJSubscription alloc] initWithPrice:price
 
 ### [Add partner parameters](add-partner-parameters)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 - (void)addPartnerParameter:(nonnull NSString *)key value:(nonnull NSString *)value;
 ```
+
+</CodeBlock>
 
 You can add partner parameters to your subscription object. The SDK sends these to Adjust's servers when the user purchases a subscription. Adjust's servers forward the information on to your network partner. To add partner parameters, call the `addPartnerParameter` method on your subscription object. You can add multiple partner parameters by calling this method multiple times.
 
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {7,8}
+```swift
 let subscription = ADJSubscription(
     price: price,
     currency: currency,
@@ -193,7 +214,7 @@ subscription.addParameterParameter("key2", value: "value2")
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {6,7}
+```objc
 ADJSubscription *subscription = [[ADJSubscription alloc] initWithPrice:price
                                                               currency:currency
                                                          transactionId:transactionId
@@ -208,16 +229,20 @@ ADJSubscription *subscription = [[ADJSubscription alloc] initWithPrice:price
 
 ## [2. Send subscription information](2-send-subscription-information)
 
-```objc title="Method signature"
+<CodeBlock title="Method signature">
+
+```objc
 + (void)trackSubscription:(nonnull ADJSubscription *)subscription;
 ```
+
+</CodeBlock>
 
 Once you have set up your subscription object, you can send it to Adjust using the Adjust SDK. Pass your completed object to the `trackSubscription` method to record the user's subscription purchase.
 
 <Tabs>
 <Tab title="Swift" sync="swift">
 
-```swift {20}
+```swift
 let subscription = ADJSubscription(
    price: price,
    currency: currency,
@@ -243,7 +268,7 @@ Adjust.trackSubscription(subscription)
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objc {16}
+```objc
 ADJSubscription *subscription = [[ADJSubscription alloc] initWithPrice:price
                                                             currency:currency
                                                          transactionId:transactionId

--- a/src/content/docs/sdk/ios/migration/v4-to-v5.mdx
+++ b/src/content/docs/sdk/ios/migration/v4-to-v5.mdx
@@ -940,7 +940,7 @@ func application(
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 - (BOOL)application:(UIApplication *)app
     openURL:(NSURL *)incomingURL
     options:(NSDictionary *)options {
@@ -985,7 +985,7 @@ func application(
 </Tab>
 <Tab title="Objective-C" sync="objc">
 
-```objective-c
+```objc
 - (BOOL)application:(UIApplication *)app
     openURL:(NSURL *)incomingURL
     options:(NSDictionary *)options {

--- a/src/content/docs/sdk/ios/plugins/criteo.mdx
+++ b/src/content/docs/sdk/ios/plugins/criteo.mdx
@@ -26,18 +26,26 @@ You can integrate the Adjust iOS SDK with Criteo events by using the Adjust Crit
 
 Add the following line to your `Podfile`:
 
-```text title="Podfile"
+<CodeBlock title="Podfile">
+
+```text
 pod 'Adjust/Criteo'
 ```
+
+</CodeBlock>
 
 </Tab>
 <Tab title="Carthage">
 
 Add following line to your `Cartfile`:
 
-```text title="Cartfile"
+<CodeBlock title="Cartfile">
+
+```text
 github "adjust/ios_sdk" "criteo"
 ```
+
+</CodeBlock>
 
 </Tab>
 </Tabs>

--- a/src/content/docs/sdk/ios/plugins/facebook-pixel.mdx
+++ b/src/content/docs/sdk/ios/plugins/facebook-pixel.mdx
@@ -23,12 +23,17 @@ As described in [Facebook's iOS SDK guide](https://developers.facebook.com/docs/
 1. In Xcode, right click on your project's `Info.plist` file and select **Open As --> Source Code**.
 2. Insert the following XML snippet into the body of your file just before the final `</dict>` element:
 
-```xml title="Info.plist"
+<CodeBlock title="Info.plist">
+
+```xml
 <dict>
   <key>FacebookAppID</key>
   <string>{your-app-id}</string>
 </dict>
+
 ```
+
+</CodeBlock>
 
 Replace `{your-app-id}` with your app's App ID. You can find this in the Facebook App Dashboard.
 

--- a/src/content/docs/sdk/ios/plugins/sociomatic.mdx
+++ b/src/content/docs/sdk/ios/plugins/sociomatic.mdx
@@ -26,18 +26,26 @@ You can integrate the Adjust SDK with Sociomantic events.
 
 Add the following line to your `Podfile`:
 
-```text title="Podfile"
+<CodeBlock title="Podfile">
+
+```text
 pod 'Adjust/Sociomatic'
 ```
+
+</CodeBlock>
 
 </Tab>
 <Tab title="Carthage">
 
 Add following line to your `Cartfile`:
 
-```text title="Cartfile"
+<CodeBlock title="Cartfile">
+
+```text
 github "adjust/ios_sdk" "sociomatic"
 ```
+
+</CodeBlock>
 
 </Tab>
 </Tabs>

--- a/src/content/docs/sdk/ios/plugins/trademob.mdx
+++ b/src/content/docs/sdk/ios/plugins/trademob.mdx
@@ -32,18 +32,26 @@ To use this feature, you first need to download and set up the Adjust SDK for yo
 
 Add the following line to your `Podfile`:
 
-```text title="Podfile"
+<CodeBlock title="Podfile">
+
+```text
 pod 'Adjust/Trademob'
 ```
+
+</CodeBlock>
 
 </Tab>
 <Tab title="Carthage">
 
 Add following line to your `Cartfile`:
 
-```text title="Cartfile"
+<CodeBlock title="Cartfile">
+
+```text
 github "adjust/ios_sdk" "trademob"
 ```
+
+</CodeBlock>
 
 </Tab>
 </Tabs>

--- a/src/content/docs/sdk/react-native/configuration.mdx
+++ b/src/content/docs/sdk/react-native/configuration.mdx
@@ -9,9 +9,13 @@ Use the methods in this document to configure the behavior of the Adjust SDK.
 
 ## [Instantiate your config object](instantiate-your-config-object)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 constructor(appToken: string, environment: Environment)
 ```
+
+</CodeBlock>
 
 To configure the Adjust SDK, you need to instantiate an `AdjustConfig` object. This object contains the **read-only** configuration options that you need to pass to the Adjust SDK.
 
@@ -35,9 +39,13 @@ Adjust.create(adjustConfig);
 
 ### [Set your logging level](set-your-logging-level)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public setLogLevel(level: LogLevel): void
 ```
+
+</CodeBlock>
 
 The Adjust SDK provides configurable log levels to return different amounts of information. The following log levels are available:
 
@@ -59,7 +67,7 @@ You can set your log level by calling the `setLogLevel` method on your `AdjustCo
 
 -  `logLevel` (`LogLevel`): The log level you want to use.
 
-```jsx {6}
+```jsx
 const adjustConfig = new AdjustConfig(
    "{YourAppToken}",
    AdjustConfig.EnvironmentSandbox,
@@ -72,9 +80,13 @@ Adjust.create(adjustConfig);
 
 ### [Set external device identifier](set-external-device-identifier)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public setExternalDeviceId(externalDeviceId: string): void
 ```
+
+</CodeBlock>
 
 An external device identifier is a custom value that you can assign to a device or user. They help you recognize users across sessions and platforms. They can also help you deduplicate installs by user so that a user isn't counted as duplicate new installs. Contact your Adjust representative to get started with external device IDs.
 
@@ -88,7 +100,7 @@ See the [External device identifiers article](https://help.adjust.com/en/article
 
 </Callout>
 
-```jsx {6}
+```jsx
 const adjustConfig = new AdjustConfig(
    "{YourAppToken}",
    AdjustConfig.EnvironmentSandbox,
@@ -105,15 +117,19 @@ You can import existing external device IDs into Adjust. This ensures that the A
 
 ### [Set default link token](set-default-link-token)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public setDefaultTracker(defaultTracker: string): void
 ```
+
+</CodeBlock>
 
 You can configure a default link token if your app is preinstalled on a device. When a user opens the preinstalled app for the first time, the install is attributed to the default link token. To set your default link token, call the `setDefaultTracker` method with the following argument:
 
 -  `defaultTracker` (`string`): The [Adjust link token](https://help.adjust.com/en/article/links#adjust-link-token) you want to record preinstalled installs against.
 
-```jsx {6}
+```jsx
 const adjustConfig = new AdjustConfig(
    "{YourAppToken}",
    AdjustConfig.EnvironmentSandbox,
@@ -126,9 +142,13 @@ Adjust.create(adjustConfig);
 
 ### [Enable cost data sending](enable-cost-data-sending)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public setNeedsCost(needsCost: boolean): void
 ```
+
+</CodeBlock>
 
 By default, the Adjust SDK doesn't send cost data as part of a user's attribution. You can configure the SDK to send this data by enabling cost data sending. To enable cost data sending, call the `setNeedsCost` method on your config instance with the following parameter:
 
@@ -136,7 +156,7 @@ By default, the Adjust SDK doesn't send cost data as part of a user's attributio
 
 Cost data is accessible in the user's [attribution information](/en/sdk/react-native/features/attribution).
 
-```jsx {6}
+```jsx
 const adjustConfig = new AdjustConfig(
    "{Your App Token}",
    AdjustConfig.EnvironmentSandbox,
@@ -147,15 +167,19 @@ adjustConfig.setNeedsCost(true);
 
 ### [Enable background recording](enable-background-recording)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public setSendInBackground(sendInBackground: boolean): void
 ```
+
+</CodeBlock>
 
 By default, the Adjust SDK pauses the sending of requests when your app is running in the background. You can configure the SDK to send requests in the background by enabling the background recording. To enable background recording, call the `setSendInBackground` method on your config instance with the following parameter:
 
 -  `sendInBackground` (`boolean`): Set to `true` to enable background sending or `false` to disable background sending.
 
-```jsx {3}
+```jsx
 const adjustConfig = new AdjustConfig(appToken, environment);
 //...
 adjustConfig.setSendInBackground(true);
@@ -165,9 +189,13 @@ Adjust.create(adjustConfig);
 
 ### [Enable event buffering](enable-event-buffering)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public setEventBufferingEnabled(eventBufferingEnabled: boolean): void
 ```
+
+</CodeBlock>
 
 The Adjust SDK sends event information as soon as a user triggers an event in your app. You can send event information on a schedule by enabling event buffering. Event buffering stores events in a local buffer on the device and sends all requests once per minute.
 
@@ -175,7 +203,7 @@ Your config object contains a boolean `eventBufferingEnabled` property that cont
 
 -  `eventBufferingEnabled` (`boolean`): Set to `true` to enable event buffering or `false` to disable event buffering.
 
-```jsx {6}
+```jsx
 const adjustConfig = new AdjustConfig(
    "{YourAppToken}",
    AdjustConfig.EnvironmentSandbox,
@@ -188,9 +216,13 @@ Adjust.create(adjustConfig);
 
 ### [Delay the start of the SDK](delay-the-start-of-the-sdk)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public setDelayStart(delayStart: number): void
 ```
+
+</CodeBlock>
 
 By default, the Adjust SDK starts as soon as your app opens. If you want to send data that isn't available at launch in [session parameters](/en/sdk/android/features/session-parameters), you can delay the start of the SDK. This can be helpful if you are sending information such as unique identifiers.
 
@@ -198,7 +230,7 @@ To configure a startup delay, call the `setDelayStart` method with the following
 
 -  `delayStart` (`number`): The time (in seconds) by which to delay the start of the SDK. You can delay the start of the SDK by up to **10 seconds**.
 
-```jsx {6}
+```jsx
 const adjustConfig = new AdjustConfig(
    "{YourAppToken}",
    AdjustConfig.EnvironmentSandbox,
@@ -215,9 +247,13 @@ Adjust.create(adjustConfig);
 
 ### [Toggle offline mode](toggle-offline-mode)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 setOfflineMode: (enabled: boolean) => void
 ```
+
+</CodeBlock>
 
 <Callout type="important">
 
@@ -237,9 +273,13 @@ Adjust.setOfflineMode(true);
 
 ### [Set push tokens](set-push-tokens)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 setPushToken: (token: string) => void
 ```
+
+</CodeBlock>
 
 Push tokens are used for [Audiences](https://help.adjust.com/en/article/audiences) and client callbacks. They're also required for [Uninstall and reinstall measurement](https://help.adjust.com/en/article/uninstalls-reinstalls).
 
@@ -265,9 +305,13 @@ You can only call this method after the first session. This setting persists bet
 
 </Callout>
 
-```ts title="Method siganture"
+<CodeBlock title="Method siganture">
+
+```ts
 setEnabled: (enabled: boolean) => void
 ```
+
+</CodeBlock>
 
 The Adjust SDK runs by default when your app is open. You can disable and re-enable the Adjust SDK to pause and resume recording. When you disable the Adjust SDK, it doesn't send any data to Adjust's servers.
 
@@ -281,9 +325,13 @@ Adjust.setEnabled(false);
 
 #### [Check enabled status](check-enabled-status)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 isEnabled: (callback: (enabled: boolean) => void) => void
 ```
+
+</CodeBlock>
 
 You can check if the Adjust SDK is enabled at any time by calling the `isEnabled` method. This method returns a `boolean` value indicating if the SDK is **enabled** (`true`) or **disabled** (`false`).
 

--- a/src/content/docs/sdk/react-native/features/ad-revenue.mdx
+++ b/src/content/docs/sdk/react-native/features/ad-revenue.mdx
@@ -14,9 +14,13 @@ You need to perform some extra setup steps in your Adjust dashboard to measure a
 
 ## [Instantiate an AdjustAdRevenue object](instantiate-an-adjustadrevenue-object)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 constructor(source: string)
 ```
+
+</CodeBlock>
 
 To send ad revenue information with the Adjust SDK, you need to instantiate an `AdjustAdRevenue` object. This object contains variables that are sent to Adjust when ad revenue is recorded in your app.
 
@@ -39,7 +43,7 @@ To instantiate an ad revenue object, create a new `AdjustAdRevenue` instance and
 
 </Table>
 
-```jsx {1}
+```jsx
 var adjustAdRevenue = new AdjustAdRevenue("source");
 //...
 Adjust.trackAdRevenue(adjustAdRevenue);
@@ -47,13 +51,17 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 ## [Send ad revenue](send-ad-revenue)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 trackAdRevenue: ((source: string, payload: string) => void) & ((source: AdjustAdRevenue) => void)
 ```
 
+</CodeBlock>
+
 To send ad revenue to Adjust, call the `trackAdRevenue` method with your ad revenue instance as an argument.
 
-```jsx {3}
+```jsx
 var adjustAdRevenue = new AdjustAdRevenue("source");
 //...
 Adjust.trackAdRevenue(adjustAdRevenue);
@@ -61,9 +69,13 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 ## [Record ad revenue amount](record-ad-revenue-amount)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public setRevenue(revenue: number, currency: string): void
 ```
+
+</CodeBlock>
 
 To send the ad revenue amount, call the `setRevenue` method and pass the following arguments:
 
@@ -76,7 +88,7 @@ Check the [guide to recording purchases in different currencies](https://help.ad
 
 </Callout>
 
-```jsx {3}
+```jsx
 var adjustAdRevenue = new AdjustAdRevenue("source");
 //...
 adjustAdRevenue.setRevenue(1.0, "EUR");
@@ -90,15 +102,19 @@ The `AdjustAdRevenue` class contains properties you can use to report on your ad
 
 ### [Ad impressions](ad-impressions)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public setAdImpressionsCount(adImpressionsCount: number): void
 ```
+
+</CodeBlock>
 
 To send the number of recorded ad impressions, call the `setAdImpressionsCount` method and pass the following arguments:
 
 -  `adImpressionsCount` (`number`): The number of ad impressions.
 
-```jsx {3}
+```jsx
 var adjustAdRevenue = new AdjustAdRevenue("source");
 //...
 adjustAdRevenue.setAdImpressionsCount(10);
@@ -108,15 +124,19 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 ### [Ad revenue network](ad-revenue-network)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public setAdRevenueNetwork(adRevenueNetwork: string): void
 ```
+
+</CodeBlock>
 
 To send the ad revenue network, call the `setAdRevenueNetwork` method and pass the following arguments:
 
 -  `adRevenueNetwork` (`string`): The network name.
 
-```jsx {3}
+```jsx
 var adjustAdRevenue = new AdjustAdRevenue("source");
 //...
 adjustAdRevenue.setAdRevenueNetwork("network1");
@@ -126,15 +146,19 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 ### [Ad revenue unit](ad-revenue-unit)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public setAdRevenueUnit(adRevenueUnit: string): void
 ```
+
+</CodeBlock>
 
 To send the ad revenue unit, call the `setAdRevenueUnit` method and pass the following arguments:
 
 -  `adRevenueUnit` (`string`): The ad unit.
 
-```jsx {3}
+```jsx
 var adjustAdRevenue = new AdjustAdRevenue("source");
 //...
 adjustAdRevenue.setAdRevenueUnit("unit1");
@@ -144,13 +168,17 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 ### [Ad revenue placement](ad-revenue-placement)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public setAdRevenuePlacement(adRevenuePlacement: string): void
 ```
 
+</CodeBlock>
+
 Record the placement of your ad by passing a `string` value to the `setAdRevenuePlacement` method.
 
-```jsx {3}
+```jsx
 var adjustAdRevenue = new AdjustAdRevenue("source");
 //...
 adjustAdRevenue.setAdRevenuePlacement("banner");
@@ -160,9 +188,13 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 ## [Add callback parameters](add-callback-parameters)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public addCallbackParameter(key: string, value: string): void
 ```
+
+</CodeBlock>
 
 If you [register a callback URL](https://help.adjust.com/en/article/recommended-placeholders-callbacks) in the Adjust dashboard, the SDK sends a GET request to your callback URL when it records an event.
 
@@ -172,9 +204,13 @@ Add callback parameters to your event by calling the `addCallbackParameter` meth
 
 The Adjust SDK measures the event and sends a request to your URL with the callback parameters. For example, if you register the URL `https://www.mydomain.com/callback`, your callback looks like this:
 
-```http "key=value" "foo=bar"
+<CodeBlock highlight="key=value, foo=bar">
+
+```http
 https://www.mydomain.com/callback?key=value&foo=bar
 ```
+
+</CodeBlock>
 
 <Callout type="note">
 
@@ -192,7 +228,7 @@ You can read more about using URL callbacks, including a full list of available 
 
 </Callout>
 
-```jsx {3}
+```jsx
 var adjustAdRevenue = new AdjustAdRevenue("source");
 //...
 adjustAdRevenue.addCallbackParameter("key", "value");
@@ -202,9 +238,13 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 ## [Add partner parameters](add-partner-parameters)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public addPartnerParameter(key: string, value: string): void
 ```
+
+</CodeBlock>
 
 You can send extra information to your network partners by adding [partner parameters](https://help.adjust.com/en/article/data-sharing-ad-network#map-parameters).
 
@@ -218,7 +258,7 @@ Partner parameters don't appear in raw data by default. You can add the `{partne
 
 Add partner parameters to your event by calling the `addPartnerParameter` method with `string` key-value arguments. You can add multiple parameters by calling this method multiple times.
 
-```jsx {3}
+```jsx
 var adjustAdRevenue = new AdjustAdRevenue("source");
 //...
 adjustAdRevenue.addPartnerParameter("key", "value");

--- a/src/content/docs/sdk/react-native/features/att.mdx
+++ b/src/content/docs/sdk/react-native/features/att.mdx
@@ -27,9 +27,13 @@ You might receive a status code of `-1` if the SDK is unable to retrieve the ATT
 
 ## [ATT authorization wrapper](att-authorization-wrapper)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 requestTrackingAuthorizationWithCompletionHandler: (handler: (status: number) => void) => void
 ```
+
+</CodeBlock>
 
 The Adjust SDK contains a wrapper around [Apple's `requestTrackingAuthorizationWithCompletionHandler` method](https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanager/3547037-requesttrackingauthorizationwith). You can use this wrapper if you don't want to customize the ATT prompt.
 
@@ -93,9 +97,13 @@ Adjust.requestTrackingAuthorizationWithCompletionHandler(function (status) {
 
 ## [Get current authorization status](get-current-authorization-status)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 getAppTrackingAuthorizationStatus: (callback: (authorizationStatus: number) => void) => void
 ```
+
+</CodeBlock>
 
 You can retrieve a user's current authorization status at any time. Call the `getAppTrackingAuthorizationStatus` method to return the authorization status code as a `number`.
 
@@ -107,16 +115,20 @@ Adjust.getAppTrackingAuthorizationStatus();
 
 This example shows how to collect the user's authorization status and convert it to a `string`. This information is assigned to a variable called `authorizationStatus` and passed as a session partner parameter with the key `"status"`.
 
-```jsx {2}
+```jsx
 var authorizationStatus = String(Adjust.getAppTrackingAuthorizationStatus());
 Adjust.addSessionPartnerParameter("status", authorizationStatus);
 ```
 
 ## [Check for authorization status changes](check-for-authorization-status-changes)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 checkForNewAttStatus: () => void
 ```
+
+</CodeBlock>
 
 If you use a custom ATT prompt, you need to inform the Adjust SDK of changes to the user's authorization status. Call the `checkForNewAttStatus` method to send the authorization status to Adjust's servers.
 
@@ -126,9 +138,13 @@ Adjust.checkForNewAttStatus();
 
 ## [Custom prompt timing](custom-prompt-timing)
 
-```js title="Method signature"
+<CodeBlock title="Method signature">
+
+```js
 AdjustConfig.prototype.setAttConsentWaitingInterval = function(attConsentWaitingInterval);
 ```
+
+</CodeBlock>
 
 If your app includes an onboarding process or a tutorial, you may want to delay sending your user's ATT consent status until after the user has completed this process. To do this, you can set the `attConsentWaitingInterval` property to delay the sending of data for **up to 120 seconds** to give the user time to complete the initial onboarding. After the timeout ends or the user sets their consent status, the SDK sends all information it has recorded during the delay to Adjust's servers along with the user's consent status.
 
@@ -138,7 +154,7 @@ If the user closes the app before the timeout ends, or before they select their 
 
 </Callout>
 
-```jsx {6}
+```jsx
 const adjustConfig = new AdjustConfig(
    "{YourAppToken}",
    AdjustConfig.EnvironmentSandbox,

--- a/src/content/docs/sdk/react-native/features/attribution.mdx
+++ b/src/content/docs/sdk/react-native/features/attribution.mdx
@@ -41,10 +41,14 @@ The following values can only be accessed if the [`needsCost` property on your `
 
 ## [Trigger a function when attribution changes](trigger-a-function-when-attribution-changes)
 
-```dart title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```dart
 typedef void AttributionCallback(AdjustAttribution attributionData);
 AttributionCallback? attributionCallback;
 ```
+
+</CodeBlock>
 
 The SDK can listen for attribution changes and call a function when it detects an update. To configure your callback function, call the `setAttributionCallbackListener` method with your function as an argument.
 
@@ -54,7 +58,9 @@ You must call the `setAttributionCallbackListener` method **before** initializin
 
 </Callout>
 
-```jsx {3-18}
+<CodeBlock highlight="{range: 3-18}">
+
+```jsx
 const adjustConfig = new AdjustConfig(appToken, environment);
 
 adjustConfig.setAttributionCallbackListener(function (attribution) {
@@ -77,11 +83,17 @@ adjustConfig.setAttributionCallbackListener(function (attribution) {
 Adjust.create(adjustConfig);
 ```
 
+</CodeBlock>
+
 ## [Get current attribution information](get-current-attribution-information)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 getAttribution: (callback: (attribution: AdjustAttribution) => void) => void
 ```
+
+</CodeBlock>
 
 When a user installs your app, Adjust attributes the install to a campaign. The Adjust SDK gives you access to campaign attribution details for your install. To return this information, call the `getAttribution` method to return the attribution information as an `AdjustAttribution` object.
 

--- a/src/content/docs/sdk/react-native/features/callbacks.mdx
+++ b/src/content/docs/sdk/react-native/features/callbacks.mdx
@@ -32,15 +32,20 @@ Session callbacks have access to a response data object. You can use its propert
 
 ### [Success callbacks](success-callbacks)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public setSessionTrackingSucceededCallbackListener(
    callback: (sessionSuccess: AdjustSessionTrackingSuccess) => void
 ): void
+
 ```
+
+</CodeBlock>
 
 Set up success callbacks to trigger functions when the SDK records a session.
 
-```jsx {6-15}
+```jsx
 const adjustConfig = new AdjustConfig(
    "{YourAppToken}",
    AdjustConfig.EnvironmentSandbox,
@@ -64,7 +69,7 @@ Adjust.create(adjustConfig);
 
 This example shows how to created a callback function `sessionSuccess` and register it as a **success** callback. The function logs the timestamp at which the SDK recorded the session.
 
-```jsx {6-10}
+```jsx
 const adjustConfig = new AdjustConfig(
    "{YourAppToken}",
    AdjustConfig.EnvironmentSandbox,
@@ -81,15 +86,20 @@ Adjust.create(adjustConfig);
 
 ### [Failure callbacks](failure-callbacks)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public setSessionTrackingFailedCallbackListener(
    callback: (sessionFailed: AdjustSessionTrackingFailure) => void
 ): void
+
 ```
+
+</CodeBlock>
 
 Set up failure callbacks to trigger functions when the SDK fails to record a session.
 
-```jsx {6-16}
+```jsx
 const adjustConfig = new AdjustConfig(
    "{YourAppToken}",
    AdjustConfig.EnvironmentSandbox,
@@ -114,7 +124,7 @@ Adjust.create(adjustConfig);
 
 This example shows how to created a callback function `sessionFailure` and register it as a **failure** callback. The function logs the session failure message.
 
-```jsx {6-10}
+```jsx
 const adjustConfig = new AdjustConfig(
    "{YourAppToken}",
    AdjustConfig.EnvironmentSandbox,
@@ -151,15 +161,20 @@ Event callbacks have access to a response data object. You can use its propertie
 
 ### [Success callbacks](success-callbacks-1)
 
-```jsx title="Method signature"
+<CodeBlock title="Method signature">
+
+```jsx
 public setEventTrackingSucceededCallbackListener(
    callback: (eventSuccess: AdjustEventTrackingSuccess) => void
 ): void
+
 ```
+
+</CodeBlock>
 
 Set up success callbacks to trigger functions when the SDK records an event.
 
-```jsx {6-15}
+```jsx
 const adjustConfig = new AdjustConfig(
    "{YourAppToken}",
    AdjustConfig.EnvironmentSandbox,
@@ -183,7 +198,7 @@ Adjust.create(adjustConfig);
 
 This example shows how to created a callback function `eventSuccess` and register it as a **success** callback. The function logs the timestamp at which the SDK recorded the event.
 
-```jsx {6-8}
+```jsx
 const adjustConfig = new AdjustConfig(
    "{YourAppToken}",
    AdjustConfig.EnvironmentSandbox,
@@ -198,15 +213,20 @@ Adjust.create(adjustConfig);
 
 ### [Failure callbacks](failure-callbacks-1)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public setEventTrackingFailedCallbackListener(
    callback: (eventFailed: AdjustEventTrackingFailure) => void
 ): void
+
 ```
+
+</CodeBlock>
 
 Set up failure callbacks to trigger functions when the SDK fails to record an event.
 
-```jsx {6-16}
+```jsx
 const adjustConfig = new AdjustConfig(
    "{Your App Token}",
    AdjustConfig.EnvironmentSandbox,
@@ -231,7 +251,7 @@ Adjust.create(adjustConfig);
 
 This example shows how to created a callback function `eventFailure` and register it as a **failure** callback. The function logs the event failure message.
 
-```jsx {6-8}
+```jsx
 const adjustConfig = new AdjustConfig(
    "{YourAppToken}",
    AdjustConfig.EnvironmentSandbox,

--- a/src/content/docs/sdk/react-native/features/device-info.mdx
+++ b/src/content/docs/sdk/react-native/features/device-info.mdx
@@ -8,9 +8,13 @@ The Adjust SDK contains helper methods that return device information. Use these
 
 ## [Adjust device identifier](adjust-device-identifier)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 getAdid: (callback: (adid: string) => void) => void
 ```
+
+</CodeBlock>
 
 Adjust generates a unique Adjust Device ID (ADID) for each device. Call the `getAdid` method to return this ID as a `string`.
 
@@ -22,9 +26,13 @@ Adjust.getAdid((adid) => {
 
 ## [ID For Advertisers](id-for-advertisers)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 getIdfa: (callback: (idfa: string) => void) => void
 ```
+
+</CodeBlock>
 
 The ID for Advertisers (IDFA) is a device-specific identifier for Apple devices. Call the `getIdfa` method to return this ID as a `string`.
 
@@ -36,9 +44,13 @@ Adjust.getIdfa((idfa) => {
 
 ## [Google Play Services Advertising ID](google-play-services-advertising-id)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 getGoogleAdId: (callback: (adid: string) => void) => void
 ```
+
+</CodeBlock>
 
 The Google Play Services Advertising ID (GPS ADID) is a device-specific identifier for Android devices.
 
@@ -54,9 +66,13 @@ Adjust.getGoogleAdId((googleAdId) => {
 
 ## [Amazon Advertiser ID](amazon-advertiser-id)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 getAmazonAdId: (callback: (adid: string) => void) => void
 ```
+
+</CodeBlock>
 
 The Amazon Advertising ID (Amazon Ad ID) is a device-specific identifier for Android devices. Call the `getAmazonAdId` method to return this ID as a `string`.
 

--- a/src/content/docs/sdk/react-native/features/events.mdx
+++ b/src/content/docs/sdk/react-native/features/events.mdx
@@ -8,9 +8,13 @@ The Adjust SDK provides an `AdjustEvent` object which can be used to structure a
 
 ## [Instantiate an AdjustEvent object](instantiate-an-adjustevent-object)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 constructor(eventToken: string)
 ```
+
+</CodeBlock>
 
 To send event information with the Adjust SDK, you need to instantiate an `AdjustEvent` object. This object contains variables that are sent to Adjust when an event occurs in your app.
 
@@ -26,9 +30,13 @@ Adjust.trackEvent(adjustEvent);
 
 ## [Send an event](send-an-event)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 trackEvent: (adjustEvent: AdjustEvent) => void
 ```
+
+</CodeBlock>
 
 You can associate your [Adjust event tokens](https://help.adjust.com/en/article/add-events#add-event) to actions in your app to record them. To record an event:
 
@@ -62,7 +70,9 @@ function _onPress_trackSimpleEvent() {
 </>;
 ```
 
-```txt collapse={6-46} title="Event log"
+<CodeBlock title="Event log" collapse="6-46">
+
+```txt
 Path:      /event
 ClientSdk: reactnative$REACT_NATIVE_VERSION
 Parameters:
@@ -109,13 +119,20 @@ Parameters:
   time_spent       23
   tracking_enabled 1
   ui_mode          1
+
 ```
+
+</CodeBlock>
 
 ## [Record event revenue](record-event-revenue)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public setRevenue(revenue: number, currency: string): void
 ```
+
+</CodeBlock>
 
 You can record revenue associated with an event by setting the revenue and currency properties on your event instance. Use this feature to record revenue-generating actions in your app.
 
@@ -130,7 +147,7 @@ Check the guide to [recording purchases in different currencies](https://help.ad
 
 </Callout>
 
-```jsx {3}
+```jsx
 var adjustEvent = new AdjustEvent("abc123");
 //...
 adjustEvent.setRevenue(0.01, "EUR");
@@ -142,7 +159,7 @@ Adjust.trackEvent(adjustEvent);
 
 This example shows how to record an event with the token `g3mfiw` whenever a user interacts with a button. The function sets the `revenue` property of this event to _`0.25`_ and the `currency` property to _`EUR`_.
 
-```jsx {3}
+```jsx
 function _onPress_trackRevenueEvent() {
    var adjustEvent = new AdjustEvent("g3mfiw");
    adjustEvent.setRevenue(0.25, "EUR");
@@ -161,7 +178,9 @@ function _onPress_trackRevenueEvent() {
 </>;
 ```
 
-```txt collapse={6-46} title="Event log"
+<CodeBlock title="Event log" collapse="6-46">
+
+```txt
 Path:      /event
 ClientSdk: reactnative$REACT_NATIVE_VERSION
 Parameters:
@@ -208,19 +227,26 @@ Parameters:
   time_spent       23
   tracking_enabled 1
   ui_mode          1
+
 ```
+
+</CodeBlock>
 
 ## [Deduplicate revenue events](deduplicate-revenue-events)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public setTransactionId(transactionId: string): void
 ```
+
+</CodeBlock>
 
 You can pass an optional identifier to avoid recording duplicate events. The SDK stores the last ten identifiers and skips revenue events with duplicate transaction IDs.
 
 To set the identifier, call the `setTransactionId` method and pass your transaction ID as a `string` argument.
 
-```jsx {3}
+```jsx
 var adjustEvent = new AdjustEvent("abc123");
 //...
 adjustEvent.setTransactionId("{transactionId}");
@@ -232,7 +258,7 @@ Adjust.trackEvent(adjustEvent);
 
 This example shows how to record an event with the token `g3mfiw` whenever a user interacts with a button. The function sets the `uniqueId` to `5e85484b-1ebc-4141-aab7-25b869e54c49` using the `setTransactionId` method.
 
-```jsx {3}
+```jsx
 function _onPress_trackRevenueEvent() {
    var adjustEvent = new AdjustEvent("g3mfiw");
    var uniqueId = "5e85484b-1ebc-4141-aab7-25b869e54c49";
@@ -252,7 +278,9 @@ function _onPress_trackRevenueEvent() {
 </>;
 ```
 
-```txt title="Event log" {7}
+<CodeBlock title="Event log" highlight="{range: 7}">
+
+```txt
 Path:      /event
 ClientSdk: reactnative$REACT_NATIVE_VERSION
 Parameters:
@@ -262,11 +290,17 @@ Parameters:
   transaction_id   5e85484b-1ebc-4141-aab7-25b869e54c49
 ```
 
+</CodeBlock>
+
 ## [Add callback parameters](add-callback-parameters)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public addCallbackParameter(key: string, value: string): void
 ```
+
+</CodeBlock>
 
 If you [register a callback URL](https://help.adjust.com/en/article/set-up-callbacks) in the Adjust dashboard, the SDK sends a GET request to your callback URL when it records an event.
 
@@ -274,7 +308,7 @@ You can configure callback parameters to send to your servers. Once you configur
 
 Add callback parameters to your event by calling the `addCallbackParameter` method with `string` key-value arguments. You can add multiple parameters by calling this method multiple times.
 
-```jsx {3}
+```jsx
 var adjustEvent = new AdjustEvent("abc123");
 //...
 adjustEvent.addCallbackParameter("key", "value");
@@ -313,11 +347,15 @@ This example shows how to record an event with the token `g3mfiw` whenever a use
 
 The resulting callback URL looks like this:
 
-```http "event_token=g3mfiw" "revenue_amount=0.05"
+<CodeBlock highlight="event_token=g3mfiw, revenue_amount=0.05">
+
+```http
 http://www.mydomain.com/callback?event_token=g3mfiw&revenue_amount=0.05
 ```
 
-```jsx {3,4}
+</CodeBlock>
+
+```jsx
 function _onPress_trackCallbackEvent() {
    var adjustEvent = new AdjustEvent("g3mfiw");
    adjustEvent.addCallbackParameter("event_token", "g3mfiw");
@@ -337,7 +375,9 @@ function _onPress_trackCallbackEvent() {
 </>;
 ```
 
-```txt {4} title="Event log"
+<CodeBlock title="Event log">
+
+```txt
 Path:      /event
 ClientSdk: reactnative$REACT_NATIVE_VERSION
 Parameters:
@@ -345,13 +385,20 @@ Parameters:
   environment      sandbox
   event_count      1
   event_token      g3mfiw
+
 ```
+
+</CodeBlock>
 
 ## [Add partner parameters](add-partner-parameters)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public addPartnerParameter(key: string, value: string): void
 ```
+
+</CodeBlock>
 
 You can send extra information to your network partners by adding [partner parameters](https://help.adjust.com/en/article/data-sharing-ad-network#map-parameters).
 
@@ -365,7 +412,7 @@ Partner parameters don't appear in raw data by default. You can add the `{partne
 
 Add partner parameters to your event by calling the `addPartnerParameter` method with `string` key-value arguments. You can add multiple parameters by calling this method multiple times.
 
-```jsx {3}
+```jsx
 var adjustEvent = new AdjustEvent("abc123");
 //...
 adjustEvent.addPartnerParameter("key", "value");
@@ -380,7 +427,7 @@ This example shows how to record an event with the token `g3mfiw` whenever a use
 -  The `product_id` of the associated product
 -  The `user_id` of the user who triggered the event
 
-```jsx {3,4}
+```jsx
 function _onPress_trackPartnerEvent() {
    var adjustEvent = new AdjustEvent("g3mfiw");
    adjustEvent.addPartnerParameter("product_id", "29");
@@ -400,7 +447,9 @@ function _onPress_trackPartnerEvent() {
 </>;
 ```
 
-```txt title="Event log" {4}
+<CodeBlock title="Event log" highlight="{range: 4}">
+
+```txt
 Path:      /event
 ClientSdk: reactnative$REACT_NATIVE_VERSION
 Parameters:
@@ -410,17 +459,23 @@ Parameters:
   event_token      g3mfiw
 ```
 
+</CodeBlock>
+
 ## [Add a callback identifier](add-a-callback-identifier)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public setCallbackId(callbackId: string): void
 ```
+
+</CodeBlock>
 
 You can add a custom string identifier to each event you want to measure. Adjust's servers can report on this identifier in event callbacks. This enables you to keep track of which events have been successfully measured.
 
 Set up this identifier by calling the `setCallbackId` method with your ID as a `string` argument.
 
-```jsx {3}
+```jsx
 var adjustEvent = new AdjustEvent("abc123");
 //...
 adjustEvent.setCallbackId("your_callback_id");
@@ -432,7 +487,7 @@ Adjust.trackEvent(adjustEvent);
 
 This example shows how to record an event with the token `g3mfiw` whenever a user interacts with a button. In this example, the `callbackId` is set to `f2e728d8-271b-49ab-80ea-27830a215147`.
 
-```jsx {3,5}
+```jsx
 function _onPress_trackUniqueCallbackEvent() {
    var adjustEvent = new AdjustEvent("g3mfiw");
    var callbackId = "f2e728d8-271b-49ab-80ea-27830a215147";
@@ -454,7 +509,9 @@ function _onPress_trackUniqueCallbackEvent() {
 </>;
 ```
 
-```txt title="Event log" {7}
+<CodeBlock title="Event log" highlight="{range: 7}">
+
+```txt
 Path:      /event
 ClientSdk: reactnative$REACT_NATIVE_VERSION
 Parameters:
@@ -463,3 +520,5 @@ Parameters:
   event_token      g3mfiw
   callback_id      f2e728d8-271b-49ab-80ea-27830a215147
 ```
+
+</CodeBlock>

--- a/src/content/docs/sdk/react-native/features/preinstalled.mdx
+++ b/src/content/docs/sdk/react-native/features/preinstalled.mdx
@@ -8,7 +8,7 @@ You can use the Adjust SDK to record activity from apps that came preinstalled o
 
 Your config object contains a `boolean` `preinstallTrackingEnabled` property that controls this feature. To enable preinstall measurement, assign a `boolean` value to the `preinstallTrackingEnabled` property of your config object.
 
-```jsx {6}
+```jsx
 const adjustConfig = new AdjustConfig(
    "{YourAppToken}",
    AdjustConfig.EnvironmentSandbox,
@@ -25,13 +25,13 @@ Configuring a default link token enables you to attribute all preinstalls to a p
 
 1. [Create a new campaign link in Campaign Lab](https://help.adjust.com/en/article/links).
 
-   ```text "{token}"
+   ```text
    https://app.adjust.com/{token}
    ```
 
 2. Copy this token and assign it to the [`defaultTracker` property](/en/sdk/flutter/configuration#set-default-link-token) of your config object.
 
-   ```jsx {6}
+   ```jsx
    const adjustConfig = new AdjustConfig(
       "{YourAppToken}",
       AdjustConfig.EnvironmentSandbox,

--- a/src/content/docs/sdk/react-native/features/privacy.mdx
+++ b/src/content/docs/sdk/react-native/features/privacy.mdx
@@ -8,9 +8,13 @@ The Adjust SDK contains features that you can use to handle user privacy in your
 
 ## [Send erasure request](send-erasure-request)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 gdprForgetMe: () => void
 ```
+
+</CodeBlock>
 
 The EU’s General Data Protection Regulation (GDPR) and similar privacy laws worldwide (CCPA, LGPD, etc.) grant data subjects comprehensive rights when it comes to the processing of their personal data. These rights include, among others, the right to erasure (see [Art. 17 GDPR](https://gdpr.eu/article-17-right-to-be-forgotten/))([1](https://help.adjust.com/en/article/gdpr#ref-1)). As a data processor, Adjust is obliged to support you (the data controller) in the processing of such requests from your (app) users.
 
@@ -29,9 +33,13 @@ You can use the Adjust SDK to record when a user changes their third-party shari
 
 ### [Instantiate an AdjustThirdPartySharing object](instantiate-an-adjustthirdpartysharing-object)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 constructor(isEnabled: boolean)
 ```
+
+</CodeBlock>
 
 To enable or disable third party sharing with the Adjust SDK, you need to instantiate an `AdjustThirdPartySharing` object. This object contains variables that control how third party sharing is handled by Adjust.
 
@@ -61,9 +69,13 @@ Adjust.trackThirdPartySharing(adjustThirdPartySharing);
 
 ### [Send granular information](send-granular-information)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public addGranularOption(partnerName: string, key: string, value: string): void
 ```
+
+</CodeBlock>
 
 You can attach granular information when a user updates their third-party sharing preferences. Use this information to communicate more detail about a user's decision. To do this, call the `addGranularOption` method with the following parameters:
 
@@ -71,7 +83,7 @@ You can attach granular information when a user updates their third-party sharin
 -  `key` (`string`): The option key.
 -  `value` (`string`): The option value.
 
-```jsx {3}
+```jsx
 var adjustThirdPartySharing = new AdjustThirdPartySharing(null);
 //...
 adjustThirdPartySharing.addGranularOption("PartnerA", "key", "value");
@@ -107,7 +119,9 @@ If you call this method with a `0` value for **either** `data_processing_options
 
 </Callout>
 
-```jsx {3-12}
+<CodeBlock highlight="{range: 3-12}">
+
+```jsx
 var adjustThirdPartySharing = new AdjustThirdPartySharing(null);
 //...
 adjustThirdPartySharing.addGranularOption(
@@ -123,6 +137,8 @@ adjustThirdPartySharing.addGranularOption(
 //...
 Adjust.trackThirdPartySharing(adjustThirdPartySharing);
 ```
+
+</CodeBlock>
 
 #### [Provide consent data to Google (Digital Markets Act compliance)](provide-consent-data-to-google-digital-markets-act-compliance)
 
@@ -162,9 +178,13 @@ Adjust.trackThirdPartySharing(adjustThirdPartySharing);
 
 ## [Disable third-party sharing](disable-third-party-sharing)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 disableThirdPartySharing: () => void
 ```
+
+</CodeBlock>
 
 To disable third-party sharing for all users, call the `disableThirdPartySharing` method. When Adjust's servers receive this information, Adjust stops sharing the user's data with third parties. The Adjust SDK continues to work as expected.
 
@@ -268,9 +288,13 @@ Adjust.trackThirdPartySharing(adjustThirdPartySharing);
 
 ## [Data residency](data-residency)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public setUrlStrategy(urlStrategy: UrlStrategy): void
 ```
+
+</CodeBlock>
 
 The URL strategy feature allows you to set either:
 
@@ -297,7 +321,9 @@ To set your country of data residency, call the `setUrlStrategy` method on your 
 
 </Table>
 
-```jsx "AdjustConfig.DataResidencyEU" {5}
+<CodeBlock highlight="AdjustConfig.DataResidencyEU, {range: 5}">
+
+```jsx
 const adjustConfig = new AdjustConfig(
    "{YourAppToken}",
    AdjustConfig.EnvironmentSandbox,
@@ -306,11 +332,17 @@ adjustConfig.setUrlStrategy(AdjustConfig.DataResidencyEU);
 Adjust.create(adjustConfig);
 ```
 
+</CodeBlock>
+
 ## [Consent measurement for specific users](consent-measurement-for-specific-users)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 trackMeasurementConsent: (measurementConsent: boolean) => void
 ```
+
+</CodeBlock>
 
 If you're using [Data Privacy settings](https://help.adjust.com/en/article/manage-data-collection-and-retention) in your Adjust dashboard, you need to set up the Adjust SDK to work with them. This includes settings such as consent expiry period and user data retention period.
 
@@ -326,16 +358,20 @@ Adjust.trackMeasurementConsent(true);
 
 ## [COPPA compliance](coppa-compliance)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public setCoppaCompliantEnabled(coppaCompliantEnabled: boolean): void
 ```
+
+</CodeBlock>
 
 If you need your app to be compliant with the Children's Online Privacy Protection Act (COPPA), call the `setCoppaCompliantEnabled` method. This method performs the following actions:
 
 1. Disables third-party sharing **before** the user launches their first `session`.
 2. Prevents the SDK from reading device and advertising IDs (for example: `gps_adid` and `android_id`).
 
-```jsx {6}
+```jsx
 const adjustConfig = new AdjustConfig(
    "{YourAppToken}",
    AdjustConfig.EnvironmentSandbox,
@@ -355,9 +391,13 @@ Disabling the `setCoppaCompliantEnabled` method _doesn't_ re-enable third-party 
 
 ## [Play Store Kids Apps (Android only)](play-store-kids-apps-android-only)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public setPlayStoreKidsAppEnabled(playStoreKidsAppEnabled: boolean): void
 ```
+
+</CodeBlock>
 
 If your app targets users under the age of 13, and the install region **isn't** the USA, you need to mark it as a Kids App. This prevents the SDK from reading device and advertising IDs (for example: `gps_adid` and `android_id`).
 
@@ -365,7 +405,7 @@ To mark your app as a Kids App, call the `setPlayStoreKidsAppEnabled` method wit
 
 -  `playStoreKidsAppEnabled` (`boolean`): set to `true` to mark the app as a Kids App, or `false` to mark the app as a non-Kids App.
 
-```jsx {6}
+```jsx
 const adjustConfig = new AdjustConfig(
    "{YourAppToken}",
    AdjustConfig.EnvironmentSandbox,

--- a/src/content/docs/sdk/react-native/features/session-parameters.mdx
+++ b/src/content/docs/sdk/react-native/features/session-parameters.mdx
@@ -18,9 +18,13 @@ You can configure callback parameters to your servers. Once you configure parame
 
 ### [Add session callback parameters](add-session-callback-parameters)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 addSessionCallbackParameter: (key: string, value: string) => void
 ```
+
+</CodeBlock>
 
 Add callback parameters to your event by calling the `addSessionCallbackParameter` method with `string` key-value arguments. You can add multiple parameters by calling this method multiple times.
 
@@ -30,9 +34,13 @@ Adjust.addSessionCallbackParameter("key", "value");
 
 ### [Remove session callback parameters](remove-session-callback-parameters)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 removeSessionCallbackParameter: (key: string) => void
 ```
+
+</CodeBlock>
 
 You can remove specific session callback parameters if they're no longer required. To do this, pass the parameter `key` to the `removeSessionCallbackParameter` method.
 
@@ -42,9 +50,13 @@ Adjust.removeSessionCallbackParameter("key");
 
 ### [Reset session callback parameters](reset-session-callback-parameters)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 resetSessionCallbackParameters: () => void
 ```
+
+</CodeBlock>
 
 You can remove all session parameters if they're no longer required. To do this, call the `resetSessionCallbackParameters` method.
 
@@ -66,9 +78,13 @@ Partner parameters don't appear in raw data by default. You can add the `{partne
 
 ### [Add session partner parameters](add-session-partner-parameters)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 addSessionPartnerParameter: (key: string, value: string) => void
 ```
+
+</CodeBlock>
 
 Send partner parameters with your session by calling the `addSessionPartnerParameter` method with `string` key-value arguments. You can add multiple parameters by calling this method multiple times.
 
@@ -78,9 +94,13 @@ Adjust.addSessionPartnerParameter("key", "value");
 
 ### [Remove session partner parameters](remove-session-partner-parameters)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 removeSessionPartnerParameter: (key: string) => void
 ```
+
+</CodeBlock>
 
 You can remove specific session partner parameters if they're no longer required. To do this, pass the parameter key to the `removeSessionPartnerParameter` method.
 
@@ -90,9 +110,13 @@ Adjust.removeSessionPartnerParameter("key");
 
 ### [Reset session partner parameters](reset-session-partner-parameters)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 resetSessionPartnerParameters: () => void
 ```
+
+</CodeBlock>
 
 You can remove all session partner parameters if they're no longer required. To do this, call the `resetSessionPartnerParameters` method.
 
@@ -110,7 +134,7 @@ You can delay the startup of the SDK by up to **10 seconds**.
 
 The Adjust SDK starts as soon as your app opens. If you want to send data that's not available at launch in session parameters, you can delay the start of the SDK. To do this, pass the delay time in seconds to the [`setDelayStart` method](/en/sdk/react-native/configuration#delay-the-start-of-the-sdk) on your config object.
 
-```jsx {6}
+```jsx
 const adjustConfig = new AdjustConfig(
    "{YourAppToken}",
    AdjustConfig.EnvironmentSandbox,

--- a/src/content/docs/sdk/react-native/features/skad.mdx
+++ b/src/content/docs/sdk/react-native/features/skad.mdx
@@ -19,9 +19,13 @@ app install and reinstall attribution. The SKAdNetwork workflow goes like this:
 
 ## [Disable SKAdNetwork communication](disable-skadnetwork-communication)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public deactivateSKAdNetworkHandling(): void
 ```
+
+</CodeBlock>
 
 <MinorVersion added="v4.23.0">
 
@@ -37,7 +41,7 @@ You must call the `deactivateSKAdNetworkHandling` method _before_ initializing t
 
 </Callout>
 
-```jsx {6}
+```jsx
 const adjustConfig = new AdjustConfig(
    "{YourAppToken}",
    AdjustConfig.EnvironmentSandbox,
@@ -50,9 +54,13 @@ Adjust.create(adjustConfig);
 
 ## [Update conversion values](update-conversion-values)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 updateConversionValue: (conversionValue: number) => void
 ```
+
+</CodeBlock>
 
 Conversion values are a mechanism used to measure user behavior in SKAdNetwork. You can map 64 conditions to values from `0` through `63` and send this integer value to SKAdNetwork on user install. This gives you insight into how your users interact with your app in the first few days.
 
@@ -66,7 +74,7 @@ Adjust.updateConversionValue(6);
 
 This example shows how to update a conversion value to `10` in response to a user triggering an event.
 
-```jsx {2}
+```jsx
 function _onPress_trackSimpleEvent() {
    Adjust.updateConversionValue(10);
 }
@@ -74,15 +82,20 @@ function _onPress_trackSimpleEvent() {
 
 ## [Listen for changes to conversion values](listen-for-changes-to-conversion-values)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public setConversionValueUpdatedCallbackListener(
    callback: (conversionValue: AdjustConversionValue) => void
 ): void
+
 ```
+
+</CodeBlock>
 
 If you use Adjust to manage conversion values, the Adjust's servers send conversion value updates to the SDK. You can set up a delegate function to listen for these changes using the `setConversionValueUpdatedCallbackListener` method. Pass your function as an argument.
 
-```jsx {3-8}
+```jsx
 const adjustConfig = new AdjustConfig(appToken, environment);
 
 adjustConfig.setConversionValueUpdatedCallbackListener(

--- a/src/content/docs/sdk/react-native/features/subscriptions.mdx
+++ b/src/content/docs/sdk/react-native/features/subscriptions.mdx
@@ -19,9 +19,13 @@ To get started, you need to create a subscription object containing details of t
 <Tabs>
 <Tab title="App Store" sync="appstore" icon="PlatformIos">
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 constructor(price: string, currency: string, transactionId: string, receipt: string)
 ```
+
+</CodeBlock>
 
 Create an `AdjustAppStoreSubscription` object with the following properties
 
@@ -36,7 +40,7 @@ Create an `AdjustAppStoreSubscription` object with the following properties
 
 </Table>
 
-```jsx {9}
+```jsx
 var subscription = new AdjustPlayStoreSubscription(
    price,
    currency,
@@ -51,9 +55,13 @@ Adjust.trackPlayStoreSubscription(subscription);
 </Tab>
 <Tab title="Play Store" sync="playstore" icon="PlatformGooglePlay">
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 constructor(price: string, currency: string, sku: string, orderId: string, signature: string, purchaseToken: string)
 ```
+
+</CodeBlock>
 
 Create an `AdjustPlayStoreSubscription` object with the following properties
 
@@ -91,13 +99,17 @@ You can record the date on which the user purchased a subscription. The SDK retu
 <Tabs>
 <Tab title="App Store" sync="appstore" icon="PlatformIos">
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public setTransactionDate(transactionDate: string): void
 ```
 
+</CodeBlock>
+
 Call the `setTransactionDate` method method on your subscription object to record the timestamp of the subscription.
 
-```jsx {10}
+```jsx
 var subscription = new AdjustPlayStoreSubscription(
    price,
    currency,
@@ -114,13 +126,17 @@ Adjust.trackPlayStoreSubscription(subscription);
 </Tab>
 <Tab title="Play Store" sync="playstore" icon="PlatformGooglePlay">
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public setPurchaseTime(purchaseTime: string): void
 ```
 
+</CodeBlock>
+
 Call the `setPurchaseTime` method on your subscription object to record the timestamp of the subscription.
 
-```jsx {9}
+```jsx
 var subscription = new AdjustPlayStoreSubscription(
    price,
    currency,
@@ -137,13 +153,17 @@ subscription.setPurchaseTime(purchaseTime);
 
 ### [Record the purchase region (iOS only)](record-the-purchase-region-ios-only)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public setSalesRegion(salesRegion: string): void
 ```
 
+</CodeBlock>
+
 You can record the region in which the user purchased a subscription. To do this, call the `setSalesRegion` method on your subscription object and pass the country code as a `string`. This needs to be formatted as the [`countryCode`](https://developer.apple.com/documentation/foundation/nslocale/1643060-countrycode?language=swift) of the [`priceLocale`](https://developer.apple.com/documentation/storekit/skproduct/1506145-pricelocale?language=swift) object.
 
-```jsx {10}
+```jsx
 var subscription = new AdjustPlayStoreSubscription(
    price,
    currency,
@@ -164,11 +184,15 @@ You can add callback parameters to your subscription object. The SDK appends the
 <Tabs>
 <Tab title="App Store" sync="appstore" icon="PlatformIos">
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public addCallbackParameter(key: string, value: string): void
 ```
 
-```jsx {10-11}
+</CodeBlock>
+
+```jsx
 var subscription = new AdjustAppStoreSubscription(
    price,
    currency,
@@ -187,11 +211,15 @@ Adjust.trackAppStoreSubscription(subscription);
 </Tab>
 <Tab title="Play Store" sync="playstore" icon="PlatformGooglePlay">
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public addCallbackParameter(key: string, value: string): void
 ```
 
-```jsx {10,11}
+</CodeBlock>
+
+```jsx
 var subscription = new AdjustPlayStoreSubscription(
    price,
    currency,
@@ -215,11 +243,15 @@ You can add partner parameters to your subscription object. The SDK sends these 
 <Tabs>
 <Tab title="App Store" sync="appstore" icon="PlatformIos">
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public addPartnerParameter(key: string, value: string): void
 ```
 
-```jsx {10-11}
+</CodeBlock>
+
+```jsx
 var subscription = new AdjustAppStoreSubscription(
    price,
    currency,
@@ -238,11 +270,15 @@ Adjust.trackAppStoreSubscription(subscription);
 </Tab>
 <Tab title="Play Store" sync="playstore" icon="PlatformGooglePlay">
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 public addPartnerParameter(key: string, value: string): void
 ```
 
-```jsx {10,11}
+</CodeBlock>
+
+```jsx
 var subscription = new AdjustPlayStoreSubscription(
    price,
    currency,
@@ -266,13 +302,17 @@ Once you have set up your subscription object, you can record it using the Adjus
 <Tabs>
 <Tab title="App Store" sync="appstore" icon="PlatformIos">
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 trackAppStoreSubscription: (subscription: AdjustAppStoreSubscription) => void
 ```
 
+</CodeBlock>
+
 Pass your subscription object to the `trackAppStoreSubscription` method method to record the user's subscription purchase.
 
-```jsx {10}
+```jsx
 var subscription = new AdjustAppStoreSubscription(
    price,
    currency,
@@ -288,13 +328,17 @@ Adjust.trackAppStoreSubscription(subscription);
 </Tab>
 <Tab title="Play Store" sync="playstore" icon="PlatformGooglePlay">
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 trackPlayStoreSubscription: (subscription: AdjustPlayStoreSubscription) => void
 ```
 
+</CodeBlock>
+
 Pass your subscription object to the `trackPlayStoreSubscription` method method to record the user's subscription purchase.
 
-```jsx {11}
+```jsx
 var subscription = new AdjustPlayStoreSubscription(
    price,
    currency,

--- a/src/content/docs/sdk/react-native/index.mdx
+++ b/src/content/docs/sdk/react-native/index.mdx
@@ -88,10 +88,15 @@ When running tests, ensure that your environment is set to `AdjustEnvironment.sa
 
 The Adjust SDK requires certain permissions to access information. Add them to your `AndroidManifest.xml` file if they're not already present:
 
-```xml title="AndroidManifest.xml"
+<CodeBlock title="AndroidManifest.xml">
+
+```xml
 <uses-permission android:name="android.permission.INTERNET"/>
 <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+
 ```
+
+</CodeBlock>
 
 <Callout type="note">
 
@@ -101,9 +106,13 @@ The Adjust SDK doesn't require the `ACCESS_WIFI_STATE` permission if you are tar
 
 The Adjust SDK includes the `com.google.android.gms.AD_ID` permission by default in version 4.32.0 and above. You can remove it by adding a `remove` directive if need to make your app COPPA-compliant or if you don't target the Google Play Store.
 
-```xml title="AndroidManifest.xml"
+<CodeBlock title="AndroidManifest.xml">
+
+```xml
 <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
 ```
+
+</CodeBlock>
 
 <Callout type="seealso">
 
@@ -115,9 +124,13 @@ See Google's [`AdvertisingIdClient.Info`](https://developers.google.com/android/
 
 Apps that target the Google Play Store must use the [Google Advertising ID](https://support.google.com/googleplay/android-developer/answer/6048248?hl=en) (`gps_adid`) to identify devices. To do this, Add the following dependency to the `dependencies` section of your `build.gradle` file.
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
 ```
+
+</CodeBlock>
 
 <Callout type="note">
 
@@ -129,7 +142,9 @@ The Adjust SDK isn't tied to any version of the `play-services-ads-identifier` d
 
 If you are using Proguard, add the following rules to your Proguard file.
 
-```java title="proguard.pro"
+<CodeBlock title="proguard.pro">
+
+```java
 -keep class com.adjust.sdk.** { *; }
 -keep class com.google.android.gms.common.ConnectionResult {
    int SUCCESS;
@@ -142,7 +157,10 @@ If you are using Proguard, add the following rules to your Proguard file.
    boolean isLimitAdTrackingEnabled();
 }
 -keep public class com.android.installreferrer.** { *; }
+
 ```
+
+</CodeBlock>
 
 ### [Set up install referrer](set-up-install-referrer)
 
@@ -169,17 +187,24 @@ To support the [Google Play Referrer API](https://developer.android.com/google/p
 
 1. Add the following line in the **dependencies block** of your top-level `build.gradle` file:
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 dependencies {
 //...
 implementation 'com.android.installreferrer:installreferrer:2.2'
 //...
 }
+
 ```
+
+</CodeBlock>
 
 2. The `installreferrer` library is part of **Google Maven** repository. You need to add Google Maven repository to your app's top-level `build.gradle` file to build your app:
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 allprojects {
    repositories {
       maven {
@@ -188,13 +213,20 @@ allprojects {
    }
 }
 
+
 ```
+
+</CodeBlock>
 
 3. If you are using Proguard, make sure you have added the following setting in your Proguard file:
 
-```java title="proguard.pro"
+<CodeBlock title="proguard.pro">
+
+```java
 -keep public class com.android.installreferrer.** { *; }
 ```
+
+</CodeBlock>
 
 #### [Huawei Referrer API](huawei-referrer-api)
 
@@ -217,7 +249,7 @@ The Adjust SDK supports the [Meta Install Referrer](https://developers.facebook.
 1. Find your Meta app ID in your [App Dashboard](https://developers.facebook.com/apps). See Meta's [App Dashboard documentation](https://developers.facebook.com/docs/development/create-an-app/app-dashboard) for more information.
 2. Pass your App ID as a `string` argument to the `AdjustConfig.setFbAppId` method.
 
-   ```jsx {6}
+   ```jsx
    const adjustConfig = new AdjustConfig(
       "{YourAppToken}",
       AdjustConfig.EnvironmentSandbox,

--- a/src/content/docs/sdk/react-native/plugins/oaid.mdx
+++ b/src/content/docs/sdk/react-native/plugins/oaid.mdx
@@ -18,15 +18,19 @@ You need to load the Adjust OAID Prefab **before** the Adjust Prefab. This ensur
 
 The Adjust OAID plugin for React Native is available from npm.
 
-```console title="npm"
+<CodeBlock title="npm">
+
+```console
 $ npm install react-native-adjust-oaid --save
 ```
+
+</CodeBlock>
 
 ## [Use the plugin](use-the-plugin)
 
 Once you have set up the plugin, you can gather the device's OAID. To do this, call the `AdjustOaid.ReadOaid` method before starting the Adjust SDK.
 
-```jsx {2}
+```jsx
 import { AdjustOaid } from "react-native-adjust-oaid";
 AdjustOaid.readOaid();
 // ...
@@ -35,7 +39,7 @@ Adjust.create(adjustConfig);
 
 To stop the SDK from reading OAID values, call the `AdjustOaid.doNotReadOaid()` method.
 
-```jsx {2}
+```jsx
 import { AdjustOaid } from "react-native-adjust-oaid";
 AdjustOaid.doNotReadOaid();
 // ...

--- a/src/content/docs/sdk/unity/configuration.mdx
+++ b/src/content/docs/sdk/unity/configuration.mdx
@@ -9,9 +9,13 @@ Use the methods in this document to configure the behavior of the Adjust SDK.
 
 ## [Instantiate your config object](instantiate-your-config-object)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public AdjustConfig(string appToken, AdjustEnvironment environment, bool allowSuppressLogLevel)
 ```
+
+</CodeBlock>
 
 To configure the Adjust SDK, you need to instantiate an `AdjustConfig` object. This object contains the **read-only** configuration options that you need to pass to the Adjust SDK.
 
@@ -21,7 +25,7 @@ To instantiate your config object, create a new `AdjustConfig` instance and pass
 -  `environment` (`AdjustEnvironment`): The environment you want to run the SDK in. Pass `AdjustEnvironment.sandbox` to run the SDK in sandbox mode for testing. Pass `AdjustEnvironment.production` to run the SDK in production mode for release.
 -  `allowSuppressLogLevel` (`bool`): Whether to suppress all logging. Set to `true` to suppress logging or `false` to enable logging.
 
-```cs {1}
+```cs
 AdjustConfig adjustConfig = new AdjustConfig("{YourAppToken}", AdjustEnvironment.Sandbox);
 // ...
 Adjust.start(adjustConfig);
@@ -33,9 +37,13 @@ Adjust.start(adjustConfig);
 
 ### [Set your logging level](set-your-logging-level)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setLogLevel(AdjustLogLevel logLevel);
 ```
+
+</CodeBlock>
 
 The Adjust SDK provides configurable log levels to return different amounts of information. The following log levels are available:
 
@@ -57,7 +65,7 @@ You can set your log level by calling the `setLogLevel` method on your `AdjustCo
 
 -  `logLevel` (`LogLevel`): The log level you want to use.
 
-```cs {3}
+```cs
 AdjustConfig config = new AdjustConfig("{YourAppToken}", AdjustEnvironment.Sandbox, true);
 //...
 config.setLogLevel(AdjustLogLevel.Error);
@@ -67,9 +75,13 @@ Adjust.start(config);
 
 ### [Set external device identifier](set-external-device-identifier)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setExternalDeviceId(string externalDeviceId);
 ```
+
+</CodeBlock>
 
 An external device identifier is a custom value that you can assign to a device or user. They help you recognize users across sessions and platforms. They can also help you deduplicate installs by user so that a user isn't counted as duplicate new installs. Contact your Adjust representative to get started with external device IDs.
 
@@ -83,7 +95,7 @@ See the [External device identifiers article](https://help.adjust.com/en/article
 
 </Callout>
 
-```cs {3}
+```cs
 AdjustConfig adjustConfig = new AdjustConfig("{YourAppToken}", AdjustEnvironment.Sandbox, true);
 //...
 adjustConfig.setExternalDeviceId("{Your-External-Device-Id}");
@@ -97,15 +109,19 @@ You can import existing external device IDs into Adjust. This ensures that the A
 
 ### [Set default link token](set-default-link-token)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setDefaultTracker(string defaultTracker);
 ```
+
+</CodeBlock>
 
 You can configure a default link token if your app is preinstalled on a device. When a user opens the preinstalled app for the first time, the install is attributed to the default link token. To set your default link token, call the `setDefaultTracker` method with the following argument:
 
 -  `defaultTracker` (`string`): The [Adjust link token](https://help.adjust.com/en/article/links#adjust-link-token) you want to record preinstalled installs against.
 
-```cs {3}
+```cs
 AdjustConfig adjustConfig = new AdjustConfig("{YourAppToken}", AdjustEnvironment.Sandbox);
 //...
 adjustConfig.setDefaultTracker("{TrackerToken}");
@@ -115,9 +131,13 @@ Adjust.start(adjustConfig);
 
 ### [Enable cost data sending](enable-cost-data-sending)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setNeedsCost(bool needsCost);
 ```
+
+</CodeBlock>
 
 By default, the Adjust SDK doesn't send cost data as part of a user's attribution. You can configure the SDK to send this data by enabling cost data sending. To enable cost data sending, call the `setNeedsCost` method on your config instance with the following parameter:
 
@@ -125,7 +145,7 @@ By default, the Adjust SDK doesn't send cost data as part of a user's attributio
 
 Cost data is accessible in the user's [attribution information](/en/sdk/unity/features/attribution).
 
-```cs {3}
+```cs
 AdjustConfig adjustConfig = new AdjustConfig("{Your App Token}", AdjustEnvironment.Sandbox);
 adjustConfig.setLogLevel(AdjustLogLevel.Verbose);
 adjustConfig.setNeedsCost(true);
@@ -133,15 +153,19 @@ adjustConfig.setNeedsCost(true);
 
 ### [Enable background recording](enable-background-recording)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setSendInBackground(bool sendInBackground);
 ```
+
+</CodeBlock>
 
 By default, the Adjust SDK pauses the sending of requests when your app is running in the background. You can configure the SDK to send requests in the background by enabling the background recording. To enable background recording, call the `setSendInBackground` method on your config instance with the following parameter:
 
 -  `sendInBackground` (`bool`): Set to `true` to enable background sending or `false` to disable background sending.
 
-```cs {3}
+```cs
 AdjustConfig adjustConfig = new AdjustConfig("{YourAppToken}", AdjustEnvironment.Sandbox);
 //...
 adjustConfig.setSendInBackground(true);
@@ -151,9 +175,13 @@ Adjust.start(adjustConfig);
 
 ### [Enable event buffering](enable-event-buffering)
 
-```cs title="Method"
+<CodeBlock title="Method">
+
+```cs
 public void setEventBufferingEnabled(bool eventBufferingEnabled);
 ```
+
+</CodeBlock>
 
 The Adjust SDK sends event information as soon as a user triggers an event in your app. You can send event information on a schedule by enabling event buffering. Event buffering stores events in a local buffer on the device and sends all requests once per minute.
 
@@ -161,7 +189,7 @@ Your config object contains a boolean `eventBufferingEnabled` property that cont
 
 -  `eventBufferingEnabled` (`bool`): Set to `true` to enable event buffering or `false` to disable event buffering.
 
-```cs {3}
+```cs
 AdjustConfig adjustConfig = new AdjustConfig("{YourAppToken}", AdjustEnvironment.Sandbox);
 //...
 adjustConfig.setEventBufferingEnabled(true);
@@ -171,9 +199,13 @@ Adjust.start(adjustConfig);
 
 ### [Delay the start of the SDK](delay-the-start-of-the-sdk)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setDelayStart(double delayStart);
 ```
+
+</CodeBlock>
 
 By default, the Adjust SDK starts as soon as your app opens. If you want to send data that isn't available at launch in [session parameters](/en/sdk/android/features/session-parameters), you can delay the start of the SDK. This can be helpful if you are sending information such as unique identifiers.
 
@@ -181,7 +213,7 @@ To configure a startup delay, call the `setDelayStart` method with the following
 
 -  `delayStart` (`double`): The time (in seconds) by which to delay the start of the SDK. You can delay the start of the SDK by up to **10 seconds**.
 
-```cs {3}
+```cs
 AdjustConfig adjustConfig = new AdjustConfig("{YourAppToken}", AdjustEnvironment.Sandbox);
 //...
 adjustConfig.setDelayStart(5.5);
@@ -195,9 +227,13 @@ Adjust.start(adjustConfig);
 
 ### [Toggle offline mode](toggle-offline-mode)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void setEnabled(bool enabled);
 ```
+
+</CodeBlock>
 
 <Callout type="important">
 
@@ -217,9 +253,13 @@ Adjust.setEnabled(false);
 
 ### [Set push tokens](set-push-tokens)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void setDeviceToken(string deviceToken);
 ```
+
+</CodeBlock>
 
 Push tokens are used for [Audiences](https://help.adjust.com/en/article/audiences) and client callbacks. They're also required for [Uninstall and reinstall measurement](https://help.adjust.com/en/article/uninstalls-reinstalls).
 
@@ -239,9 +279,13 @@ You can only call this method after the first session. This setting persists bet
 
 </Callout>
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void setEnabled(bool enabled);
 ```
+
+</CodeBlock>
 
 The Adjust SDK runs by default when your app is open. You can disable and re-enable the Adjust SDK to pause and resume recording. When you disable the Adjust SDK, it doesn't send any data to Adjust's servers.
 
@@ -255,9 +299,13 @@ Adjust.setEnabled(false);
 
 #### [Check enabled status](check-enabled-status)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static bool isEnabled();
 ```
+
+</CodeBlock>
 
 You can check if the Adjust SDK is enabled at any time by calling the `isEnabled` method. This method returns a `bool` value indicating if the SDK is **enabled** (`true`) or **disabled** (`false`).
 

--- a/src/content/docs/sdk/unity/features/ad-revenue.mdx
+++ b/src/content/docs/sdk/unity/features/ad-revenue.mdx
@@ -14,9 +14,13 @@ You need to perform some extra setup steps in your Adjust dashboard to measure a
 
 ## [Instantiate an AdjustAdRevenue object](instantiate-an-adjustadrevenue-object)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public AdjustAdRevenue(string source)
 ```
+
+</CodeBlock>
 
 To send ad revenue information with the Adjust SDK, you need to instantiate an `AdjustAdRevenue` object. This object contains variables that are sent to Adjust when ad revenue is recorded in your app.
 
@@ -40,20 +44,24 @@ To instantiate an ad revenue object, create a new `AdjustAdRevenue` instance and
 
 </Table>
 
-```cs {1}
+```cs
 AdjustAdRevenue adjustAdRevenue = new AdjustAdRevenue("source");
 Adjust.trackAdRevenue(adjustAdRevenue);
 ```
 
 ## [Send ad revenue](send-ad-revenue)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void trackAdRevenue(AdjustAdRevenue adRevenue);
 ```
 
+</CodeBlock>
+
 To send ad revenue to Adjust, call the `trackAdRevenue` method with your ad revenue instance as an argument.
 
-```cs {3}
+```cs
 AdjustAdRevenue adjustAdRevenue = new AdjustAdRevenue("source");
 //...
 Adjust.trackAdRevenue(adjustAdRevenue);
@@ -61,9 +69,13 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 ## [Record ad revenue amount](record-ad-revenue-amount)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setRevenue(double amount, string currency);
 ```
+
+</CodeBlock>
 
 To send the ad revenue amount, call the `setRevenue` method and pass the following arguments:
 
@@ -76,7 +88,7 @@ Check the [guide to recording purchases in different currencies](https://help.ad
 
 </Callout>
 
-```cs {3}
+```cs
 AdjustAdRevenue adjustAdRevenue = new AdjustAdRevenue("source");
 //...
 adjustAdRevenue.setRevenue(1.00, "EUR");
@@ -90,15 +102,19 @@ The `AdjustAdRevenue` class contains properties you can use to report on your ad
 
 ### [Ad impressions](ad-impressions)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setAdImpressionsCount(int adImpressionsCount);
 ```
+
+</CodeBlock>
 
 To send the number of recorded ad impressions, call the `setAdImpressionsCount` method and pass the following arguments:
 
 -  `adImpressionsCount` (`int`): The number of ad impressions.
 
-```cs {3}
+```cs
 AdjustAdRevenue adjustAdRevenue = new AdjustAdRevenue("source");
 //...
 adjustAdRevenue.setAdImpressionsCount(10);
@@ -108,15 +124,19 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 ### [Ad revenue network](ad-revenue-network)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setAdRevenueNetwork(string adRevenueNetwork);
 ```
+
+</CodeBlock>
 
 To send the ad revenue network, call the `setAdRevenueNetwork` method and pass the following arguments:
 
 -  `adRevenueNetwork` (`string`): The network name.
 
-```cs {3}
+```cs
 AdjustAdRevenue adjustAdRevenue = new AdjustAdRevenue("source");
 //...
 adjustAdRevenue.setAdRevenueNetwork("network1");
@@ -126,15 +146,19 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 ### [Ad revenue unit](ad-revenue-unit)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setAdRevenueUnit(string adRevenueUnit);
 ```
+
+</CodeBlock>
 
 To send the ad revenue unit, call the `setAdRevenueUnit` method and pass the following arguments:
 
 -  `adRevenueUnit` (`string`): The ad unit.
 
-```cs {3}
+```cs
 AdjustAdRevenue adjustAdRevenue = new AdjustAdRevenue("source");
 //...
 adjustAdRevenue.setAdRevenueUnit("unit1");
@@ -144,15 +168,19 @@ Adjust.trackAdRevenue(adjustAdRevenue);
 
 ### [Ad revenue placement](ad-revenue-placement)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setAdRevenuePlacement(string adRevenuePlacement);
 ```
+
+</CodeBlock>
 
 To send the ad revenue placement, call the `setAdRevenuePlacement` method and pass the following arguments:
 
 -  `adRevenuePlacement` (`string`): The ad placement.
 
-```cs {3}
+```cs
 AdjustAdRevenue adjustAdRevenue = new AdjustAdRevenue("source");
 //...
 adjustAdRevenue.setAdRevenuePlacement("banner");
@@ -174,9 +202,13 @@ Add callback parameters to your event by calling the `addCallbackParameter` meth
 
 The Adjust SDK measures the event and sends a request to your URL with the callback parameters. For example, if you register the URL `https://www.mydomain.com/callback`, your callback looks like this:
 
-```http "key=value" "foo=bar"
+<CodeBlock highlight="key=value, foo=bar">
+
+```http
 https://www.mydomain.com/callback?key=value&foo=bar
 ```
+
+</CodeBlock>
 
 <Callout type="note">
 
@@ -194,7 +226,7 @@ You can read more about using URL callbacks, including a full list of available 
 
 </Callout>
 
-```cs {3}
+```cs
 AdjustAdRevenue adjustAdRevenue = new AdjustAdRevenue("source");
 //...
 adjustAdRevenue.addCallbackParameter("key", "value");
@@ -220,7 +252,7 @@ Partner parameters don't appear in raw data by default. You can add the `{partne
 
 Add partner parameters to your event by calling the `addPartnerParameter` method with `string` key-value arguments. You can add multiple parameters by calling this method multiple times.
 
-```cs {3}
+```cs
 AdjustAdRevenue adjustAdRevenue = new AdjustAdRevenue("source");
 //...
 adjustAdRevenue.addPartnerParameter("key", "value");

--- a/src/content/docs/sdk/unity/features/att.mdx
+++ b/src/content/docs/sdk/unity/features/att.mdx
@@ -27,9 +27,13 @@ You might receive a status code of `-1` if the SDK is unable to retrieve the ATT
 
 ## [ATT authorization wrapper](att-authorization-wrapper)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void requestTrackingAuthorizationWithCompletionHandler(Action<int> statusCallback, string sceneName = "Adjust");
 ```
+
+</CodeBlock>
 
 The Adjust SDK contains a wrapper around [Apple's `requestTrackingAuthorizationWithCompletionHandler` method](https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanager/3547037-requesttrackingauthorizationwith). You can use this wrapper if you don't want to customize the ATT prompt.
 
@@ -91,9 +95,13 @@ Adjust.requestTrackingAuthorizationWithCompletionHandler((status) =>
 
 ## [Get current authorization status](get-current-authorization-status)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static int getAppTrackingAuthorizationStatus();
 ```
+
+</CodeBlock>
 
 You can retrieve a user's current authorization status at any time. Call the `getAppTrackingAuthorizationStatus` method to return the authorization status code as an `int`.
 
@@ -112,9 +120,13 @@ Adjust.addSessionPartnerParameter("status", authorizationStatus);
 
 ## [Check for authorization status changes](check-for-authorization-status-changes)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void checkForNewAttStatus();
 ```
+
+</CodeBlock>
 
 If you use a custom ATT prompt, you need to inform the Adjust SDK of changes to the user's authorization status. Call the `checkForNewAttStatus` method to send the authorization status to Adjust's servers.
 
@@ -124,9 +136,13 @@ Adjust.checkForNewAttStatus();
 
 ## [Custom prompt timing](custom-prompt-timing)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setAttConsentWaitingInterval(int numberOfSeconds);
 ```
+
+</CodeBlock>
 
 If your app includes an onboarding process or a tutorial, you may want to delay sending your user's ATT consent status until after the user has completed this process. To do this, you can set the `attConsentWaitingInterval` property to delay the sending of data for **up to 120 seconds** to give the user time to complete the initial onboarding. After the timeout ends or the user sets their consent status, the SDK sends all information it has recorded during the delay to Adjust's servers along with the user's consent status.
 
@@ -136,7 +152,7 @@ If the user closes the app before the timeout ends, or before they select their 
 
 </Callout>
 
-```cs {3}
+```cs
 AdjustConfig adjustConfig = new AdjustConfig("{YourAppToken}", AdjustEnvironment.Sandbox);
 //...
 adjustConfig.attConsentWaitingInterval(30);

--- a/src/content/docs/sdk/unity/features/attribution.mdx
+++ b/src/content/docs/sdk/unity/features/attribution.mdx
@@ -41,9 +41,13 @@ The following values can only be accessed if the [`needsCost` property on your `
 
 ## [Trigger a function when attribution changes](trigger-a-function-when-attribution-changes)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setAttributionChangedDelegate(Action<AdjustAttribution> attributionChangedDelegate, string sceneName = "Adjust");
 ```
+
+</CodeBlock>
 
 The SDK can listen for attribution changes and call a function when it detects an update. To configure your callback function, call the `setAttributionChangedDelegate` method with your function name as an argument.
 
@@ -53,7 +57,9 @@ You must call the `setAttributionChangedDelegate` method **before** initializing
 
 </Callout>
 
-```cs {8, 13-16}
+<CodeBlock highlight="{range: 8}, {range: 13-16}">
+
+```cs
 using com.adjust.sdk;
 
 public class ExampleGUI : MonoBehaviour {
@@ -73,11 +79,17 @@ public class ExampleGUI : MonoBehaviour {
 }
 ```
 
+</CodeBlock>
+
 ## [Get current attribution information](get-current-attribution-information)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static AdjustAttribution getAttribution();
 ```
+
+</CodeBlock>
 
 When a user installs your app, Adjust attributes the install to a campaign. The Adjust SDK gives you access to campaign attribution details for your install. To return this information, call the `getAttribution` method to return the attribution information as an `AdjustAttribution` object.
 

--- a/src/content/docs/sdk/unity/features/callbacks.mdx
+++ b/src/content/docs/sdk/unity/features/callbacks.mdx
@@ -32,13 +32,17 @@ Session callbacks have access to a response data object. You can use its propert
 
 ### [Success callbacks](success-callbacks)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setSessionSuccessDelegate(Action<AdjustSessionSuccess> sessionSuccessDelegate, string sceneName = "Adjust");
 ```
 
+</CodeBlock>
+
 Set up success callbacks to trigger functions when the SDK records a session.
 
-```cs {3, 7-9}
+```cs
 AdjustConfig adjustConfig = new AdjustConfig("{Your App Token}", AdjustEnvironment.Sandbox);
 adjustConfig.setLogLevel(AdjustLogLevel.Verbose);
 adjustConfig.setSessionSuccessDelegate(SessionSuccessCallback);
@@ -68,13 +72,17 @@ public void sessionSuccess (AdjustSessionSuccess sessionSuccessData) {
 
 ### [Failure callbacks](failure-callbacks)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setSessionFailureDelegate(Action<AdjustSessionFailure> sessionFailureDelegate, string sceneName = "Adjust");
 ```
 
+</CodeBlock>
+
 Set up failure callbacks to trigger functions when the SDK fails to record a session.
 
-```cs {3, 7-9}
+```cs
 AdjustConfig adjustConfig = new AdjustConfig("{Your App Token}", AdjustEnvironment.Sandbox);
 adjustConfig.setLogLevel(AdjustLogLevel.Verbose);
 adjustConfig.setSessionFailureDelegate(SessionFailureCallback);
@@ -124,13 +132,17 @@ Event callbacks have access to a response data object. You can use its propertie
 
 ### [Success callbacks](success-callbacks-1)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setEventSuccessDelegate(Action<AdjustEventSuccess> eventSuccessDelegate, string sceneName = "Adjust");
 ```
 
+</CodeBlock>
+
 Set up success callbacks to trigger functions when the SDK records an event.
 
-```cs {3, 7-9}
+```cs
 AdjustConfig adjustConfig = new AdjustConfig("{Your App Token}", AdjustEnvironment.Sandbox);
 adjustConfig.setLogLevel(AdjustLogLevel.Verbose);
 adjustConfig.setEventSuccessDelegate(EventSuccessCallback);
@@ -160,13 +172,17 @@ public void eventSuccess (AdjustEventSuccess eventSuccessData) {
 
 ### [Failure callbacks](failure-callbacks-1)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setEventFailureDelegate(Action<AdjustEventFailure> eventFailureDelegate, string sceneName = "Adjust");
 ```
 
+</CodeBlock>
+
 Set up failure callbacks to trigger functions when the SDK fails to record an event.
 
-```cs {3, 7-9}
+```cs
 AdjustConfig adjustConfig = new AdjustConfig("{Your App Token}", AdjustEnvironment.Sandbox);
 adjustConfig.setLogLevel(AdjustLogLevel.Verbose);
 adjustConfig.setEventFailureDelegate(EventFailureCallback);

--- a/src/content/docs/sdk/unity/features/deep-links.mdx
+++ b/src/content/docs/sdk/unity/features/deep-links.mdx
@@ -56,13 +56,17 @@ Android devices use a unique URI scheme to handle deep links. To set up deep lin
 
 ### [Disable deferred deep linking](disable-deferred-deep-linking)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setLaunchDeferredDeeplink(bool launchDeferredDeeplink);
 ```
 
+</CodeBlock>
+
 The SDK opens deferred deep links by default. You can configure this by passing a `bool` argument to the `setLaunchDeferredDeeplink` method.
 
-```cs {3}
+```cs
 AdjustConfig adjustConfig = new AdjustConfig("{YourAppToken}", AdjustEnvironment.Sandbox);
 //...
 adjustConfig.setLaunchDeferredDeeplink(true);
@@ -72,13 +76,17 @@ Adjust.start(adjustConfig);
 
 ### [Set up a deferred deep link delegate](set-up-a-deferred-deep-link-delegate)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setDeferredDeeplinkDelegate(Action<string> deferredDeeplinkDelegate, string sceneName = "Adjust");
 ```
 
+</CodeBlock>
+
 You can configure the Adjust SDK to call a delegate function when it receives a deferred deep link. This delegate function receives the deep link as a `string` argument.
 
-```cs {1-3, 6}
+```cs
 private void DeferredDeeplinkCallback(string deeplinkURL) {
    //...
 }
@@ -105,9 +113,13 @@ Adjust.start(adjustConfig);
 
 ### [Enable LinkMe](enable-linkme)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setLinkMeEnabled(bool linkMeEnabled);
 ```
+
+</CodeBlock>
 
 The Adjust SDK lets you copy deep link information from the device pasteboard. When combined with Adjust’s LinkMe solution, this feature enables deferred deep linking on devices running iOS 15 and above.
 
@@ -121,7 +133,7 @@ When a user clicks on a LinkMe URL they have the option to copy the link informa
 
 To enable pasteboard checking in your app, pass a `true` value to the `setLinkMeEnabled` method on your config object:
 
-```cs {3}
+```cs
 AdjustConfig adjustConfig = new AdjustConfig("{YourAppToken}", AdjustEnvironment.Sandbox, true);
 //...
 adjustConfig.setLinkMeEnabled(true);

--- a/src/content/docs/sdk/unity/features/device-info.mdx
+++ b/src/content/docs/sdk/unity/features/device-info.mdx
@@ -20,9 +20,13 @@ string adid = Adjust.getAdid();
 
 ## [ID For Advertisers](id-for-advertisers)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static string getIdfa();
 ```
+
+</CodeBlock>
 
 The ID for Advertisers (IDFA) is a device-specific identifier for Apple devices. Call the `getIdfa` method to return this ID as a `string`.
 
@@ -32,9 +36,13 @@ string idfa = Adjust.getIdfa();
 
 ## [Google Play Services Advertising ID](google-play-services-advertising-id)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void getGoogleAdId(Action<string> onDeviceIdsRead);
 ```
+
+</CodeBlock>
 
 The Google Play Services Advertising ID (GPS ADID) is a device-specific identifier for Android devices.
 
@@ -50,9 +58,13 @@ Adjust.getGoogleAdId((string googleAdId) => {
 
 ## [Amazon Advertiser ID](amazon-advertiser-id)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static string getAmazonAdId();
 ```
+
+</CodeBlock>
 
 The Amazon Advertising ID (Amazon Ad ID) is a device-specific identifier for Android devices. Call the `getAmazonAdId` method to return this ID as a `string`.
 

--- a/src/content/docs/sdk/unity/features/events.mdx
+++ b/src/content/docs/sdk/unity/features/events.mdx
@@ -8,13 +8,18 @@ The Adjust SDK provides an `AdjustEvent` object which can be used to structure a
 
 ## [Instantiate an AdjustEvent object](instantiate-an-adjustevent-object)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public AdjustEvent(string eventToken)
 {
    this.eventToken = eventToken;
    this.isReceiptSet = false;
 }
+
 ```
+
+</CodeBlock>
 
 To send event information with the Adjust SDK, you need to instantiate an `AdjustEvent` object. This object contains variables that are sent to Adjust when an event occurs in your app.
 
@@ -22,7 +27,7 @@ To instantiate an event object, create a new `AdjustEvent` instance and pass the
 
 -  `eventToken` (`string`): Your Adjust [event token](https://help.adjust.com/en/article/add-events#manage-your-events).
 
-```cs {1}
+```cs
 AdjustEvent adjustEvent = new AdjustEvent("abc123");
 //...
 Adjust.trackEvent(adjustEvent);
@@ -30,16 +35,20 @@ Adjust.trackEvent(adjustEvent);
 
 ## [Send an event](send-an-event)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void trackEvent(AdjustEvent adjustEvent);
 ```
+
+</CodeBlock>
 
 You can associate your [Adjust event tokens](https://help.adjust.com/en/article/add-events#add-event) to actions in your app to record them. To record an event:
 
 -  Create a new Adjust event instance and pass your event token as a string argument.
 -  Call the `trackEvent` method with your event instance as an argument.
 
-```cs {3}
+```cs
 AdjustEvent adjustEvent = new AdjustEvent("abc123");
 //...
 Adjust.trackEvent(adjustEvent);
@@ -56,7 +65,9 @@ if (GUI.Button(new Rect(0, Screen.height * 1 / numberOfButtons, Screen.width, Sc
 }
 ```
 
-```txt collapse={6-46} title="Event log"
+<CodeBlock title="Event log" collapse="6-46">
+
+```txt
 Path:      /event
 ClientSdk: unity$UNITY_VERSION
 Parameters:
@@ -103,13 +114,20 @@ Parameters:
   time_spent       23
   tracking_enabled 1
   ui_mode          1
+
 ```
+
+</CodeBlock>
 
 ## [Record event revenue](record-event-revenue)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setRevenue(double amount, string currency);
 ```
+
+</CodeBlock>
 
 You can record revenue associated with an event by setting the revenue and currency properties on your event instance. Use this feature to record revenue-generating actions in your app.
 
@@ -124,7 +142,7 @@ Check the guide to [recording purchases in different currencies](https://help.ad
 
 </Callout>
 
-```cs {3}
+```cs
 AdjustEvent adjustEvent = new AdjustEvent("abc123");
 //...
 adjustEvent.setRevenue(0.01, "EUR");
@@ -144,7 +162,9 @@ if (GUI.Button(new Rect(0, Screen.height * 2 / numberOfButtons, Screen.width, Sc
 }
 ```
 
-```txt title="Event log" {7,8}
+<CodeBlock title="Event log" highlight="{range: 7-8}">
+
+```txt
 Path:      /event
 ClientSdk: unity$UNITY_VERSION
 Parameters:
@@ -154,6 +174,8 @@ Parameters:
   revenue          0.25
   currency         EUR
 ```
+
+</CodeBlock>
 
 ### [Purchase verification](purchase-verification)
 
@@ -184,15 +206,19 @@ Adjust.trackEvent(adjustEvent);
 
 ## [Unique events](unique-events)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setTransactionId(string transactionId);
 ```
+
+</CodeBlock>
 
 You can pass an optional identifier to avoid recording duplicate events. The SDK stores the last ten identifiers and skips revenue events with duplicate transaction IDs.
 
 To set the identifier, call the `setTransactionId` method and pass your transaction ID as a `string` argument.
 
-```cs {3}
+```cs
 AdjustEvent adjustEvent = new AdjustEvent("abc123");
 //...
 adjustEvent.setTransactionId("transactionId");
@@ -213,7 +239,9 @@ if (GUI.Button(new Rect(0, Screen.height * 2 / numberOfButtons, Screen.width, Sc
 }
 ```
 
-```txt title="Event log" {7}
+<CodeBlock title="Event log" highlight="{range: 7}">
+
+```txt
 Path:      /event
 ClientSdk: unity$UNITY_VERSION
 Parameters:
@@ -223,11 +251,17 @@ Parameters:
   transaction_id   5e85484b-1ebc-4141-aab7-25b869e54c49
 ```
 
+</CodeBlock>
+
 ## [Add callback parameters](add-callback-parameters)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void addCallbackParameter(string key, string value);
 ```
+
+</CodeBlock>
 
 If you [register a callback URL](https://help.adjust.com/en/article/set-up-callbacks) in the Adjust dashboard, the SDK sends a GET request to your callback URL when it records an event.
 
@@ -235,7 +269,7 @@ You can configure callback parameters to send to your servers. Once you configur
 
 Add callback parameters to your event by calling the `addCallbackParameter` method with `string` key-value arguments. You can add multiple parameters by calling this method multiple times.
 
-```cs {3}
+```cs
 AdjustEvent adjustEvent = new AdjustEvent("abc123");
 //...
 adjustEvent.addCallbackParameter("key", "value");
@@ -287,7 +321,9 @@ if (GUI.Button(new Rect(0, Screen.height * 2 / numberOfButtons, Screen.width, Sc
 }
 ```
 
-```txt {4} title="Event log"
+<CodeBlock title="Event log" highlight="{range: 4}">
+
+```txt
 Path:      /event
 ClientSdk: unity$UNITY_VERSION
 Parameters:
@@ -295,13 +331,20 @@ Parameters:
   environment      sandbox
   event_count      1
   event_token      g3mfiw
+
 ```
+
+</CodeBlock>
 
 ## [Add partner parameters](add-partner-parameters)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void addPartnerParameter(string key, string value);
 ```
+
+</CodeBlock>
 
 You can send extra information to your network partners by adding [partner parameters](https://help.adjust.com/en/article/data-sharing-ad-network#map-parameters).
 
@@ -315,7 +358,7 @@ Partner parameters don't appear in raw data by default. You can add the `{partne
 
 Add partner parameters to your event by calling the `addPartnerParameter` method with `string` key-value arguments. You can add multiple parameters by calling this method multiple times.
 
-```cs {3}
+```cs
 AdjustEvent adjustEvent = new AdjustEvent("abc123");
 //...
 adjustEvent.addPartnerParameter("key", "value");
@@ -339,7 +382,9 @@ if (GUI.Button(new Rect(0, Screen.height * 2 / numberOfButtons, Screen.width, Sc
 }
 ```
 
-```txt title="Event log" {4}
+<CodeBlock title="Event log" highlight="{range: 4}">
+
+```txt
 Path:      /event
 ClientSdk: unity$UNITY_VERSION
 Parameters:
@@ -349,11 +394,17 @@ Parameters:
   event_token      g3mfiw
 ```
 
+</CodeBlock>
+
 ## [Add a callback identifier](add-a-callback-identifier)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setCallbackId(string callbackId)
 ```
+
+</CodeBlock>
 
 You can add a custom string identifier to each event you want to measure. Adjust's servers can report on this identifier in event callbacks. This enables you to keep track of which events have been successfully measured.
 
@@ -380,7 +431,9 @@ if (GUI.Button(new Rect(0, Screen.height * 2 / numberOfButtons, Screen.width, Sc
 }
 ```
 
-```txt title="Event log" {7}
+<CodeBlock title="Event log" highlight="{range: 7}">
+
+```txt
 Path:      /event
 ClientSdk: unity$UNITY_VERSION
 Parameters:
@@ -389,3 +442,5 @@ Parameters:
   event_token      g3mfiw
   callback_id      f2e728d8-271b-49ab-80ea-27830a215147
 ```
+
+</CodeBlock>

--- a/src/content/docs/sdk/unity/features/preinstalled.mdx
+++ b/src/content/docs/sdk/unity/features/preinstalled.mdx
@@ -34,19 +34,28 @@ The content provider method makes use of a read-only content provider. The SDK u
 
 To set the permissions, add the following to your `AndroidManifest.xml` file.
 
-```xml title="AndroidManifest.xml"
+<CodeBlock title="AndroidManifest.xml">
+
+```xml
 <uses-permission android:name="com.adjust.preinstall.READ_PERMISSION"/>
 ```
 
+</CodeBlock>
+
 To access a list of preinstalled apps on the device, add the following to your `AndroidManifest.xml` file.
 
-```xml title="AndroidManifest.xml"
+<CodeBlock title="AndroidManifest.xml">
+
+```xml
 <queries>
    <intent>
        <action android:name="com.attribution.REFERRAL_PROVIDER"/>
    </intent>
 </queries>
+
 ```
+
+</CodeBlock>
 
 ## [System installer receiver](system-installer-receiver)
 
@@ -54,13 +63,18 @@ The system installer method uses a broadcast receiver. The system installer broa
 
 To set up the receiver, add the following to your `AndroidManifest.xml` file.
 
-```xml title="AndroidManifest.xml"
+<CodeBlock title="AndroidManifest.xml">
+
+```xml
 <receiver android:name="com.adjust.sdk.AdjustPreinstallReferrerReceiver">
    <intent-filter>
       <action android:name="com.attribution.SYSTEM_INSTALLER_REFERRER" />
    </intent-filter>
 </receiver>
+
 ```
+
+</CodeBlock>
 
 ## [World-readable directory](world-readable-directory)
 
@@ -82,7 +96,7 @@ Configuring a default link token enables you to attribute all preinstalls to a p
 
 1. [Create a new campaign link in Campaign Lab](https://help.adjust.com/en/article/links).
 
-   ```http "{token}"
+   ```http
    https://app.adjust.com/{token}
    ```
 

--- a/src/content/docs/sdk/unity/features/privacy.mdx
+++ b/src/content/docs/sdk/unity/features/privacy.mdx
@@ -8,9 +8,13 @@ The Adjust SDK contains features that you can use to handle user privacy in your
 
 ## [Send erasure request](send-erasure-request)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void gdprForgetMe();
 ```
+
+</CodeBlock>
 
 The EU’s General Data Protection Regulation (GDPR) and similar privacy laws worldwide (CCPA, LGPD, etc.) grant data subjects comprehensive rights when it comes to the processing of their personal data. These rights include, among others, the right to erasure (see [Art. 17 GDPR](https://gdpr.eu/article-17-right-to-be-forgotten/))([1](https://help.adjust.com/en/article/gdpr#ref-1)). As a data processor, Adjust is obliged to support you (the data controller) in the processing of such requests from your (app) users.
 
@@ -29,9 +33,13 @@ You can use the Adjust SDK to record when a user changes their third-party shari
 
 ### [Instantiate an AdjustThirdPartySharing object](instantiate-an-adjustthirdpartysharing-object)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public AdjustThirdPartySharing(bool? isEnabled);
 ```
+
+</CodeBlock>
 
 To enable or disable third party sharing with the Adjust SDK, you need to instantiate an `AdjustThirdPartySharing` object. This object contains variables that control how third party sharing is handled by Adjust.
 
@@ -39,7 +47,7 @@ To instantiate a third party sharing object, create a new `AdjustThirdPartyShari
 
 -  `isEnabled` (`bool`): Whether third party sharing is enabled. Pass `true` to enable third party sharing or `false` to disable third party sharing
 
-```cs {1}
+```cs
 AdjustThirdPartySharing adjustThirdPartySharing = new AdjustThirdPartySharing(true);
 //...
 Adjust.trackThirdPartySharing(adjustThirdPartySharing);
@@ -53,7 +61,7 @@ If you set the `isEnabled` property to `false`, Adjust stops sharing the user's 
 
 Once you've instantiated your `AdjustThirdPartySharing` object, you can send the information to Adjust by calling the `Adjust.trackThirdPartySharing` method with your `AdjustThirdPartySharing` instance as an argument.
 
-```cs {3}
+```cs
 AdjustThirdPartySharing adjustThirdPartySharing = new AdjustThirdPartySharing(true);
 //...
 Adjust.trackThirdPartySharing(adjustThirdPartySharing);
@@ -61,9 +69,13 @@ Adjust.trackThirdPartySharing(adjustThirdPartySharing);
 
 ### [Send granular information](send-granular-information)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void addGranularOption(string partnerName, string key, string value);
 ```
+
+</CodeBlock>
 
 You can attach granular information when a user updates their third-party sharing preferences. Use this information to communicate more detail about a user's decision. To do this, call the `addGranularOption` method with the following parameters:
 
@@ -90,7 +102,7 @@ The following partners are available:
 
 </Table>
 
-```cs {3}
+```cs
 AdjustThirdPartySharing adjustThirdPartySharing = new AdjustThirdPartySharing(null);
 //...
 adjustThirdPartySharing.addGranularOption("PartnerA", "key", "value");
@@ -126,7 +138,7 @@ If you call this method with a `0` value for **either** `data_processing_options
 
 </Callout>
 
-```cs {3,4}
+```cs
 AdjustThirdPartySharing adjustThirdPartySharing = new AdjustThirdPartySharing(null);
 //...
 adjustThirdPartySharing.addGranularOption("facebook", "data_processing_options_country", "1");
@@ -263,9 +275,13 @@ Adjust.trackThirdPartySharing(adjustThirdPartySharing);
 
 ## [Disable third-party sharing](disable-third-party-sharing)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void disableThirdPartySharing();
 ```
+
+</CodeBlock>
 
 To disable third-party sharing for all users, call the `disableThirdPartySharing` method. When Adjust's servers receive this information, Adjust stops sharing the user's data with third parties. The Adjust SDK continues to work as expected.
 
@@ -275,9 +291,13 @@ Adjust.disableThirdPartySharing();
 
 ## [Set URL strategy](set-url-strategy)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setUrlStrategy(String urlStrategy);
 ```
+
+</CodeBlock>
 
 The URL strategy feature allows you to set either:
 
@@ -303,7 +323,7 @@ To set your country of data residency, call the `setUrlStrategy` method on your 
 
 </Table>
 
-```cs {2}
+```cs
 AdjustConfig adjustConfig = new AdjustConfig("{YourAppToken}", AdjustEnvironment.Sandbox);
 adjustConfig.setUrlStrategy(AdjustConfig.AdjustDataResidencyEU);
 Adjust.start(adjustConfig);
@@ -311,9 +331,13 @@ Adjust.start(adjustConfig);
 
 ## [Consent measurement for specific users](consent-measurement-for-specific-users)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void trackMeasurementConsent(bool measurementConsent);
 ```
+
+</CodeBlock>
 
 If you're using [Data Privacy settings](https://help.adjust.com/en/article/manage-data-collection-and-retention) in your Adjust dashboard, you need to set up the Adjust SDK to work with them. This includes settings such as consent expiry period and user data retention period.
 

--- a/src/content/docs/sdk/unity/features/session-parameters.mdx
+++ b/src/content/docs/sdk/unity/features/session-parameters.mdx
@@ -18,9 +18,13 @@ You can configure callback parameters to your servers. Once you configure parame
 
 ### [Add session callback parameters](add-session-callback-parameters)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void addSessionCallbackParameter(string key, string value);
 ```
+
+</CodeBlock>
 
 Add callback parameters to your event by calling the `addSessionCallbackParameter` method with `string` key-value arguments. You can add multiple parameters by calling this method multiple times.
 
@@ -30,9 +34,13 @@ Adjust.addSessionCallbackParameter("key", "value");
 
 ### [Remove session callback parameters](remove-session-callback-parameters)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void removeSessionCallbackParameter(string key);
 ```
+
+</CodeBlock>
 
 You can remove specific session callback parameters if they're no longer required. To do this, pass the parameter `key` to the `removeSessionCallbackParameter` method.
 
@@ -42,9 +50,13 @@ Adjust.removeSessionCallbackParameter("key");
 
 ### [Reset session callback parameters](reset-session-callback-parameters)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void resetSessionCallbackParameters();
 ```
+
+</CodeBlock>
 
 You can remove all session parameters if they're no longer required. To do this, call the `resetSessionCallbackParameters` method.
 
@@ -66,9 +78,13 @@ Partner parameters don't appear in raw data by default. You can add the `{partne
 
 ### [Add session partner parameters](add-session-partner-parameters)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void addSessionPartnerParameter(string key, string value);
 ```
+
+</CodeBlock>
 
 Send partner parameters with your session by calling the `addSessionPartnerParameter` method with `string` key-value arguments. You can add multiple parameters by calling this method multiple times.
 
@@ -78,9 +94,13 @@ Adjust.addSessionPartnerParameter("key", "value");
 
 ### [Remove session partner parameters](remove-session-partner-parameters)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void removeSessionPartnerParameter(string key);
 ```
+
+</CodeBlock>
 
 You can remove specific session partner parameters if they're no longer required. To do this, pass the parameter key to the `removeSessionPartnerParameter` method.
 
@@ -90,9 +110,13 @@ Adjust.removeSessionPartnerParameter("key");
 
 ### [Reset session partner parameters](reset-session-partner-parameters)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void resetSessionPartnerParameters();
 ```
+
+</CodeBlock>
 
 You can remove all session partner parameters if they're no longer required. To do this, call the `resetSessionPartnerParameters` method.
 
@@ -110,7 +134,7 @@ You can delay the startup of the SDK by up to **10 seconds**.
 
 The Adjust SDK starts as soon as your app opens. If you want to send data that's not available at launch in session parameters, you can delay the start of the SDK. To do this, pass the delay time in seconds to the [`setDelayStart` method](/en/sdk/unity/configuration#delay-the-start-of-the-sdk) on your config object.
 
-```cs {3}
+```cs
 AdjustConfig adjustConfig = new AdjustConfig("{YourAppToken}", AdjustEnvironment.Sandbox);
 //...
 adjustConfig.setDelayStart(5.5);

--- a/src/content/docs/sdk/unity/features/skad.mdx
+++ b/src/content/docs/sdk/unity/features/skad.mdx
@@ -18,9 +18,13 @@ StoreKit Ad Network (SKAdNetwork) is Apple's attribution framework for app insta
 
 ## [Disable SKAdNetwork communication](disable-skadnetwork-communication)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void deactivateSKAdNetworkHandling();
 ```
+
+</CodeBlock>
 
 <MinorVersion added="v4.23.0">
 
@@ -36,7 +40,7 @@ You must call the `deactivateSKAdNetworkHandling` method _before_ initializing t
 
 </Callout>
 
-```cs {3}
+```cs
 AdjustConfig adjustConfig = new AdjustConfig("{YourAppToken}", AdjustEnvironment.Sandbox, true);
 //...
 adjustConfig.deactivateSKAdNetworkHandling();
@@ -46,9 +50,13 @@ Adjust.start(adjustConfig);
 
 ## [Update conversion values](update-conversion-values)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void updateConversionValue(int conversionValue);
 ```
+
+</CodeBlock>
 
 Conversion values are a mechanism used to measure user behavior in SKAdNetwork. You can map 64 conditions to values from 0 through 63 and send this integer value to SKAdNetwork on user install. This gives you insight into how your users interact with your app in the first few days.
 
@@ -62,7 +70,7 @@ Adjust.updateConversionValue(6);
 
 This example shows how to update a conversion value to `10` in response to a user triggering an event.
 
-```cs {2}
+```cs
 public void OnButtonClick() {
    Adjust.updateConversionValue(10);
 }
@@ -70,13 +78,17 @@ public void OnButtonClick() {
 
 ## [Listen for changes to conversion values](listen-for-changes-to-conversion-values)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setConversionValueUpdatedDelegate(Action<int> conversionValueUpdatedDelegate, string sceneName = "Adjust");
 ```
 
+</CodeBlock>
+
 If you use Adjust to manage conversion values, the Adjust's servers send conversion value updates to the SDK. You can set up a delegate function to listen for these changes using the `setConversionValueUpdatedDelegate` method. Pass your function as an argument.
 
-```cs {3}
+```cs
 AdjustConfig adjustConfig = new AdjustConfig("{YourAppToken}", AdjustEnvironment.Sandbox, true);
 //...
 adjustConfig.setConversionValueUpdatedDelegate(ConversionValueUpdatedCallback);
@@ -91,7 +103,9 @@ This example shows how to log the following when the conversion value updates:
 -  A message confirming the conversion value update
 -  The new conversion value
 
-```cs {8, 14-17}
+<CodeBlock highlight="{range: 8}, {range: 14-17}">
+
+```cs
 using com.adjust.sdk;
 
 public class ExampleGUI : MonoBehaviour {
@@ -111,3 +125,5 @@ public class ExampleGUI : MonoBehaviour {
     }
 }
 ```
+
+</CodeBlock>

--- a/src/content/docs/sdk/unity/features/subscriptions.mdx
+++ b/src/content/docs/sdk/unity/features/subscriptions.mdx
@@ -19,9 +19,13 @@ To get started, you need to create a subscription object containing details of t
 <Tabs>
 <Tab title="App Store" sync="appstore" icon="PlatformIos">
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public AdjustAppStoreSubscription(string price, string currency, string transactionId, string receipt)
 ```
+
+</CodeBlock>
 
 Create an `AdjustAppStoreSubscription` object with the following properties:
 
@@ -47,9 +51,13 @@ AdjustAppStoreSubscription subscription = new AdjustAppStoreSubscription(
 </Tab>
 <Tab title="Play Store" sync="playstore" icon="PlatformGooglePlay">
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public AdjustPlayStoreSubscription(string price, string currency, string sku, string orderId, string signature, string purchaseToken)
 ```
+
+</CodeBlock>
 
 Create an `AdjustPlayStoreSubscription` object with the following properties:
 
@@ -86,13 +94,17 @@ You can record the date on which the user purchased a subscription. The SDK retu
 <Tabs>
 <Tab title="App Store" sync="appstore" icon="PlatformIos">
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setTransactionDate(string transactionDate);
 ```
 
+</CodeBlock>
+
 Call the `setTransactionDate` method on your subscription object to record the timestamp of the subscription.
 
-```cs {7}
+```cs
 AdjustAppStoreSubscription subscription = new AdjustAppStoreSubscription(
     price,
     currency,
@@ -105,13 +117,17 @@ subscription.setTransactionDate(transactionDate);
 </Tab>
 <Tab title="Play Store" sync="playstore" icon="PlatformGooglePlay">
 
-```cs title="Methdo signature"
+<CodeBlock title="Methdo signature">
+
+```cs
 public void setPurchaseTime(string purchaseTime);
 ```
 
+</CodeBlock>
+
 Call the `setPurchaseTime` method on your subscription object to record the timestamp of the subscription.
 
-```cs {8}
+```cs
 AdjustPlayStoreSubscription subscription = new AdjustPlayStoreSubscription(
     price,
     currency,
@@ -127,13 +143,17 @@ subscription.setPurchaseTime(purchaseTime);
 
 ### [Record the purchase region (iOS only)](record-the-purchase-region-ios-only)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setSalesRegion(string salesRegion);
 ```
 
+</CodeBlock>
+
 You can record the region in which the user purchased a subscription. To do this, call the `setSalesRegion` method on your subscription object and pass the country code as a `string`. This needs to be formatted as the [`countryCode`](https://developer.apple.com/documentation/foundation/nslocale/1643060-countrycode?language=swift) of the [`priceLocale`](https://developer.apple.com/documentation/storekit/skproduct/1506145-pricelocale?language=swift) object.
 
-```cs {7}
+```cs
 AdjustAppStoreSubscription subscription = new AdjustAppStoreSubscription(
     price,
     currency,
@@ -150,11 +170,15 @@ You can add callback parameters to your subscription object. The SDK appends the
 <Tabs>
 <Tab title="App Store" sync="appstore" icon="PlatformIos">
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void addCallbackParameter(string key, string value);
 ```
 
-```cs {7-8}
+</CodeBlock>
+
+```cs
 AdjustAppStoreSubscription subscription = new AdjustAppStoreSubscription(
     price,
     currency,
@@ -168,11 +192,15 @@ subscription.addCallbackParameter("key2", "value2");
 </Tab>
 <Tab title="Play Store" sync="playstore" icon="PlatformGooglePlay">
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void addCallbackParameter(string key, string value);
 ```
 
-```cs {9-10}
+</CodeBlock>
+
+```cs
 AdjustPlayStoreSubscription subscription = new AdjustPlayStoreSubscription(
     price,
     currency,
@@ -195,11 +223,15 @@ You can add partner parameters to your subscription object. The SDK sends these 
 <Tabs>
 <Tab title="App Store" sync="appstore" icon="PlatformIos">
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void addPartnerParameter(string key, string value);
 ```
 
-```cs {7-8}
+</CodeBlock>
+
+```cs
 AdjustAppStoreSubscription subscription = new AdjustAppStoreSubscription(
     price,
     currency,
@@ -213,11 +245,15 @@ subscription.addPartnerParameter("key2", "value2");
 </Tab>
 <Tab title="Play Store" sync="playstore" icon="PlatformGooglePlay">
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void addPartnerParameter(string key, string value);
 ```
 
-```cs {9-10}
+</CodeBlock>
+
+```cs
 AdjustPlayStoreSubscription subscription = new AdjustPlayStoreSubscription(
     price,
     currency,
@@ -240,13 +276,17 @@ Once you have set up your subscription object, you can record it using the Adjus
 <Tabs>
 <Tab title="App Store" sync="appstore" icon="PlatformIos">
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void trackAppStoreSubscription(AdjustAppStoreSubscription subscription);
 ```
 
+</CodeBlock>
+
 Pass your subscription object to the `trackAppStoreSubscription` method to record the user's subscription purchase.
 
-```cs {13}
+```cs
 AdjustAppStoreSubscription subscription = new AdjustAppStoreSubscription(
    price,
    currency,
@@ -265,13 +305,17 @@ Adjust.trackAppStoreSubscription(subscription);
 </Tab>
 <Tab title="Play Store" sync="playstore" icon="PlatformGooglePlay">
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void trackPlayStoreSubscription(AdjustPlayStoreSubscription subscription);
 ```
 
+</CodeBlock>
+
 Pass your subscription object to the `trackPlayStoreSubscription` method to record the user's subscription purchase.
 
-```cs {14}
+```cs
 AdjustPlayStoreSubscription subscription = new AdjustPlayStoreSubscription(
    price,
    currency,

--- a/src/content/docs/sdk/unity/index.mdx
+++ b/src/content/docs/sdk/unity/index.mdx
@@ -153,19 +153,23 @@ The Adjust SDK supports the [Meta Install Referrer](https://developers.facebook.
 1. Find your Meta app ID in your [App Dashboard](https://developers.facebook.com/apps). See Meta's [App Dashboard documentation](https://developers.facebook.com/docs/development/create-an-app/app-dashboard) for more information.
 2. [Add the Meta apps to your `AndroidManifest.xml` file](https://developers.facebook.com/docs/app-ads/meta-install-referrer#step-1--add-the-meta-apps).
 
-   ```xml title="AndroidManifest.xml"
-   <queries>
-      <package android:name="com.facebook.katana" />
-   </queries>
+<CodeBlock title="AndroidManifest.xml">
 
-   <queries>
-      <package android:name="com.instagram.android" />
-   </queries>
-   ```
+```xml
+<queries>
+   <package android:name="com.facebook.katana" />
+</queries>
+
+<queries>
+   <package android:name="com.instagram.android" />
+</queries>
+```
+
+</CodeBlock>
 
 3. Pass your App ID as a `string` argument to the `AdjustConfig.setFbAppId` method.
 
-   ```cs {3}
+   ```cs
    AdjustConfig config = new AdjustConfig("{YourAppToken}", AdjustEnvironment.Sandbox, true);
    //...
    config.setFbAppId("{FB_APP_ID_STRING}");

--- a/src/content/docs/sdk/unity/plugins/imei.mdx
+++ b/src/content/docs/sdk/unity/plugins/imei.mdx
@@ -23,20 +23,29 @@ To use the IMEI plugin, you need to add it to your project. There are two ways t
 -  [Download the JAR from Adjust's GitHub releases page](https://github.com/adjust/android_sdk/releases).
 -  Add the dependency to your `build.gradle` file.
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 dependencies {
    implementation 'com.adjust.sdk:adjust-android:$UNITY_VERSION'
    implementation 'com.adjust.sdk:adjust-android-imei:$UNITY_VERSION'
 }
+
 ```
+
+</CodeBlock>
 
 ## [Add permissions](add-permissions)
 
 Ensure the following permission is present in your `AndroidManifest.xml` file. Add it if it's not.
 
-```xml title="AndroidManifest.xml"
+<CodeBlock title="AndroidManifest.xml">
+
+```xml
 <uses-permission android:name="android.permission.READ_PHONE_STATE" />
 ```
+
+</CodeBlock>
 
 <Callout type="note">
 
@@ -48,9 +57,13 @@ As of Android 6.0 you may need to [request app permission](https://developer.and
 
 If your app doesn't target the Google Play Store, you don't need to add all the rules set out in the get started guide. You can remove rules related to Google Play Services and install referrer libraries. You only need to keep the rules that apply to the Adjust SDK.
 
-```java title="proguard.pro"
+<CodeBlock title="proguard.pro">
+
+```java
 -keep public class com.adjust.sdk.** { *; }
 ```
+
+</CodeBlock>
 
 ## [Use the plugin](use-the-plugin)
 

--- a/src/content/docs/sdk/unity/plugins/oaid.mdx
+++ b/src/content/docs/sdk/unity/plugins/oaid.mdx
@@ -67,35 +67,53 @@ You can use the HMS Core SDK to access the OAID of Huawei devices. To enable the
 
 1. Add the Huawei maven repository.
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 repositories {
   maven {
       url "https://developer.huawei.com/repo/"
   }
 }
+
 ```
+
+</CodeBlock>
 
 2. Add the HMS Core SDK.
 
-```groovy title="build.gradle"
+<CodeBlock title="build.gradle">
+
+```groovy
 dependencies {
    implementation 'com.huawei.hms:ads-identifier:3.4.62.300'
 }
+
 ```
+
+</CodeBlock>
 
 ## [Proguard settings](proguard-settings)
 
 If your app isn't targeting the Google Play Store, you don't need to add all the rules set out in the Android get started guide. You can remove rules related to Google Play Services and install referrer libraries. You only need to keep the rules that apply to the Adjust SDK.
 
-```java title="proguard.pro"
+<CodeBlock title="proguard.pro">
+
+```java
 -keep public class com.adjust.sdk.** { *; }
 ```
 
+</CodeBlock>
+
 If you are adding the MSA SDK AAR as a dependency, add the following rules:
 
-```java title="proguard.pro"
+<CodeBlock title="proguard.pro">
+
+```java
 -keep class com.bun.miitmdid.core.** { *; }
 ```
+
+</CodeBlock>
 
 ## [Use the plugin](use-the-plugin)
 

--- a/src/content/docs/sdk/web/configuration.mdx
+++ b/src/content/docs/sdk/web/configuration.mdx
@@ -10,9 +10,13 @@ You can configure the behavior of the Adjust SDK by assigning properties in the 
 
 ## [Required configuration](required-configuration)
 
-```ts title="Method signature"
+<CodeBlock title="Method signature">
+
+```ts
 function initSdk({ logLevel, logOutput, ...options }: InitOptions): void;
 ```
+
+</CodeBlock>
 
 To configure the Adjust SDK, you need to call the `Adjust.initSdk` method with the following arguments:
 
@@ -28,14 +32,19 @@ Adjust.initSdk({
 
 ### [Logging options](logging-options)
 
-```js title="Interface declaration"
+<CodeBlock title="Interface declaration">
+
+```js
 export type LogOptionsT = $ReadOnly<
    $Shape<{|
       logLevel: "none" | "error" | "warning" | "info" | "verbose",
       logOutput: string,
    |}>
 >;
+
 ```
+
+</CodeBlock>
 
 The Adjust SDK provides configurable log levels to return different amounts of information. The following log levels are available:
 
@@ -53,7 +62,7 @@ The Adjust SDK provides configurable log levels to return different amounts of i
 
 You can set the log level by specifying an `logLevel` argument in the `initSdk` method. The SDK defaults to `error` if no value is passed.
 
-```js {4}
+```js
 Adjust.initSdk({
    appToken: "YOUR_APP_TOKEN",
    environment: "sandbox",
@@ -65,7 +74,7 @@ Adjust.initSdk({
 
 You can delegate a log output location in your web app to show logs directly on the screen. To do this, specify an HTML selector in the `logOutput` argument in the `initSdk` method. The SDK logs will print to this container.
 
-```js {4}
+```js
 Adjust.initSdk({
    appToken: "YOUR_APP_TOKEN",
    environment: "sandbox",
@@ -75,7 +84,9 @@ Adjust.initSdk({
 
 ## [Initialization options](initialization-options)
 
-```js title="Interface declaration"
+<CodeBlock title="Interface declaration">
+
+```js
 export type InitOptionsT = $ReadOnly<
    $Shape<{|
       appToken: $PropertyType<BaseParamsT, "appToken">,
@@ -93,13 +104,20 @@ export type InitOptionsT = $ReadOnly<
       attributionCallback: (string, Object) => mixed,
    |}>
 >;
+
 ```
+
+</CodeBlock>
 
 ### [Set external device identifier](set-external-device-identifier)
 
-```js title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```js
 externalDeviceId: string;
 ```
+
+</CodeBlock>
 
 An external device identifier is a custom value that you can assign to a device or user. They help you recognize users across sessions and platforms. They can also help you deduplicate installs by user so that a user isn't counted as duplicate new installs. Contact your Adjust representative to get started with external device IDs.
 
@@ -111,7 +129,7 @@ See the [External device identifiers article](https://help.adjust.com/en/article
 
 </Callout>
 
-```js {4}
+```js
 Adjust.initSdk({
    appToken: "YOUR_APP_TOKEN",
    environment: "sandbox",
@@ -125,13 +143,17 @@ You can import existing external device IDs into Adjust. This ensures that the A
 
 ### [Set default link token](set-default-link-token)
 
-```js title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```js
 defaultTracker: string;
 ```
 
+</CodeBlock>
+
 You can configure a default link token if your app is preinstalled on a device. When a user opens the preinstalled app for the first time, the install is attributed to the default link token. Pass your token in the `defaultTracker` argument of your `Adjust.initSdk` call.
 
-```js {4}
+```js
 Adjust.initSdk({
    appToken: "YOUR_APP_TOKEN",
    environment: "sandbox",
@@ -141,9 +163,13 @@ Adjust.initSdk({
 
 ### [Set storage namespace](set-storage-namespace)
 
-```js title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```js
 namespace: string;
 ```
+
+</CodeBlock>
 
 The Adjust SDK creates a storage namespace to store data in by default. You can override this an specify a custom namespace if you want to control where the data ends up.
 
@@ -157,7 +183,7 @@ Don't change your custom namespace after you set it. Information stored in the c
 
 You can set an custom namespace by specifying a `namespace` property in the `initSdk` method.
 
-```js {4}
+```js
 Adjust.initSdk({
    appToken: "YOUR_APP_TOKEN",
    environment: "sandbox",
@@ -171,9 +197,13 @@ Adjust.initSdk({
 
 ### [Toggle offline mode](toggle-offline-mode)
 
-```js title="Method signature"
+<CodeBlock title="Method signature">
+
+```js
 function switchToOfflineMode(): void;
 ```
+
+</CodeBlock>
 
 <Callout type="important">
 
@@ -191,9 +221,13 @@ Adjust.switchToOfflineMode();
 
 #### [Event buffering](event-buffering)
 
-```js title="Method signature"
+<CodeBlock title="Method signature">
+
+```js
 function switchBackToOnlineMode(): void;
 ```
+
+</CodeBlock>
 
 The SDK sends all saved information to Adjust's servers when you disable offline mode. To do this, call the `switchBackToOnlineMode` method.
 

--- a/src/content/docs/sdk/web/features/attribution.mdx
+++ b/src/content/docs/sdk/web/features/attribution.mdx
@@ -8,7 +8,9 @@ When a user interacts with an Adjust link, their attribution information updates
 
 The Attribution object contains the following information:
 
-```js title="Interface declaration"
+<CodeBlock title="Interface declaration">
+
+```js
 export type AttributionMapT = $ReadOnly<{|
    adid: string,
    tracker_token: string,
@@ -21,6 +23,8 @@ export type AttributionMapT = $ReadOnly<{|
    state: string,
 |}>;
 ```
+
+</CodeBlock>
 
 <Table>
 
@@ -40,9 +44,13 @@ export type AttributionMapT = $ReadOnly<{|
 
 ## [Trigger a callback when attribution changes](trigger-a-callback-when-attribution-changes)
 
-```js title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```js
 attributionCallback: (string, Object) => mixed;
 ```
+
+</CodeBlock>
 
 The SDK can listen for attribution changes and call a function when it detects an update. You can set an attribution callback method by specifying an `attributionCallback` function in the `initSdk` method. Within your function, you have access to the user's attribution information.
 
@@ -66,9 +74,13 @@ Adjust.initSdk({
 
 ## [Get current attribution information](get-current-attribution-information)
 
-```js title="Method signature"
+<CodeBlock title="Method signature">
+
+```js
 function getAttribution(): Attribution | undefined;
 ```
+
+</CodeBlock>
 
 When a user installs your app, Adjust attributes the install to a campaign. The Adjust SDK gives you access to campaign attribution details for your install. To return this information, call the `getAttribution` method.
 
@@ -78,9 +90,13 @@ const attribution = Adjust.getAttribution();
 
 ## [Set a referrer](set-a-referrer)
 
-```js title="Method signature"
+<CodeBlock title="Method signature">
+
+```js
 function setReferrer(referrer: string): void;
 ```
+
+</CodeBlock>
 
 You can set a referrer to trigger an SDK click with a custom click ID when the SDK starts. The SDK sends your custom click ID to Adjust's servers for attribution purposes.
 
@@ -92,6 +108,10 @@ Call this method as close to initializing the SDK as possible to ensure your ref
 
 To set your referrer, call the `setReferrer` method and pass your referrer as a URL-encoded `string` argument.
 
-```js '"adjust_external_click_id%3DEXTERNAL_CLICK_ID"'
+<CodeBlock highlight={"\"adjust_external_click_id%3DEXTERNAL_CLICK_ID\""}>
+
+```js
 Adjust.setReferrer("adjust_external_click_id%3DEXTERNAL_CLICK_ID");
 ```
+
+</CodeBlock>

--- a/src/content/docs/sdk/web/features/device-info.mdx
+++ b/src/content/docs/sdk/web/features/device-info.mdx
@@ -8,9 +8,13 @@ The Adjust SDK contains helper methods that return device information. Use these
 
 ## [Web UUID](web-uuid)
 
-```js title="Method signature"
+<CodeBlock title="Method signature">
+
+```js
 function getWebUUID(): string | undefined;
 ```
+
+</CodeBlock>
 
 To identify web users in Adjust, Web SDK generates a unique `web_uuid` when it sends the first session. The ID is created per subdomain and per browser. The identifier follows the Universally Unique Identifier (UUID) format.
 

--- a/src/content/docs/sdk/web/features/events.mdx
+++ b/src/content/docs/sdk/web/features/events.mdx
@@ -6,7 +6,9 @@ slug: en/sdk/web/features/events
 
 The Adjust SDK provides an event interface which can be used to structure and send event information from your app to Adjust's servers.
 
-```js title="Interface declaration"
+<CodeBlock title="Interface declaration">
+
+```js
 export type EventParamsT = {|
    eventToken: string,
    revenue?: number,
@@ -17,11 +19,13 @@ export type EventParamsT = {|
 |};
 ```
 
+</CodeBlock>
+
 ## [Send an event](send-an-event)
 
 To send an event, call the `Adjust.trackEvent` method and pass your Adjust [event token](https://help.adjust.com/en/article/add-events#manage-your-events) as an argument.
 
-```js {2}
+```js
 Adjust.trackEvent({
    eventToken: "{YourEventToken}",
 });
@@ -76,7 +80,7 @@ Check the guide to [recording purchases in different currencies](https://help.ad
 
 </Callout>
 
-```js {3,4}
+```js
 Adjust.trackEvent({
    // ... other params go here, including mandatory ones
    revenue: 110,
@@ -88,7 +92,9 @@ Adjust.trackEvent({
 
 This example shows how to record an event with the token _`g3mfiw`_ whenever a user interacts with a button. The function sets the `revenue` property of this event to _`0.25`_ and the `currency` property to _`EUR`_.
 
-```js {26-28}
+<CodeBlock highlight="{range: 26-28}">
+
+```js
 function init(defaultEventConfig = {}) {
    _ui.trackRevenueEventButton.addEventListener(
       "click",
@@ -122,13 +128,15 @@ function _handleTrackEvent() {
 }
 ```
 
+</CodeBlock>
+
 ## [Deduplicate revenue events](deduplicate-revenue-events)
 
 You can pass an optional identifier to avoid measuring duplicate events. The SDK stores the last 10 identifiers and skips revenue events with duplicate transaction IDs.
 
 To configure this, set the `deduplicationId` property to your transaction ID.
 
-```js {3}
+```js
 Adjust.trackEvent({
    // ... other params go here, including mandatory ones
    deduplicationId: "{YourDeduplicationId}",
@@ -139,7 +147,9 @@ Adjust.trackEvent({
 
 This example shows how to record an event with the token _`g3mfiw`_ whenever a user interacts with a button. The function sets the `deduplicationId` to _`5e85484b-1ebc-4141-aab7-25b869e54c49`_.
 
-```js {26-27}
+<CodeBlock highlight="{range: 26-27}">
+
+```js
 function init(defaultEventConfig = {}) {
    _ui.trackUniqueEventButton.addEventListener(
       "click",
@@ -172,9 +182,11 @@ function _handleTrackEvent() {
 }
 ```
 
+</CodeBlock>
+
 You can override the deduplication limit to change the number of identifiers the Adjust SDK stores. To do this, specify the new limit in the `eventDeduplicationListLimit` argument of the `initSdk` method.
 
-```js {4}
+```js
 Adjust.initSdk({
    appToken: "YOUR_APP_TOKEN",
    environment: "sandbox",
@@ -184,12 +196,16 @@ Adjust.initSdk({
 
 ## [Add callback parameters](add-callback-parameters)
 
-```js title="Interface declaration"
+<CodeBlock title="Interface declaration">
+
+```js
 export type GlobalParamsT = {|
    key: string,
    value: string,
 |};
 ```
+
+</CodeBlock>
 
 If you [register a callback URL](https://help.adjust.com/en/article/set-up-callbacks) in the Adjust dashboard, the SDK sends a GET request to your callback URL when it records an event.
 
@@ -197,7 +213,7 @@ You can configure callback parameters to send to your servers. Once you configur
 
 Add callback parameters to your event by creating a `callbackParams` array containing `GlobalParam` objects.
 
-```js {3-6}
+```js
 Adjust.trackEvent({
    // ... other params go here, including mandatory ones
    callbackParams: [
@@ -209,9 +225,13 @@ Adjust.trackEvent({
 
 The Adjust SDK measures the event and sends a request to your URL with the callback parameters. For example, if you register the URL `https://www.mydomain.com/callback`, your callback looks like this:
 
-```text "key" "value" "foo" "bar"
+<CodeBlock highlight="key, value, foo, bar">
+
+```text
 https://www.mydomain.com/callback?key=value&foo=bar
 ```
+
+</CodeBlock>
 
 <Callout type="note">
 
@@ -238,11 +258,17 @@ This example shows how to record an event with the token _`g3mfiw`_ whenever a u
 
 The resulting callback URL looks like this:
 
-```text "g3mfiw" "0.05"
+<CodeBlock highlight="g3mfiw, 0.05">
+
+```text
 http://www.mydomain.com/callback?event_token=g3mfiw&revenue_amount=0.05
 ```
 
-```js {26-29}
+</CodeBlock>
+
+<CodeBlock highlight="{range: 26-29}">
+
+```js
 function init(defaultEventConfig = {}) {
    _ui.trackCallbackEventButton.addEventListener(
       "click",
@@ -278,14 +304,20 @@ function _handleTrackEvent() {
 }
 ```
 
+</CodeBlock>
+
 ## [Add partner parameters](add-partner-parameters)
 
-```js title="Interface declaration"
+<CodeBlock title="Interface declaration">
+
+```js
 export type GlobalParamsT = {|
    key: string,
    value: string,
 |};
 ```
+
+</CodeBlock>
 
 You can send extra information to your network partners by adding [partner parameters](https://help.adjust.com/en/article/data-sharing-ad-network#map-parameters).
 
@@ -299,7 +331,7 @@ Partner parameters don't appear in raw data by default. You can add the `{partne
 
 Add partner parameters to your event by creating a `partnerParams` array containing `GlobalParam` objects.
 
-```javascript {3-6}
+```js
 Adjust.trackEvent({
    // ... other params go here, including mandatory ones
    partnerParams: [
@@ -316,7 +348,9 @@ This example shows how to record an event with the token _`g3mfiw`_ whenever a u
 -  The `product_id` of the associated product
 -  The `user_id` of the user who triggered the event
 
-```javascript {26-29}
+<CodeBlock highlight="{range: 26-29}">
+
+```js
 function init(defaultEventConfig = {}) {
    _ui.trackPartnerEventButton.addEventListener(
       "click",
@@ -352,13 +386,19 @@ function _handleTrackEvent() {
 }
 ```
 
+</CodeBlock>
+
 ## [Record event and redirect to an external page](record-event-and-redirect-to-an-external-page)
 
-```js title="Method signature"
+<CodeBlock title="Method signature">
+
+```js
 function trackEvent(params: EventParamsT): Promise<void> {
    return _internalTrackEvent(params);
 }
 ```
+
+</CodeBlock>
 
 You can record redirects to external pages as events with the Adjust SDK. To ensure the SDK records the event before the redirect happens, the `trackEvent` method returns a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). This `Promise` is fulfilled after the SDK receives a response from Adjust's servers. If an internal error response is returned, the `Promise` is rejected.
 
@@ -372,7 +412,7 @@ The Adjust SDK saves events to an internal queue. This means that even if your r
 
 ### [Example](example-5)
 
-```javascript
+```js
 Promise.race([
    Adjust.trackEvent({
       eventToken: "YOUR_EVENT_TOKEN",

--- a/src/content/docs/sdk/web/features/global-params.mdx
+++ b/src/content/docs/sdk/web/features/global-params.mdx
@@ -14,9 +14,13 @@ You can configure global callback parameters to your servers. Once you configure
 
 ### [Add callback parameters](add-callback-parameters)
 
-```js title="Method signature"
+<CodeBlock title="Method signature">
+
+```js
 function addGlobalCallbackParameters(params: Array<GlobalParams>): void;
 ```
+
+</CodeBlock>
 
 Add callback parameters to your sessions and events by calling the `addGlobalCallbackParameters` method with an array of `string` key-value pair objects. You can add as many objects to this array as you require.
 
@@ -29,15 +33,23 @@ Adjust.addGlobalCallbackParameters([
 
 For the above example, the callback URL looks like this:
 
-```text "key1" "value1" "key2" "value2"
+<CodeBlock highlight="key1, value1, key2, value2">
+
+```text
 https://www.mydomain.com/callback?key1=value1&key2=value2
 ```
 
+</CodeBlock>
+
 ### [Remove callback parameters](remove-callback-parameters)
 
-```js title="Method signature"
+<CodeBlock title="Method signature">
+
+```js
 function removeGlobalCallbackParameter(key: string): void;
 ```
+
+</CodeBlock>
 
 You can remove global callback parameters if they're no longer required. To do this, pass the parameter key to the `removeGlobalCallbackParameter` method.
 
@@ -71,9 +83,13 @@ Partner parameters don't appear in raw data by default. You can add the `{partne
 
 ### [Add partner parameters](add-partner-parameters)
 
-```js title="Method signature"
+<CodeBlock title="Method signature">
+
+```js
 function addGlobalPartnerParameters(params: Array<GlobalParams>): void;
 ```
+
+</CodeBlock>
 
 Add partner parameters to your sessions and events by calling the `addGlobalPartnerParameters` method with an array of `string` key-value pair objects. You can add as many objects to this array as you require.
 
@@ -86,9 +102,13 @@ Adjust.addGlobalPartnerParameters([
 
 ### [Remove partner parameters](remove-partner-parameters)
 
-```js title="Method signature"
+<CodeBlock title="Method signature">
+
+```js
 function removeGlobalPartnerParameter(key: string): void;
 ```
+
+</CodeBlock>
 
 You can remove global partner parameters if they're no longer required. To do this, pass the parameter key to the `removeGlobalPartnerParameter` method.
 
@@ -98,9 +118,13 @@ Adjust.removeGlobalPartnerParameter("key1");
 
 ### [Clear all partner parameters](clear-all-partner-parameters)
 
-```js title="Method signature"
+<CodeBlock title="Method signature">
+
+```js
 function clearGlobalPartnerParameters(): void;
 ```
+
+</CodeBlock>
 
 You can remove all global partner parameters if they're no longer required. To do this, call the `clearGlobalPartnerParameters` method.
 

--- a/src/content/docs/sdk/web/features/privacy.mdx
+++ b/src/content/docs/sdk/web/features/privacy.mdx
@@ -8,9 +8,13 @@ The Adjust SDK contains features that you can use to handle user privacy in your
 
 ## [Send erasure request](send-erasure-request)
 
-```js title="Method signature"
+<CodeBlock title="Method signature">
+
+```js
 function gdprForgetMe(): void;
 ```
+
+</CodeBlock>
 
 The EU’s General Data Protection Regulation (GDPR) and similar privacy laws worldwide (CCPA, LGPD, etc.) grant data subjects comprehensive rights when it comes to the processing of their personal data. These rights include, among others, the right to erasure (see [Art. 17 GDPR](https://gdpr.eu/article-17-right-to-be-forgotten/))([1](https://help.adjust.com/en/article/gdpr#ref-1)). As a data processor, Adjust is obliged to support you (the data controller) in the processing of such requests from your (app) users.
 
@@ -25,9 +29,13 @@ Adjust.gdprForgetMe();
 
 ## [Disable third-party sharing](disable-third-party-sharing)
 
-```js title="Method signature"
+<CodeBlock title="Method signature">
+
+```js
 function disableThirdPartySharing(): void;
 ```
+
+</CodeBlock>
 
 To disable third-party sharing for all users, call the `disableThirdPartySharing` method. When Adjust's servers receive this information, Adjust stops sharing the user's data with third parties. The Adjust SDK continues to work as expected.
 
@@ -37,9 +45,13 @@ Adjust.disableThirdPartySharing();
 
 ## [Data residency](data-residency)
 
-```js title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```js
 dataResidency: "EU" | "TR" | "US";
 ```
+
+</CodeBlock>
 
 The data residency feature allows you to choose the country in which Adjust stores your data. This is useful if you're operating in a country with strict privacy requirements. When you set up data residency, Adjust stores your data in a data center located in the region your have chosen.
 
@@ -55,7 +67,7 @@ To set your country of data residency, pass the region code of your preferred co
 
 </Table>
 
-```js {5}
+```js
 Adjust.initSdk({
    appToken: "YOUR_APP_TOKEN",
    environment: "production",
@@ -66,9 +78,13 @@ Adjust.initSdk({
 
 ## [URL strategy](url-strategy)
 
-```js title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```js
 urlStrategy: "india" | "china";
 ```
+
+</CodeBlock>
 
 You can set a URL strategy to prioritize regional endpoints for sending data from the Adjust SDK. To do this, pass the region of your preferred country code in the `urlStrategy` property of the `initSdk` method.
 
@@ -81,7 +97,7 @@ You can set a URL strategy to prioritize regional endpoints for sending data fro
 
 </Table>
 
-```js {5}
+```js
 Adjust.initSdk({
    appToken: "YOUR_APP_TOKEN",
    environment: "production",
@@ -92,13 +108,17 @@ Adjust.initSdk({
 
 ## [Set custom endpoint](set-custom-endpoint)
 
-```js title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```js
 customUrl: string;
 ```
 
+</CodeBlock>
+
 By default, the Adjust SDK sends all data to Adjust's endpoints. If you want to specify a custom endpoint, pass your endpoint in the `customUrl` property of the `initSdk` method.
 
-```js {4}
+```js
 Adjust.initSdk({
    appToken: "YOUR_APP_TOKEN",
    environment: "sandbox",

--- a/src/content/docs/sdk/windows/configuration.mdx
+++ b/src/content/docs/sdk/windows/configuration.mdx
@@ -10,9 +10,13 @@ Use the methods in this document to configure the behavior of the Adjust SDK.
 
 ## [Instantiate your config object](instantiate-your-config-object)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public AdjustConfig(string appToken, string environment, Action<string> logDelegate = null, LogLevel? logLevel = null)
 ```
+
+</CodeBlock>
 
 To configure the Adjust SDK, you need to instantiate an `AdjustConfig` object. This object contains the **read-only** configuration options that you need to pass to the Adjust SDK.
 
@@ -51,13 +55,17 @@ Adjust.ApplicationLaunching(adjustConfig);
 
 ### [Configure a log delegate](configure-a-log-delegate)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setLogDelegate(Action<String> logDelegate);
 ```
 
+</CodeBlock>
+
 A log delegate is a function that the Adjust SDK calls to record logs. To configure a log delegate, pass your log function to the `setLogDelegate`. The Adjust SDK calls this function each time it outputs a log message.
 
-```cs {3}
+```cs
 AdjustConfig adjustConfig = new AdjustConfig("{YourAppToken}", AdjustEnvironment.Sandbox, true);
 //...
 adjustConfig.setLogDelegate(msg => Debug.Log(msg));
@@ -67,9 +75,13 @@ Adjust.ApplicationLaunching(config);
 
 ### [Set external device identifier](set-external-device-identifier)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void setExternalDeviceId(string externalDeviceId);
 ```
+
+</CodeBlock>
 
 An external device identifier is a custom value that you can assign to a device or user. They help you recognize users across sessions and platforms. They can also help you deduplicate installs by user so that a user isn't counted as duplicate new installs. Contact your Adjust representative to get started with external device IDs.
 
@@ -83,7 +95,7 @@ See the [External device identifiers article](https://help.adjust.com/en/article
 
 </Callout>
 
-```cs {3}
+```cs
 AdjustConfig adjustConfig = new AdjustConfig("{YourAppToken}", AdjustEnvironment.Sandbox, true);
 //...
 adjustConfig.setExternalDeviceId("{Your-External-Device-Id}");
@@ -97,13 +109,17 @@ You can import existing external device IDs into Adjust. This ensures that the A
 
 ### [Set default link token](set-default-link-token)
 
-```cs title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```cs
 public string DefaultTracker { get; set; }
 ```
 
+</CodeBlock>
+
 You can configure a default link token if your app is preinstalled on a device. When a user opens the preinstalled app for the first time, the install is attributed to the default link token. To set your default link token, assign your [Adjust link token](https://help.adjust.com/en/article/links#adjust-link-token) to the `DefaultTracker` property on your config instance.
 
-```cs {3}
+```cs
 var adjustConfig = new AdjustConfig(appToken, environment,
    msg => System.Diagnostics.Debug.WriteLine(msg), LogLevel.Verbose);
 adjustConfig.DefaultTracker = "{TrackerToken}";
@@ -112,13 +128,17 @@ Adjust.ApplicationLaunching(adjustConfig);
 
 ### [Enable background recording](enable-background-recording)
 
-```cs title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```cs
 public bool SendInBackground { get; set; }
 ```
 
+</CodeBlock>
+
 By default, the Adjust SDK pauses the sending of requests when your app is running in the background. You can configure the SDK to send requests in the background by enabling the background recording. To enable background recording, assign a `bool` value to the `SendInBackground` property of your config instance.
 
-```cs {4}
+```cs
 var adjustConfig = new AdjustConfig(appToken, environment,
    msg => System.Diagnostics.Debug.WriteLine(msg), LogLevel.Verbose);
 //...
@@ -129,9 +149,13 @@ Adjust.ApplicationLaunching(adjustConfig);
 
 ### [Enable event buffering](enable-event-buffering)
 
-```cs title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```cs
 public bool EventBufferingEnabled { get; set; }
 ```
+
+</CodeBlock>
 
 The Adjust SDK sends event information as soon as a user triggers an event in your app. You can send event information on a schedule by enabling event buffering. Event buffering stores events in a local buffer on the device and sends all requests once per minute.
 
@@ -139,7 +163,7 @@ Your config object contains a `bool` `EventBufferingEnabled` property that contr
 
 -  `EventBufferingEnabled` (`bool`): Set to `true` to enable event buffering or `false` to disable event buffering.
 
-```cs {4}
+```cs
 var adjustConfig = new AdjustConfig(appToken, environment,
    msg => System.Diagnostics.Debug.WriteLine(msg), LogLevel.Verbose);
 //...
@@ -150,9 +174,13 @@ Adjust.ApplicationLaunching(adjustConfig);
 
 ### [Delay the start of the SDK](delay-the-start-of-the-sdk)
 
-```cs title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```cs
 public TimeSpan? DelayStart { get; set; }
 ```
+
+</CodeBlock>
 
 By default, the Adjust SDK starts as soon as your app opens. If you want to send data that isn't available at launch in [session parameters](/en/sdk/flutter/features/session-parameters), you can delay the start of the SDK. This can be helpful if you are sending information such as unique identifiers.
 
@@ -170,9 +198,13 @@ adjustConfig.DelayStart = TimeSpan.FromSeconds(5.5);
 
 ### [Toggle offline mode](toggle-offline-mode)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void SetOfflineMode(bool offline);
 ```
+
+</CodeBlock>
 
 <Callout type="important">
 
@@ -192,9 +224,13 @@ Adjust.SetOfflineMode(true);
 
 ### [Set push tokens](set-push-tokens)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void SetPushToken(string pushToken);
 ```
+
+</CodeBlock>
 
 Push tokens are used for [Audiences](https://help.adjust.com/en/article/audiences) and client callbacks. They're also required for [Uninstall and reinstall measurement](https://help.adjust.com/en/article/uninstalls-reinstalls).
 
@@ -220,9 +256,13 @@ You can only call this method after the first session. This setting persists bet
 
 </Callout>
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void SetEnabled(bool enabled);
 ```
+
+</CodeBlock>
 
 The Adjust SDK runs by default when your app is open. You can disable and re-enable the Adjust SDK to pause and resume recording. When you disable the Adjust SDK, it doesn't send any data to Adjust's servers.
 
@@ -236,9 +276,13 @@ Adjust.SetEnabled(false);
 
 #### [Check enabled status](check-enabled-status)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static bool IsEnabled();
 ```
+
+</CodeBlock>
 
 You can check if the Adjust SDK is enabled at any time by calling the `isEnabled` method. This method returns a `bool` value indicating if the SDK is **enabled** (`true`) or **disabled** (`false`).
 

--- a/src/content/docs/sdk/windows/features/attribution.mdx
+++ b/src/content/docs/sdk/windows/features/attribution.mdx
@@ -27,9 +27,13 @@ The `AdjustAttribution` class contains details about the current attribution sta
 
 ## [Trigger a function when attribution changes](trigger-a-function-when-attribution-changes)
 
-```cs title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```cs
 public Action<AdjustAttribution> AttributionChanged { get; set; }
 ```
+
+</CodeBlock>
 
 The SDK can listen for attribution changes and call a function when it detects an update. To configure your callback function, assign your function to the `AttributionChanged` property on your config instance. You can pass the name of a function or write the function inline.
 
@@ -42,7 +46,7 @@ You must call the `AttributionChanged` method **before** initializing the Adjust
 <Tabs>
 <Tab title="Inline function">
 
-```cs {3,4}
+```cs
 var config = new AdjustConfig(appToken, environment);
 
 config.AttributionChanged = (attribution) =>
@@ -54,7 +58,7 @@ Adjust.ApplicationLaunching(config);
 </Tab>
 <Tab title="Function name">
 
-```cs "AdjustAttributionChanged"
+```cs
 var config = new AdjustConfig(appToken, environment);
 config.AttributionChanged = AdjustAttributionChanged;
 Adjust.ApplicationLaunching(config);
@@ -70,9 +74,13 @@ private void AdjustAttributionChanged(AdjustAttribution attribution)
 
 ## [Get current attribution information](get-current-attribution-information)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static AdjustAttribution GetAttribution();
 ```
+
+</CodeBlock>
 
 <MinorVersion added="v4.12.0">
 

--- a/src/content/docs/sdk/windows/features/callbacks.mdx
+++ b/src/content/docs/sdk/windows/features/callbacks.mdx
@@ -32,13 +32,19 @@ Session callbacks have access to a response data object. You can use its propert
 
 ### [Success callbacks](success-callbacks)
 
-```cs title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```cs
 public Action<AdjustSessionSuccess> SessionTrackingSucceeded { get; set; }
 ```
 
+</CodeBlock>
+
 Set up success callbacks to trigger functions when the SDK records a session.
 
-```cs {3-6}
+<CodeBlock highlight="{range: {3-6}}">
+
+```cs
 var config = new AdjustConfig(appToken, environment,
    msg => System.Diagnostics.Debug.WriteLine(msg), LogLevel.Verbose);
 config.SessionTrackingSucceeded = adjustSessionSuccess =>
@@ -48,11 +54,15 @@ config.SessionTrackingSucceeded = adjustSessionSuccess =>
 Adjust.ApplicationLaunching(config);
 ```
 
+</CodeBlock>
+
 #### [Example](example)
 
 This example shows how to log the timestamp at which the SDK recorded the session.
 
-```cs {3-6}
+<CodeBlock highlight="{range: {3-6}}">
+
+```cs
 var config = new AdjustConfig(appToken, environment,
    msg => System.Diagnostics.Debug.WriteLine(msg), LogLevel.Verbose);
 config.SessionTrackingSucceeded = adjustSessionSuccess =>
@@ -62,15 +72,23 @@ config.SessionTrackingSucceeded = adjustSessionSuccess =>
 Adjust.ApplicationLaunching(config);
 ```
 
+</CodeBlock>
+
 ### [Failure callbacks](failure-callbacks)
 
-```cs title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```cs
 public Action<AdjustSessionFailure> SessionTrackingFailed { get; set; }
 ```
 
+</CodeBlock>
+
 Set up failure callbacks to trigger functions when the SDK fails to record a session.
 
-```cs {3-6}
+<CodeBlock highlight="{range: {3-6}}">
+
+```cs
 var config = new AdjustConfig(appToken, environment,
    msg => System.Diagnostics.Debug.WriteLine(msg), LogLevel.Verbose);
 config.EventTrackingFailed = adjustEventFailure =>
@@ -80,11 +98,15 @@ config.EventTrackingFailed = adjustEventFailure =>
 Adjust.ApplicationLaunching(config);
 ```
 
+</CodeBlock>
+
 #### [Example](example-1)
 
 This example shows how to log the session failure message.
 
-```cs {3-6}
+<CodeBlock highlight="{range: {3-6}}">
+
+```cs
 var config = new AdjustConfig(appToken, environment,
    msg => System.Diagnostics.Debug.WriteLine(msg), LogLevel.Verbose);
 config.SessionTrackingFailed = adjustSessionFailure =>
@@ -93,6 +115,8 @@ config.SessionTrackingFailed = adjustSessionFailure =>
 };
 Adjust.ApplicationLaunching(config);
 ```
+
+</CodeBlock>
 
 ## [Event callbacks](event-callbacks)
 
@@ -116,13 +140,19 @@ Event callbacks have access to a response data object. You can use its propertie
 
 ### [Success callbacks](success-callbacks-1)
 
-```cs title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```cs
 public Action<AdjustEventSuccess> EventTrackingSucceeded { get; set; }
 ```
 
+</CodeBlock>
+
 Set up success callbacks to trigger functions when the SDK records an event.
 
-```cs {3-6}
+<CodeBlock highlight="{range: {3-6}}">
+
+```cs
 var config = new AdjustConfig(appToken, environment,
    msg => System.Diagnostics.Debug.WriteLine(msg), LogLevel.Verbose);
 config.EventTrackingSucceeded = adjustEventSuccess =>
@@ -132,11 +162,15 @@ config.EventTrackingSucceeded = adjustEventSuccess =>
 Adjust.ApplicationLaunching(config);
 ```
 
+</CodeBlock>
+
 #### [Example](example-2)
 
 This example shows how to log the timestamp at which the SDK recorded an event.
 
-```cs {3-6}
+<CodeBlock highlight="{range: {3-6}}">
+
+```cs
 var config = new AdjustConfig(appToken, environment,
    msg => System.Diagnostics.Debug.WriteLine(msg), LogLevel.Verbose);
 config.EventTrackingSucceeded = adjustEventSuccess =>
@@ -146,15 +180,23 @@ config.EventTrackingSucceeded = adjustEventSuccess =>
 Adjust.ApplicationLaunching(config);
 ```
 
+</CodeBlock>
+
 ### [Failure callbacks](failure-callbacks-1)
 
-```cs title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```cs
 public Action<AdjustEventFailure> EventTrackingFailed { get; set; }
 ```
 
+</CodeBlock>
+
 Set up failure callbacks to trigger functions when the SDK fails to record an event.
 
-```cs {3-6}
+<CodeBlock highlight="{range: {3-6}}">
+
+```cs
 var config = new AdjustConfig(appToken, environment,
    msg => System.Diagnostics.Debug.WriteLine(msg), LogLevel.Verbose);
 config.EventTrackingFailed = adjustEventFailure =>
@@ -164,11 +206,15 @@ config.EventTrackingFailed = adjustEventFailure =>
 Adjust.ApplicationLaunching(config);
 ```
 
+</CodeBlock>
+
 #### [Example](example-3)
 
 This example shows how to log an event failure message.
 
-```cs {3-6}
+<CodeBlock highlight="{range: {3-6}}">
+
+```cs
 var config = new AdjustConfig(appToken, environment,
    msg => System.Diagnostics.Debug.WriteLine(msg), LogLevel.Verbose);
 config.EventTrackingFailed = adjustEventFailure =>
@@ -177,3 +223,5 @@ config.EventTrackingFailed = adjustEventFailure =>
 };
 Adjust.ApplicationLaunching(config);
 ```
+
+</CodeBlock>

--- a/src/content/docs/sdk/windows/features/deep-links.mdx
+++ b/src/content/docs/sdk/windows/features/deep-links.mdx
@@ -27,7 +27,9 @@ If a user has your app installed, it opens when they interact with a link contai
 
 Next, you need to set up your `OnActivated` event handler. This handles the activated deep link event. To set this up, add the following to your your `App.xaml.cs` file:
 
-```cs title="App.xaml.cs"
+<CodeBlock title="App.xaml.cs">
+
+```cs
 // ...
 protected override void OnActivated(IActivatedEventArgs args) {
    if (args.Kind == ActivationKind.Protocol) {
@@ -43,6 +45,8 @@ protected override void OnActivated(IActivatedEventArgs args) {
 // ...
 ```
 
+</CodeBlock>
+
 <Callout type="seealso">
 
 Check the official [Microsoft documentation](https://learn.microsoft.com/en-us/windows/uwp/launch-resume/handle-uri-activation) for URI activation handling for more information.
@@ -53,13 +57,19 @@ Your app opens when a user interacts with a link containing your **unique scheme
 
 ## [Deferred deep linking](deferred-deep-linking)
 
-```cs title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```cs
 public Func<Uri, bool> DeeplinkResponse { get; set; }
 ```
 
+</CodeBlock>
+
 You can configure the Adjust SDK to call a delegate function when it receives a deferred deep link. This delegate function receives the deep link as a `string` argument. Once the SDK receives the deep link content from Adjust's servers, it delivers it through this delegate function and expects a `bool` return value. This value represents whether the SDK should launch the `OnActivated` event handler.
 
-```cs {4-14}
+<CodeBlock highlight="{range: 4-14}">
+
+```cs
 var adjustConfig = new AdjustConfig(appToken, environment,
    msg => System.Diagnostics.Debug.WriteLine(msg), LogLevel.Verbose);
 
@@ -79,11 +89,17 @@ Adjust.ApplicationLaunching(adjustConfig);
 // ...
 ```
 
+</CodeBlock>
+
 ## [Reattribution using deep links](reattribution-using-deep-links)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void AppWillOpenUrl(Uri uri);
 ```
+
+</CodeBlock>
 
 <Callout type="seealso">
 
@@ -97,7 +113,9 @@ If the user needs to be reattributed due to clicking on an Adjust deep link, thi
 
 You must call `Adjust.AppWillOpenUrl` in the `OnActivated` method of your app:
 
-```cs {8-10}
+<CodeBlock highlight="{range: 8-10}">
+
+```cs
 using AdjustSdk;
 
 public partial class App : Application
@@ -113,3 +131,5 @@ public partial class App : Application
    }
 }
 ```
+
+</CodeBlock>

--- a/src/content/docs/sdk/windows/features/device-info.mdx
+++ b/src/content/docs/sdk/windows/features/device-info.mdx
@@ -8,9 +8,13 @@ The Adjust SDK contains helper methods that return device information. Use these
 
 ## [Adjust device identifier](adjust-device-identifier)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static string GetAdid();
 ```
+
+</CodeBlock>
 
 Adjust generates a unique Adjust Device ID (ADID) for each device. Call the `GetAdid` method to return this ID as a `string`.
 
@@ -20,9 +24,13 @@ string adid = Adjust.GetAdid();
 
 ## [Windows advertising identifier](windows-advertising-identifier)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static string GetWindowsAdId();
 ```
+
+</CodeBlock>
 
 The Windows Advertising ID (Windows ADID) is a device-specific identifier for Windows devices. Call the `GetWindowsAdId` method to return this ID as a `string`.
 

--- a/src/content/docs/sdk/windows/features/events.mdx
+++ b/src/content/docs/sdk/windows/features/events.mdx
@@ -8,9 +8,13 @@ The Adjust SDK provides an `AdjustEvent` object which can be used to structure a
 
 ## [Instantiate an AdjustEvent object](instantiate-an-adjustevent-object)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public AdjustEvent(string eventToken);
 ```
+
+</CodeBlock>
 
 To send event information with the Adjust SDK, you need to instantiate an `AdjustEvent` object. This object contains variables that are sent to Adjust when an event occurs in your app.
 
@@ -18,23 +22,27 @@ To instantiate an event object, create a new `AdjustEvent` instance and pass the
 
 -  `eventToken` (`string`): Your Adjust [event token](https://help.adjust.com/en/article/add-events#manage-your-events).
 
-```cs {1}
+```cs
 var adjustEvent = new AdjustEvent("abc123");
 Adjust.TrackEvent(adjustEvent);
 ```
 
 ## [Send an event](send-an-event)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void TrackEvent(AdjustEvent adjustEvent);
 ```
+
+</CodeBlock>
 
 You can associate your [Adjust event tokens](https://help.adjust.com/en/article/add-events#add-event) to actions in your app to record them. To record an event:
 
 -  Create a new Adjust event instance and pass your event token as a string argument.
 -  Call the `TrackEvent` method with your event instance as an argument.
 
-```cs {2}
+```cs
 var adjustEvent = new AdjustEvent("abc123");
 Adjust.TrackEvent(adjustEvent);
 ```
@@ -43,7 +51,9 @@ Adjust.TrackEvent(adjustEvent);
 
 This example shows how to record an event with the token `g3mfiw` whenever a user interacts with a button.
 
-```cs {14-18}
+<CodeBlock highlight="{range: 14-18}">
+
+```cs
 using AdjustSdk;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -66,6 +76,8 @@ namespace AdjustWSExample
 }
 ```
 
+</CodeBlock>
+
 ```xml
 <Page
    x:Class="AdjustWSExample.MainPage"
@@ -84,9 +96,13 @@ namespace AdjustWSExample
 
 ## [Record event revenue](record-event-revenue)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void SetRevenue(double revenue, string currency);
 ```
+
+</CodeBlock>
 
 You can record revenue associated with an event by setting the revenue and currency properties on your event instance. Use this feature to record revenue-generating actions in your app.
 
@@ -101,7 +117,7 @@ Check the guide to [recording purchases in different currencies](https://help.ad
 
 </Callout>
 
-```cs {2}
+```cs
 var adjustEvent = new AdjustEvent("abc123");
 adjustEvent.SetRevenue(0.01, "EUR");
 Adjust.TrackEvent(adjustEvent);
@@ -111,7 +127,9 @@ Adjust.TrackEvent(adjustEvent);
 
 This example shows how to record an event with the token `g3mfiw` whenever a user interacts with a button. The function sets the `revenue` property of this event to _`0.25`_ and the `currency` property to _`EUR`_.
 
-```cs {14-19}
+<CodeBlock highlight="{range: 14-19}">
+
+```cs
 using AdjustSdk;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -135,6 +153,8 @@ namespace AdjustWSExample
 }
 ```
 
+</CodeBlock>
+
 ```xml
 <Page
    x:Class="AdjustWSExample.MainPage"
@@ -153,15 +173,19 @@ namespace AdjustWSExample
 
 ## [Deduplicate revenue events](deduplicate-revenue-events)
 
-```cs title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```cs
 public string PurchaseId { get; set; }
 ```
+
+</CodeBlock>
 
 You can pass an optional identifier to avoid recording duplicate events. The SDK stores the last ten identifiers and skips revenue events with duplicate purchase IDs.
 
 To set the identifier, assign your purchase ID to the `PurchaseId` property on your event object.
 
-```cs {4}
+```cs
 AdjustEvent event = new AdjustEvent("abc123");
 
 event.SetRevenue(0.01, "EUR");
@@ -174,7 +198,9 @@ Adjust.trackEvent(event);
 
 This example shows how to record an event with the token `g3mfiw` whenever a user interacts with a button. The function sets `PurchaseId` property to `5e85484b-1ebc-4141-aab7-25b869e54c49`.
 
-```cs {14-20}
+<CodeBlock highlight="{range: 14-20}">
+
+```cs
 using AdjustSdk;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -199,6 +225,8 @@ namespace AdjustWSExample
 }
 ```
 
+</CodeBlock>
+
 ```xml
 <Page
    x:Class="AdjustWSExample.MainPage"
@@ -217,9 +245,13 @@ namespace AdjustWSExample
 
 ## [Add callback parameters](add-callback-parameters)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void AddCallbackParameter(string key, string value);
 ```
+
+</CodeBlock>
 
 If you [register a callback URL](https://help.adjust.com/en/article/set-up-callbacks) in the Adjust dashboard, the SDK sends a GET request to your callback URL when it records an event.
 
@@ -227,20 +259,22 @@ You can configure callback parameters to send to your servers. Once you configur
 
 Add callback parameters to your event by calling the `addCallbackParameter` method with `string` key-value arguments. You can add multiple parameters by calling this method multiple times.
 
-```cs {3,4}
+```cs
 var adjustEvent = new AdjustEvent("abc123");
-
 adjustEvent.AddCallbackParameter("key", "value");
 adjustEvent.AddCallbackParameter("foo", "bar");
-
 Adjust.TrackEvent(adjustEvent);
 ```
 
 The Adjust SDK measures the event and sends a request to your URL with the callback parameters. For example, if you register the URL `https://www.mydomain.com/callback`, your callback looks like this:
 
-```http "key=value" "foo=bar"
+<CodeBlock highlight="key=value, foo=bar">
+
+```http
 https://www.mydomain.com/callback?key=value&foo=bar
 ```
+
+</CodeBlock>
 
 <Callout type="note">
 
@@ -267,11 +301,17 @@ This example shows how to record an event with the token `g3mfiw` whenever a use
 
 The resulting callback URL looks like this:
 
-```http "event_token=g3mfiw" "revenue_amount=0.05"
+<CodeBlock highlight="event_token=g3mfiw, revenue_amount=0.05">
+
+```http
 http://www.mydomain.com/callback?event_token=g3mfiw&revenue_amount=0.05
 ```
 
-```cs {14-20}
+</CodeBlock>
+
+<CodeBlock highlight="{range: 14-20}">
+
+```cs
 using AdjustSdk;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -296,6 +336,8 @@ namespace AdjustWSExample
 }
 ```
 
+</CodeBlock>
+
 ```xml
 <Page
    x:Class="AdjustWSExample.MainPage"
@@ -314,9 +356,13 @@ namespace AdjustWSExample
 
 ## [Add partner parameters](add-partner-parameters)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public void AddPartnerParameter(string key, string value);
 ```
+
+</CodeBlock>
 
 You can send extra information to your network partners by adding [partner parameters](https://help.adjust.com/en/article/data-sharing-ad-network#map-parameters).
 
@@ -330,12 +376,10 @@ Partner parameters don't appear in raw data by default. You can add the `{partne
 
 Add partner parameters to your event by calling the `addPartnerParameter` method with `string` key-value arguments. You can add multiple parameters by calling this method multiple times.
 
-```cs {3,4}
+```cs
 var adjustEvent = new AdjustEvent("abc123");
-
 adjustEvent.AddPartnerParameter("key", "value");
 adjustEvent.AddPartnerParameter("foo", "bar");
-
 Adjust.TrackEvent(adjustEvent);
 ```
 
@@ -346,7 +390,9 @@ This example shows how to record an event with the token `g3mfiw` whenever a use
 -  The `product_id` of the associated product
 -  The `user_id` of the user who triggered the event
 
-```cs {14-20}
+<CodeBlock highlight="{range: 14-20}">
+
+```cs
 using AdjustSdk;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -371,6 +417,8 @@ namespace AdjustWSExample
 }
 ```
 
+</CodeBlock>
+
 ```xml
 <Page
    x:Class="AdjustWSExample.MainPage"
@@ -389,19 +437,21 @@ namespace AdjustWSExample
 
 ## [Add a callback identifier](add-a-callback-identifier)
 
-```cs title="Property declaration"
+<CodeBlock title="Property declaration">
+
+```cs
 public string CallbackId { get; set; }
 ```
+
+</CodeBlock>
 
 You can add a custom string identifier to each event you want to measure. Adjust's servers can report on this identifier in event callbacks. This enables you to keep track of which events have been successfully measured.
 
 Set up this identifier by assigning your identifier to the `CallbackId` property on your event object.
 
-```cs {3}
+```cs
 var adjustEvent = new AdjustEvent("abc123");
-
 adjustEvent.CallbackId = "Your-Custom-Id";
-
 Adjust.TrackEvent(adjustEvent);
 ```
 
@@ -409,7 +459,9 @@ Adjust.TrackEvent(adjustEvent);
 
 This example shows how to record an event with the token `g3mfiw` whenever a user interacts with a button. In this example, the `callbackId` is set to `f2e728d8-271b-49ab-80ea-27830a215147`.
 
-```cs {14-19}
+<CodeBlock highlight="{range: 14-19}">
+
+```cs
 using AdjustSdk;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -432,6 +484,8 @@ namespace AdjustWSExample
    }
 }
 ```
+
+</CodeBlock>
 
 ```xml
 <Page

--- a/src/content/docs/sdk/windows/features/preinstalled.mdx
+++ b/src/content/docs/sdk/windows/features/preinstalled.mdx
@@ -12,18 +12,22 @@ Configuring a default link token enables you to attribute all preinstalls to a p
 
 1. [Create a new campaign link in Campaign Lab](https://help.adjust.com/en/article/links).
 
-   ```text "{token}"
+   ```text
    https://app.adjust.com/{token}
    ```
 
 2. Copy this token and assign it to the [`defaultTracker` property](/en/sdk/flutter/configuration#set-default-link-token) of your config object.
 
-   ```cs {3}
+   <CodeBlock highlight="{range: 3}">
+
+   ```cs
    var config = new AdjustConfig(appToken, environment,
       msg => System.Diagnostics.Debug.WriteLine(msg), LogLevel.Verbose);
    config.DefaultTracker = "{TrackerToken}";
    Adjust.ApplicationLaunching(config);
    ```
+
+   </CodeBlock>
 
 3. Build and run your app. If you have logging enabled, you should see a message in your log
 

--- a/src/content/docs/sdk/windows/features/privacy.mdx
+++ b/src/content/docs/sdk/windows/features/privacy.mdx
@@ -8,9 +8,13 @@ The Adjust SDK contains features that you can use to handle user privacy in your
 
 ## [Send erasure request](send-erasure-request)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void GdprForgetMe();
 ```
+
+</CodeBlock>
 
 The EU’s General Data Protection Regulation (GDPR) and similar privacy laws worldwide (CCPA, LGPD, etc.) grant data subjects comprehensive rights when it comes to the processing of their personal data. These rights include, among others, the right to erasure (see [Art. 17 GDPR](https://gdpr.eu/article-17-right-to-be-forgotten/))([1](https://help.adjust.com/en/article/gdpr#ref-1)). As a data processor, Adjust is obliged to support you (the data controller) in the processing of such requests from your (app) users.
 

--- a/src/content/docs/sdk/windows/features/session-parameters.mdx
+++ b/src/content/docs/sdk/windows/features/session-parameters.mdx
@@ -18,9 +18,13 @@ You can configure callback parameters to your servers. Once you configure parame
 
 ### [Add session callback parameters](add-session-callback-parameters)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void AddSessionCallbackParameter(string key, string value);
 ```
+
+</CodeBlock>
 
 Add callback parameters to your event by calling the `AddSessionCallbackParameter` method with `string` key-value arguments. You can add multiple parameters by calling this method multiple times.
 
@@ -30,9 +34,13 @@ Adjust.AddSessionCallbackParameter("key", "value");
 
 ### [Remove session callback parameters](remove-session-callback-parameters)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void RemoveSessionCallbackParameter(string key);
 ```
+
+</CodeBlock>
 
 You can remove specific session callback parameters if they're no longer required. To do this, pass the parameter `key` to the `RemoveSessionCallbackParameter` method.
 
@@ -42,9 +50,13 @@ Adjust.RemoveSessionCallbackParameter("key");
 
 ### [Reset session callback parameters](reset-session-callback-parameters)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void ResetSessionCallbackParameters();
 ```
+
+</CodeBlock>
 
 You can remove all session parameters if they're no longer required. To do this, call the `ResetSessionCallbackParameters` method.
 
@@ -66,9 +78,13 @@ Partner parameters don't appear in raw data by default. You can add the `{partne
 
 ### [Add session partner parameters](add-session-partner-parameters)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void AddSessionPartnerParameter(string key, string value);
 ```
+
+</CodeBlock>
 
 Send partner parameters with your session by calling the `AddSessionPartnerParameter` method with `string` key-value arguments. You can add multiple parameters by calling this method multiple times.
 
@@ -78,9 +94,13 @@ Adjust.AddSessionPartnerParameter("key", "value");
 
 ### [Remove session partner parameters](remove-session-partner-parameters)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void RemoveSessionPartnerParameter(string key);
 ```
+
+</CodeBlock>
 
 You can remove specific session partner parameters if they're no longer required. To do this, pass the parameter key to the `RemoveSessionPartnerParameter` method.
 
@@ -90,9 +110,13 @@ Adjust.RemoveSessionPartnerParameter("key");
 
 ### [Reset session partner parameters](reset-session-partner-parameters)
 
-```cs title="Method signature"
+<CodeBlock title="Method signature">
+
+```cs
 public static void ResetSessionPartnerParameters();
 ```
+
+</CodeBlock>
 
 You can remove all session partner parameters if they're no longer required. To do this, call the `ResetSessionPartnerParameters` method.
 

--- a/src/content/docs/sdk/windows/index.mdx
+++ b/src/content/docs/sdk/windows/index.mdx
@@ -43,9 +43,13 @@ Once you've added the Adjust SDK to your Visual Studio project, you need to inte
 2. Open the `App.xaml.cs` file.
 3. Add the following directive to the top of the file:
 
-```cs title="App.xaml.cs"
+<CodeBlock title="App.xaml.cs">
+
+```cs
 using AdjustSdk;
 ```
+
+</CodeBlock>
 
 ## [3. Initialize the Adjust SDK](3-initialize-the-adjust-sdk)
 


### PR DESCRIPTION
Expressive code's built-in syntax doesn't work with translations. We need to update all code blocks to work with our custom code block builder where necessary.

This PR updates all code blocks and replaces the existing jsdom logic with more robust rehype logic.