### PR TITLE
THC-1044 changed old space size to 7 GB

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro build",
+    "build": "NODE_OPTIONS=--max_old_space_size=7168 astro build",
     "preview": "astro preview",
     "astro": "astro",
     "clean": "rm -rf dist",


### PR DESCRIPTION
Fix was done by this approach: https://vercel.com/guides/troubleshooting-sigkill-out-of-memory-errors#4.-increase-memory-allocation-for-node