### PR TITLE
Add extraction step for links

### DIFF
--- a/.github/scripts/extract_links.py
+++ b/.github/scripts/extract_links.py
@@ -30,8 +30,10 @@ def main():
       for text, url in all_links:
          temp_file.write(f'[{text}]({url})\n')
 
-      # Print the name of the temporary file for GitHub Actions
-      print(f"::set-output name=file::{temp_file.name}")
+      # Output the name of the temporary file to $GITHUB_OUTPUT
+      output_file = os.getenv('GITHUB_OUTPUT')
+      with open(output_file, 'a') as f:
+         f.write(f"file={temp_file.name}\n")
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/extract_links.py
+++ b/.github/scripts/extract_links.py
@@ -1,0 +1,37 @@
+import os
+import re
+import glob
+import tempfile
+
+# Regex patterns for Markdown links and headers
+markdown_link_pattern = re.compile(r'\[([^\]]+)\]\(([^)]+)\)')
+header_pattern = re.compile(r'^\s{0,3}#{1,6}\s')
+
+def extract_links(file):
+   links = []
+   with open(file, 'r', encoding='utf-8') as f:
+      for line in f:
+         if not header_pattern.match(line):
+               links.extend(markdown_link_pattern.findall(line))
+   return links
+
+def main():
+   all_links = []
+
+   pattern = f"src/content/docs/**/*.mdx"
+   files = glob.glob(pattern, recursive=True)
+
+   for file in files:
+      links = extract_links(file)
+      all_links.extend(links)
+
+   # Create a temporary file to store the extracted links
+   with tempfile.NamedTemporaryFile(delete=False, mode='w', suffix='.md', prefix='extracted_links_', dir='.') as temp_file:
+      for text, url in all_links:
+         temp_file.write(f'[{text}]({url})\n')
+
+      # Print the name of the temporary file for GitHub Actions
+      print(f"::set-output name=file::{temp_file.name}")
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -16,11 +16,18 @@ jobs:
           allow_inactive: true
           environment: Preview
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Extract links
+        id: extract_links
+        run: python ./.github/scripts/extract_links.py
       - name: Check for broken links
         if: steps.waitForVercel.outputs.url
         uses: lycheeverse/lychee-action@v1.10.0
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
-          args: --max-redirects 10 --base ${{ steps.waitForVercel.outputs.url }} './src/content/docs/**/*.mdx'
+          args: --max-redirects 10 --base ${{ steps.waitForVercel.outputs.url }} ${{ steps.extract_links.outputs.file }}
           fail: true

--- a/src/content/docs/sdk/android/setup/preinstall-tool-ja.mdx
+++ b/src/content/docs/sdk/android/setup/preinstall-tool-ja.mdx
@@ -81,14 +81,14 @@ $ brew install apktool
 $ brew install openjdk@16
 ```
 
-Oracle JDKを使用している場合は、[Oracle Webサイト](https://docs.oracle.com/ja/java/javase/16/install/installation-jdk-macos.html#GUID-E8A251B6-D9A9-4276-ABC8-CC0DAD62EA33)の手順に従ってください。
+Oracle JDKを使用している場合は、[Oracle Webサイト](https://docs.oracle.com/en/java/javase/16/install/installation-jdk-macos.html#GUID-E8A251B6-D9A9-4276-ABC8-CC0DAD62EA33)の手順に従ってください。
 
 </Tab>
 <Tab title="Linux" sync="linux">
 
 `jarsigner` はJava Development Kit（JDK）の一部として含まれています。OpenJDKとOracle JDKの両方の実装で利用可能です。OpenJDKは、多くの主要なディストリビューションのリポジトリで利用可能です。お使いのディストリビューションのインストール手順を検索し、OpenJDKをインストールしてください。`jarsigner`を使用するには、開発パッケージをインストールする必要があります。
 
-Oracle JDKを使用している場合は、[Oracle Webサイト](https://docs.oracle.com/ja/java/javase/16/install/installation-jdk-linux-platforms.html#GUID-737A84E4-2EFF-4D38-8E60-3E29D1B884B8)の手順に従ってください。
+Oracle JDKを使用している場合は、[Oracle Webサイト](https://docs.oracle.com/en/java/javase/16/install/installation-jdk-linux-platforms.html#GUID-737A84E4-2EFF-4D38-8E60-3E29D1B884B8)の手順に従ってください。
 
 </Tab>
 </Tabs>

--- a/src/content/docs/sdk/android/setup/preinstall-tool-ko.mdx
+++ b/src/content/docs/sdk/android/setup/preinstall-tool-ko.mdx
@@ -81,14 +81,14 @@ $ brew install apktool
 $ brew install openjdk@16
 ```
 
-Oracle JDK를 사용하는 경우, [Oracle 웹사이트](https://docs.oracle.com/ko/java/javase/16/install/installation-jdk-macos.html#GUID-E8A251B6-D9A9-4276-ABC8-CC0DAD62EA33)의 지침을 참조하시기 바랍니다.
+Oracle JDK를 사용하는 경우, [Oracle 웹사이트](https://docs.oracle.com/en/java/javase/16/install/installation-jdk-macos.html#GUID-E8A251B6-D9A9-4276-ABC8-CC0DAD62EA33)의 지침을 참조하시기 바랍니다.
 
 </Tab>
 <Tab title="Linux" sync="linux">
 
 `jarsigner` JDK\(Java Development Kit\)의 일부로 포함되어 있습니다. 이는 OpenJDK와 Oracle JDK 모두에서 이용 가능합니다. OpenJDK는 다양한 주요 배포 버전의 리포지터리에서 찾을 수 있습니다. 배포 버전의 설치 설명서를 검색하여 OpenJDK를 설치하시기 바랍니다. `jarsigner`를 사용하려면 개발 패키지를 설치해야 합니다.
 
-Oracle JDK를 사용하는 경우, [Oracle 웹사이트](https://docs.oracle.com/ko/java/javase/16/install/installation-jdk-linux-platforms.html#GUID-737A84E4-2EFF-4D38-8E60-3E29D1B884B8)의 지침을 참조하시기 바랍니다.
+Oracle JDK를 사용하는 경우, [Oracle 웹사이트](https://docs.oracle.com/en/java/javase/16/install/installation-jdk-linux-platforms.html#GUID-737A84E4-2EFF-4D38-8E60-3E29D1B884B8)의 지침을 참조하시기 바랍니다.
 
 </Tab>
 </Tabs>

--- a/src/content/docs/sdk/android/setup/preinstall-tool-zh.mdx
+++ b/src/content/docs/sdk/android/setup/preinstall-tool-zh.mdx
@@ -81,14 +81,14 @@ $ brew install apktool
 $ brew install openjdk@16
 ```
 
-如果您使用的是 Oracle JDK，请按照 [Oracle 网站](https://docs.oracle.com/zh/java/javase/16/install/installation-jdk-macos.html#GUID-E8A251B6-D9A9-4276-ABC8-CC0DAD62EA33)上的说明操作。
+如果您使用的是 Oracle JDK，请按照 [Oracle 网站](https://docs.oracle.com/en/java/javase/16/install/installation-jdk-macos.html#GUID-E8A251B6-D9A9-4276-ABC8-CC0DAD62EA33)上的说明操作。
 
 </Tab>
 <Tab title="Linux" sync="linux">
 
 `jarsigner` 已经包含在 Java Development Kit \(JDK\) 中，OpenJDK 和 Oracle JDK 安装均可用。许多主要发行版的库中都有 OpenJDK。请查看发行版对应的安装说明，安装 OpenJDK。要使用`jarsigner`，您需要安装开发包。
 
-如果您使用的是 Oracle JDK，请按照 [Oracle 网站](https://docs.oracle.com/zh/java/javase/16/install/installation-jdk-linux-platforms.html#GUID-737A84E4-2EFF-4D38-8E60-3E29D1B884B8)上的说明操作。
+如果您使用的是 Oracle JDK，请按照 [Oracle 网站](https://docs.oracle.com/en/java/javase/16/install/installation-jdk-linux-platforms.html#GUID-737A84E4-2EFF-4D38-8E60-3E29D1B884B8)上的说明操作。
 
 </Tab>
 </Tabs>

--- a/src/content/docs/sdk/android/setup/preinstall-tool-zh.mdx
+++ b/src/content/docs/sdk/android/setup/preinstall-tool-zh.mdx
@@ -44,7 +44,7 @@ macOS 设备上已预装 Ruby。
 </Tab>
 <Tab title="Linux" sync="linux">
 
-请查看 [ruby\-lang 网站上列出](https://www.ruby-lang.org/zh/documentation/installation/)的对应发布版本说明。
+请查看 [ruby\-lang 网站上列出](https://www.ruby-lang.org/en/documentation/installation/)的对应发布版本说明。
 
 </Tab>
 </Tabs>

--- a/src/content/docs/sdk/ios/features/deep-links/resolution-ja.mdx
+++ b/src/content/docs/sdk/ios/features/deep-links/resolution-ja.mdx
@@ -144,9 +144,9 @@ sidebar-position: 5
 
    **例：** [`short.io`](http://short.io)
 
-6. URL短縮サービスで、URL短縮ドメインをカスタムドメインとして設定します。URL短縮サービスのサーバーをポイントするように、URL短縮ドメインのDNSを設定してください（[short.ioにカスタムドメインを追加する参照ドキュメント](https://help.short.io/ja/articles/4065811-how-can-i-add-a-domain)）。
+6. URL短縮サービスで、URL短縮ドメインをカスタムドメインとして設定します。URL短縮サービスのサーバーをポイントするように、URL短縮ドメインのDNSを設定してください（[short.ioにカスタムドメインを追加する参照ドキュメント](https://help.short.io/en/articles/4065811-how-can-i-add-a-domain)）。
 
-7. URL短縮サービスでユニバーサルリンクを設定します（[short.ioのユニバーサルリンクを設定する参照ドキュメント](https://help.short.io/ja/articles/4065870-how-to-set-up-deep-links-for-ios)）。
+7. URL短縮サービスでユニバーサルリンクを設定します（[short.ioのユニバーサルリンクを設定する参照ドキュメント](https://help.short.io/en/articles/4065870-how-to-set-up-deep-links-for-ios)）。
 
 #### [例](example-1)
 

--- a/src/content/docs/sdk/ios/features/deep-links/resolution-ko.mdx
+++ b/src/content/docs/sdk/ios/features/deep-links/resolution-ko.mdx
@@ -144,9 +144,9 @@ sidebar-position: 5
 
    **예:** [`short.io`](http://short.io)
 
-6. URL 단축 도메인을 URL 단축 서비스의 맞춤 도메인으로 구성합니다. URL 단축 도메인에 대해 DNS를 구성하여 URL 단축 서비스의 서버로 전달되도록 해야 합니다. \([short.io에 커스텀 도메인을 추가하기 위한 참고 문서](https://help.short.io/ko/articles/4065811-how-can-i-add-a-domain)\).
+6. URL 단축 도메인을 URL 단축 서비스의 맞춤 도메인으로 구성합니다. URL 단축 도메인에 대해 DNS를 구성하여 URL 단축 서비스의 서버로 전달되도록 해야 합니다. \([short.io에 커스텀 도메인을 추가하기 위한 참고 문서](https://help.short.io/en/articles/4065811-how-can-i-add-a-domain)\).
 
-7. URL 단축 서비스에서 유니버설 링크를 구성합니다. \([short.io에 유니버설 링크를 구성하기 위한 참고 문서](https://help.short.io/ko/articles/4065870-how-to-set-up-deep-links-for-ios)\).
+7. URL 단축 서비스에서 유니버설 링크를 구성합니다. \([short.io에 유니버설 링크를 구성하기 위한 참고 문서](https://help.short.io/en/articles/4065870-how-to-set-up-deep-links-for-ios)\).
 
 #### [예시](example-1)
 

--- a/src/content/docs/sdk/ios/features/deep-links/resolution-zh.mdx
+++ b/src/content/docs/sdk/ios/features/deep-links/resolution-zh.mdx
@@ -143,9 +143,9 @@ sidebar-position: 5
 
    **示例** ：[`short.io`](http://short.io)
 
-6. 在短 URL 生成服务平台上，将短 URL 生成域配置为自定义域。您需要进行 DNS 配置，才能让短 URL 生成域指向短 URL 生成服务的服务器。\([在 short.io 中添加自定义域的参考文档](https://help.short.io/zh/articles/4065811-how-can-i-add-a-domain)\)。
+6. 在短 URL 生成服务平台上，将短 URL 生成域配置为自定义域。您需要进行 DNS 配置，才能让短 URL 生成域指向短 URL 生成服务的服务器。\([在 short.io 中添加自定义域的参考文档](https://help.short.io/en/articles/4065811-how-can-i-add-a-domain)\)。
 
-7. 在 URL 缩短服务中配置通用链接。\([在 short.io 中设置通用链接的参考文档](https://help.short.io/zh/articles/4065870-how-to-set-up-deep-links-for-ios)\)。
+7. 在 URL 缩短服务中配置通用链接。\([在 short.io 中设置通用链接的参考文档](https://help.short.io/en/articles/4065870-how-to-set-up-deep-links-for-ios)\)。
 
 #### [示例](example-1)
 

--- a/src/content/docs/sdk/smart-banner/deep-linking.mdx
+++ b/src/content/docs/sdk/smart-banner/deep-linking.mdx
@@ -42,7 +42,7 @@ AdjustSmartBanner.setIosDeepLinkPath(
 
 The Smart Banner SDK replaces these parameters with values from the context provided:
 
--  [In the `init` function](/en/article/sdk/smart-banner/init-options#configure-deep-links)
+-  [In the `init` function](/en/sdk/smart-banner/init-options#configure-deep-links)
 -  [By the `setContext` function](#set-deep-link-context)
 -  [From URL parameters](#use-get-parameters-as-context)
 

--- a/src/content/docs/sdk/smart-banner/deep-linking.mdx
+++ b/src/content/docs/sdk/smart-banner/deep-linking.mdx
@@ -10,7 +10,7 @@ A deep link is a link that directs users to specific events or pages in your app
 
 There are two ways to configure a dynamic deep link in the Smart Banner SDK:
 
--  [Pass parameters to the `AdjustSmartBanner.init` function](/en/article/init-options-smart-banner-sdk#configure-deep-links).
+-  [Pass parameters to the `AdjustSmartBanner.init` function](/en/sdk/smart-banners/init-options#configure-deep-links).
    -  Provide context by configuring the `context` object.
 -  Call the `setAndroidDeepLinkPath` and `setIosDeepLinkPath` setters.
    -  Provide context by calling the `setContext` setter
@@ -42,7 +42,7 @@ AdjustSmartBanner.setIosDeepLinkPath(
 
 The Smart Banner SDK replaces these parameters with values from the context provided:
 
--  [In the `init` function](/en/article/init-options-smart-banner-sdk#configure-deep-links)
+-  [In the `init` function](/en/article/sdk/smart-banner/init-options#configure-deep-links)
 -  [By the `setContext` function](#set-deep-link-context)
 -  [From URL parameters](#use-get-parameters-as-context)
 

--- a/src/content/docs/sdk/smart-banner/deep-linking.mdx
+++ b/src/content/docs/sdk/smart-banner/deep-linking.mdx
@@ -10,7 +10,7 @@ A deep link is a link that directs users to specific events or pages in your app
 
 There are two ways to configure a dynamic deep link in the Smart Banner SDK:
 
--  [Pass parameters to the `AdjustSmartBanner.init` function](/en/sdk/smart-banners/init-options#configure-deep-links).
+-  [Pass parameters to the `AdjustSmartBanner.init` function](/en/sdk/smart-banner/init-options#configure-deep-links).
    -  Provide context by configuring the `context` object.
 -  Call the `setAndroidDeepLinkPath` and `setIosDeepLinkPath` setters.
    -  Provide context by calling the `setContext` setter


### PR DESCRIPTION
Closes https://adjustcom.atlassian.net/browse/THC-1009

Since we use link syntax to set up persistent headers in files, our link checking step isn't working. To resolve this, this PR adds a script that pull out all Markdown links excluding those found in headers and passes their output to Lychee.