### PR TITLE
Improve versioned header links

### DIFF
--- a/src/utils/helpers/toc/getTocHeadings.ts
+++ b/src/utils/helpers/toc/getTocHeadings.ts
@@ -1,20 +1,14 @@
 import type { MarkdownHeading } from "astro";
 
 const HEADER_HEIGHT = 150;
-let versionNumber = "";
 
-export const getTocHeadings = (headers: Element[], versionNumber?: string): MarkdownHeading[] => {
+export const getTocHeadings = (headers: Element[]): MarkdownHeading[] => {
   return headers.map((header) => {
     const text = header.textContent ?? "";
     let slug = header.id;
 
     if (!slug) {
       slug = text.toLowerCase().replace(/[^\w\s-]/g, "").replace(/\s+/g, "-");
-      header.id = slug;
-    }
-
-    if (versionNumber && !slug.startsWith(versionNumber)) {
-      slug = `${versionNumber}-${slug}`;
       header.id = slug;
     }
 
@@ -26,6 +20,18 @@ export const getTocHeadings = (headers: Element[], versionNumber?: string): Mark
   });
 };
 
+const removeHeaderIds = () => {
+  const headers = Array.from(document.querySelectorAll(
+    '.article-content h1, .article-content h2:not([class^="Banner__"]), .article-content h3, .article-content h4'
+  ));
+  headers.filter((header) => {
+    const parentDiv = header.closest("sdk-version-block") || header.closest("api-version-block");
+    if (parentDiv && parentDiv.matches(".hidden")) {
+      header.removeAttribute("id")
+    }
+  })
+}
+
 export const getHeaders = (): Element[] | false => {
   const headers = Array.from(document.querySelectorAll(
     '.article-content h1, .article-content h2:not([class^="Banner__"]), .article-content h3, .article-content h4'
@@ -35,7 +41,6 @@ export const getHeaders = (): Element[] | false => {
   const versionedHeaders = headers.filter((header) => {
     const parentDiv = header.closest("sdk-version-block") || header.closest("api-version-block");
     if (parentDiv && !parentDiv.matches(".hidden")) {
-      versionNumber = parentDiv.getAttribute("data-message")!;
       return true;
     }
     return false;
@@ -59,8 +64,8 @@ export const updateHeadings = (): void => {
     [toc, bigToc, mobileToc].forEach(el => el.classList.add("!hidden"));
     return;
   }
-
-  const headings = getTocHeadings(headers, versionNumber);
+  removeHeaderIds();
+  const headings = getTocHeadings(headers);
 
   if (headings.length === 0) {
     [toc, bigToc, mobileToc].forEach(el => el.classList.add("!hidden"));

--- a/src/utils/helpers/toc/getTocHeadings.ts
+++ b/src/utils/helpers/toc/getTocHeadings.ts
@@ -27,7 +27,9 @@ const removeHeaderIds = () => {
   headers.filter((header) => {
     const parentDiv = header.closest("sdk-version-block") || header.closest("api-version-block");
     if (parentDiv && parentDiv.matches(".hidden")) {
-      header.removeAttribute("id")
+      header.id = `hiddendiv-${header.id}`
+    } else {
+      header.id = header.id.replace("hiddendiv-", "")
     }
   })
 }


### PR DESCRIPTION
Currently, headers are updated on the page based on the version selected. This is due to a limitation in how multi-version documents are handled.

This change updates this logic to remove headers from any hidden blocks. This means all headers remain unique, and the header IDs will be added only when the the blocks are visible.

This is a workaround to improve behavior until our content collection issues are resolved.