### PR TITLE
Fix token import

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,4 +10,4 @@ DEV_HUB_ALGOLIA_INDEX_NAME=
 # Create a GitHub API token so you don't hit rate limits when populating functions
 # https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic
 
-GITHUB_TOKEN=
+VITE_GITHUB_TOKEN=

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,6 +11,7 @@ import rehypeExternalLinks from 'rehype-external-links';
 import remarkHeaderLinkToId from "./src/integrations/remarkHeaderLinkToId";
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 
+console.log(`${import.meta.env.VITE_GITHUB_TOKEN ? "Token found" : "No token found"}`)
 const versions = await fetchVersions()
 
 // https://astro.build/config

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -2,7 +2,7 @@
 /// <reference path="../.astro/types.d.ts" />
 
 interface ImportMetaEnv {
-  readonly GITHUB_TOKEN: string | undefined;
+  readonly VITE_GITHUB_TOKEN: string | undefined;
   readonly HELP_CENTER_ALGOLIA_APP_ID: string;
   readonly HELP_CENTER_ALGOLIA_API_KEY: string;
   readonly HELP_CENTER_ALGOLIA_INDEX_NAME: string;

--- a/src/integrations/fetchSdkVersions.ts
+++ b/src/integrations/fetchSdkVersions.ts
@@ -1,6 +1,6 @@
 import { Octokit } from "@octokit/core";
 
-const octokit = new Octokit({ auth: import.meta.env.GITHUB_TOKEN });
+const octokit = new Octokit({ auth: import.meta.env.VITE_GITHUB_TOKEN });
 
 let versionReplacements: VersionMap = {
    "android": {


### PR DESCRIPTION
Currently, the GitHub token isn't being imported properly due to not having a `VITE_` prefix. This PR fixes this issue and adds a log to let people know if the token is loaded during build.