### PR TITLE
Removed asterisk from method

### DIFF
--- a/src/content/docs/sdk/ios/configuration.mdx
+++ b/src/content/docs/sdk/ios/configuration.mdx
@@ -582,7 +582,7 @@ Adjust.isEnabled() { isEnabled in
 <Tab title="Objective-C" sync="objc">
 
 ```objc
-[Adjust isEnabledWithCompletionHandler:^(BOOL * isEnabled) {
+[Adjust isEnabledWithCompletionHandler:^(BOOL isEnabled) {
    // Your completion handler
 }]
 ```


### PR DESCRIPTION
As per ticket ES-7945, removed asterisk from the isEnabledWithCompletionHandler method.