### PR TITLE
Update event section for Flutter SDK v5

### DIFF
--- a/src/content/docs/sdk/flutter/features/events.mdx
+++ b/src/content/docs/sdk/flutter/features/events.mdx
@@ -35,7 +35,7 @@ Adjust.trackEvent(myAdjustEvent);
 ```dart
 static void trackEvent(AdjustEvent event)
 ```
-
+</CodeBlock>
 <CodeBlock title="Event log" collapse="6-46">
 
 ```txt
@@ -145,7 +145,7 @@ String? deduplicationId;
 
 </CodeBlock>
 
-You can pass an optional identifier to avoid recording duplicate events. By default, the SDK stores the last ten identifiers and skips revenue events with duplicate transaction IDs. In case you would like the SDK to store more than 10 identifiers, you can set the desired number of identifiers by assigning the value to `eventDeduplicationIdsMaxSize` of the `AdjustConfig` instance.
+You can pass an optional identifier to avoid recording duplicate events. By default, the SDK stores the last 10 identifiers and skips revenue events with duplicate transaction IDs. In case you would like the SDK to store more than 10 identifiers, you can set the desired number of identifiers by assigning the value to `eventDeduplicationIdsMaxSize` of the `AdjustConfig` instance.
 
 To set the identifier, assign your deduplcation ID to the `deduplicationId` property of your event instance.
 
@@ -159,7 +159,7 @@ AdjustEvent myAdjustEvent = new AdjustEvent('abc123');
 myAdjustEvent.deduplicationId = 'deduplication-id';
 Adjust.trackEvent(myAdjustEvent);
 ```
-
+</CodeBlock>
 <CodeBlock title="Event log" highlight="{range: 7}">
 
 ```txt
@@ -271,7 +271,7 @@ Parameters:
   event_count      1
   event_token      abc123
 ```
-
+</CodeBlock>
 ## [Add a callback identifier](add-a-callback-identifier)
 
 <CodeBlock title="Property declaration">

--- a/src/content/docs/sdk/flutter/features/events.mdx
+++ b/src/content/docs/sdk/flutter/features/events.mdx
@@ -2,7 +2,10 @@
 title: Send event information
 description: Use these methods send event information to Adjust.
 slug: en/sdk/flutter/features/events
+multiVersion: true
 ---
+
+<SdkVersion version="v5">
 
 The Adjust SDK provides an `AdjustEvent` object which can be used to structure and send event information from your app to Adjust's servers.
 
@@ -35,6 +38,7 @@ Adjust.trackEvent(myAdjustEvent);
 ```dart
 static void trackEvent(AdjustEvent event)
 ```
+
 </CodeBlock>
 <CodeBlock title="Event log" collapse="6-46">
 
@@ -159,7 +163,7 @@ AdjustEvent myAdjustEvent = new AdjustEvent('abc123');
 myAdjustEvent.deduplicationId = 'deduplication-id';
 Adjust.trackEvent(myAdjustEvent);
 ```
-</CodeBlock>
+
 <CodeBlock title="Event log" highlight="{range: 7}">
 
 ```txt
@@ -271,6 +275,7 @@ Parameters:
   event_count      1
   event_token      abc123
 ```
+
 </CodeBlock>
 ## [Add a callback identifier](add-a-callback-identifier)
 
@@ -306,3 +311,600 @@ Parameters:
 
 </CodeBlock>
 
+</SdkVersion>
+
+<SdkVersion version="v4">
+
+The Adjust SDK provides an `AdjustEvent` object which can be used to structure and send event information from your app to Adjust's servers.
+
+## [Instantiate an AdjustEvent object](instantiate-an-adjustevent-object)
+
+<CodeBlock title="Method signature">
+
+```dart
+AdjustEvent(string eventToken)
+```
+
+</CodeBlock>
+
+To send event information with the Adjust SDK, you need to instantiate an `AdjustEvent` object. This object contains variables that are sent to Adjust when an event occurs in your app.
+
+To instantiate an event object, create a new `AdjustEvent` instance and pass the following parameters:
+
+-  `eventToken` (`String`): Your Adjust [event token](https://help.adjust.com/en/article/add-events#manage-your-events).
+
+```dart
+AdjustEvent myAdjustEvent = new AdjustEvent('abc123');
+//...
+Adjust.trackEvent(myAdjustEvent);
+```
+
+## [Send an event](send-an-event)
+
+<CodeBlock title="Method signature">
+
+```dart
+static void trackEvent(AdjustEvent event)
+```
+
+</CodeBlock>
+
+You can associate your [Adjust event tokens](https://help.adjust.com/en/article/add-events#add-event) to actions in your app to record them. To record an event:
+
+-  Create a new Adjust event instance and pass your event token as a string argument.
+-  Call the `trackEvent` method with your event instance as an argument.
+
+```dart
+AdjustEvent myAdjustEvent = new AdjustEvent('abc123');
+//...
+Adjust.trackEvent(myAdjustEvent);
+```
+
+### [Example](example)
+
+This example shows how to record an event with the token `g3mfiw` whenever a user interacts with a button.
+
+<CodeBlock title="util.dart">
+
+```dart
+import 'package:adjust_sdk/adjust_event.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class Util {
+   static const String EVENT_TOKEN_SIMPLE = 'g3mfiw';
+
+   static Widget buildCupertinoButton(String text, Function action) {
+      return new CupertinoButton(
+         child: Text(text),
+         color: CupertinoColors.activeBlue,
+         padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 30.0),
+         onPressed: action as void Function()?,
+      );
+   }
+
+   static AdjustEvent myAdjustEvent() {
+      return new AdjustEvent(EVENT_TOKEN_SIMPLE);
+   }
+}
+
+// main.dart
+import 'util.dart';
+
+Util.buildCupertinoButton('Track Simple Event',
+   () => Adjust.trackEvent(Util.myAdjustEvent())),
+const Padding(padding: const EdgeInsets.all(7.0))
+```
+
+</CodeBlock>
+
+<CodeBlock title="Event log" collapse="6-46">
+
+```txt
+Path:      /event
+ClientSdk: flutter$FLUTTER_VERSION
+Parameters:
+  android_uuid     781f17d5-5048-4fae-a4e5-77b58bab62b9
+  api_level        34
+  app_token        2fm9gkqubvpc
+  app_version      1.0
+  attribution_deeplink 1
+  callback_params  {"key":"value","foo":"bar"}
+  connectivity_type 1
+  country          US
+  cpu_type         arm64-v8a
+  created_at       2024-01-25T14:13:16.151Z+0100
+  currency         EUR
+  device_manufacturer Google
+  device_name      sdk_gphone64_arm64
+  device_type      phone
+  display_height   2205
+  display_width    1080
+  environment      sandbox
+  event_buffering_enabled 0
+  event_count      3
+  event_token      g3mfiw
+  gps_adid         5962dfc1-3a53-4692-850b-22c4bf4311a5
+  gps_adid_attempt 2
+  gps_adid_src     service
+  hardware_name    UE1A.230829.036
+  language         en
+  mcc              310
+  mnc              260
+  needs_response_details 1
+  os_build         UE1A.230829.036
+  os_name          android
+  os_version       14
+  package_name     com.adjust.examples
+  partner_params   {"key":"value","foo":"bar"}
+  revenue          0.25
+  screen_density   high
+  screen_format    long
+  screen_size      normal
+  session_count    2
+  session_length   23
+  subsession_count 1
+  time_spent       23
+  tracking_enabled 1
+  ui_mode          1
+```
+
+</CodeBlock>
+
+## [Record event revenue](record-event-revenue)
+
+<CodeBlock title="Method signature">
+
+```dart
+void setRevenue(Num revenue, String currency)
+```
+
+</CodeBlock>
+
+You can record revenue associated with an event by setting the revenue and currency properties on your event instance. Use this feature to record revenue-generating actions in your app.
+
+To set these properties, call the `setRevenue` method and pass the following arguments:
+
+-  `revenue` (`num`): The amount of revenue generated by the event
+-  `currency` (`String`): The [ISO 4217 code](https://www.iban.com/currency-codes) of the event currency.
+
+<Callout type="seealso">
+
+Check the guide to [recording purchases in different currencies](https://help.adjust.com/en/article/currency-conversion) for more information.
+
+</Callout>
+
+```dart
+AdjustEvent myAdjustEvent = new AdjustEvent('abc123');
+//...
+adjustEvent.setRevenue(0.01, 'EUR');
+//...
+Adjust.trackEvent(myAdjustEvent);
+```
+
+### [Example](example-1)
+
+This example shows how to record an event with the token `g3mfiw` whenever a user interacts with a button. The function sets the `revenue` property of this event to _`0.25`_ and the `currency` property to _`EUR`_.
+
+<CodeBlock title="util.dart">
+
+```dart
+import 'package:adjust_sdk/adjust_event.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class Util {
+   static const String EVENT_TOKEN_REVENUE = 'g3mfiw';
+
+   static Widget buildCupertinoButton(String text, Function action) {
+      return new CupertinoButton(
+         child: Text(text),
+         color: CupertinoColors.activeBlue,
+         padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 30.0),
+         onPressed: action as void Function()?,
+      );
+   }
+
+   static AdjustEvent myAdjustEvent() {
+      AdjustEvent event = new AdjustEvent(EVENT_TOKEN_REVENUE);
+      event.setRevenue(0.25, 'EUR');
+      return event;
+   }
+
+}
+
+// main.dart
+import 'util.dart';
+
+// Send revenue event button.
+Util.buildCupertinoButton('Send Revenue Event',
+   () => Adjust.trackEvent(Util.myAdjustEvent())),
+const Padding(padding: const EdgeInsets.all(7.0))
+
+```
+
+</CodeBlock>
+
+<CodeBlock title="Event log" highlight="{range: 7-8}">
+
+```txt
+Path:      /event
+ClientSdk: flutter$FLUTTER_VERSION
+Parameters:
+  environment      sandbox
+  event_count      3
+  event_token      abc123
+  revenue          0.25
+  currency         EUR
+```
+
+</CodeBlock>
+
+## [Deduplicate revenue events](deduplicate-revenue-events)
+
+<CodeBlock title="Property declaration">
+
+```dart
+String? transactionId;
+```
+
+</CodeBlock>
+
+You can pass an optional identifier to avoid recording duplicate events. The SDK stores the last ten identifiers and skips revenue events with duplicate transaction IDs.
+
+To set the identifier, assign your transaction ID to the `setTransactionId` property of your event instance.
+
+```dart
+AdjustEvent myAdjustEvent = new AdjustEvent('abc123');
+//...
+myAdjustEvent.transactionId = '{TransactionId}';
+//...
+Adjust.trackEvent(myAdjustEvent);
+```
+
+### [Example](example-2)
+
+This example shows how to record an event with the token `g3mfiw` whenever a user interacts with a button. The function sets the `uniqueId` to `5e85484b-1ebc-4141-aab7-25b869e54c49` using the `setTransactionId` method.
+
+<CodeBlock title="util.dart">
+
+```dart
+import 'package:adjust_sdk/adjust_event.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class Util {
+   static const String EVENT_TOKEN_REVENUE = 'g3mfiw';
+   static const String UNIQUE_ID = '5e85484b-1ebc-4141-aab7-25b869e54c49';
+
+   static Widget buildCupertinoButton(String text, Function action) {
+      return new CupertinoButton(
+         child: Text(text),
+         color: CupertinoColors.activeBlue,
+         padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 30.0),
+         onPressed: action as void Function()?,
+      );
+   }
+
+   static AdjustEvent myAdjustEvent() {
+      AdjustEvent event = new AdjustEvent(EVENT_TOKEN_REVENUE);
+      event.transactionId = UNIQUE_ID;
+      return event;
+   }
+
+}
+
+// main.dart
+import 'util.dart';
+
+// Send revenue event button.
+Util.buildCupertinoButton('Send Revenue Event',
+   () => Adjust.trackEvent(Util.myAdjustEvent())),
+const Padding(padding: const EdgeInsets.all(7.0))
+
+```
+
+</CodeBlock>
+
+<CodeBlock title="Event log" highlight="{range: 7}">
+
+```txt
+Path:      /event
+ClientSdk: flutter$FLUTTER_VERSION
+Parameters:
+  environment      sandbox
+  event_count      3
+  event_token      abc123
+  transaction_id   5e85484b-1ebc-4141-aab7-25b869e54c49
+```
+
+</CodeBlock>
+
+## [Add callback parameters](add-callback-parameters)
+
+<CodeBlock title="Method signature">
+
+```dart
+void addCallbackParameter(String key, String value)
+```
+
+</CodeBlock>
+
+If you [register a callback URL](https://help.adjust.com/en/article/set-up-callbacks) in the Adjust dashboard, the SDK sends a GET request to your callback URL when it records an event.
+
+You can configure callback parameters to send to your servers. Once you configure parameters on an event, the SDK appends them to your [callback URL](https://help.adjust.com/en/article/raw-data-exports). You can use this information to analyze your users' in-app behavior with your BI system.
+
+Add callback parameters to your event by calling the `addCallbackParameter` method with `String` key-value arguments. You can add multiple parameters by calling this method multiple times.
+
+```dart
+AdjustEvent myAdjustEvent = new AdjustEvent('abc123');
+//...
+adjustEvent.addCallbackParameter('key', 'value');
+//...
+Adjust.trackEvent(myAdjustEvent);
+```
+
+The Adjust SDK measures the event and sends a request to your URL with the callback parameters. For example, if you register the URL `https://www.mydomain.com/callback`, your callback looks like this:
+
+```http
+https://www.mydomain.com/callback?key=value&foo=bar
+```
+
+<Callout type="note">
+
+Adjust doesn't store your custom callback parameters. Custom parameters are only appended to your callback URL.
+
+</Callout>
+
+If you're using CSV uploads, make sure to add the parameters to your CSV definition.
+
+Adjust supports many placeholders which you can use to pass information from the SDK to your URL. For example, the `{idfa}` placeholder for iOS and the `{gps_adid}` placeholder for Android. The `{publisher_parameter}` placeholder presents all callback parameters in a single string.
+
+<Callout type="seealso">
+
+You can read more about using URL callbacks, including a full list of available values, in the [callbacks guide](https://help.adjust.com/en/article/callbacks).
+
+</Callout>
+
+### [Example](example-3)
+
+This example shows how to record an event with the token `g3mfiw` whenever a user interacts with a button. The following callback parameters are added:
+
+-  The `event_token`
+-  The `revenue_amount` generated by the event
+
+The resulting callback URL looks like this:
+
+<CodeBlock highlight="event_token=g3mfiw, revenue_amount=0.05">
+
+```http
+http://www.mydomain.com/callback?event_token=g3mfiw&revenue_amount=0.05
+```
+
+</CodeBlock>
+
+<CodeBlock title="util.dart">
+
+```dart
+import 'package:adjust_sdk/adjust_event.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class Util {
+   static const String EVENT_TOKEN_CALLBACK = 'g3mfiw';
+
+   static Widget buildCupertinoButton(String text, Function action) {
+      return new CupertinoButton(
+         child: Text(text),
+         color: CupertinoColors.activeBlue,
+         padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 30.0),
+         onPressed: action as void Function()?,
+      );
+   }
+
+   static AdjustEvent buildCallbackEvent() {
+      AdjustEvent event = new AdjustEvent(EVENT_TOKEN_CALLBACK);
+         event.addCallbackParameter('event_token', EVENT_TOKEN_CALLBACK);
+         event.addCallbackParameter('revenue_amount', '0.05');
+   return event;
+   }
+
+}
+
+// main.dart
+import 'util.dart';
+
+// Send callback event button.
+Util.buildCupertinoButton('Send Callback Event',
+   () => Adjust.trackEvent(Util.buildCallbackEvent())),
+const Padding(padding: const EdgeInsets.all(7.0))
+```
+
+</CodeBlock>
+
+<CodeBlock title="Event log" highlight="{range: 4}">
+
+```txt
+Path:      /event
+ClientSdk: flutter$FLUTTER_VERSION
+Parameters:
+  callback_params  {"event_token":"g3mfiw","revenue_amount":"0.05"}
+  environment      sandbox
+  event_count      1
+  event_token      g3mfiw
+```
+
+</CodeBlock>
+
+## [Add partner parameters](add-partner-parameters)
+
+<CodeBlock title="Method signature">
+
+```dart
+void addPartnerParameter(String key, String value)
+```
+
+</CodeBlock>
+
+You can send extra information to your network partners by adding [partner parameters](https://help.adjust.com/en/article/data-sharing-ad-network#map-parameters).
+
+Adjust sends partner parameters to [external partners](https://help.adjust.com/en/article/integrated-partners) you have set up. This information is useful for more granular analysis and retargeting purposes. Adjust's servers forward these parameters once you have set them up and enabled them for a partner.
+
+<Callout type="note">
+
+Partner parameters don't appear in raw data by default. You can add the `{partner_parameters}` placeholder to receive them as a single string.
+
+</Callout>
+
+Add partner parameters to your event by calling the `addPartnerParameter` method with `String` key-value arguments. You can add multiple parameters by calling this method multiple times.
+
+```dart
+AdjustEvent myAdjustEvent = new AdjustEvent('abc123');
+//...
+adjustEvent.addPartnerParameter('key', 'value');
+//...
+Adjust.trackEvent(myAdjustEvent);
+```
+
+### [Example](example-4)
+
+This example shows how to record an event with the token `g3mfiw` whenever a user interacts with a button. The following partner parameters are added:
+
+-  The `product_id` of the associated product
+-  The `user_id` of the user who triggered the event
+
+<CodeBlock title="util.dart">
+
+```dart
+import 'package:adjust_sdk/adjust_event.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class Util {
+   static const String EVENT_TOKEN_PARTNER = 'g3mfiw';
+
+   static Widget buildCupertinoButton(String text, Function action) {
+      return new CupertinoButton(
+         child: Text(text),
+         color: CupertinoColors.activeBlue,
+         padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 30.0),
+         onPressed: action as void Function()?,
+      );
+   }
+
+   static AdjustEvent buildPartnerEvent() {
+      AdjustEvent event = new AdjustEvent(EVENT_TOKEN_PARTNER);
+      event.addPartnerParameter('product_id', '29');
+      event.addPartnerParameter('user_id', '835');
+      return event;
+   }
+
+}
+
+// main.dart
+import 'util.dart';
+
+// Send partner event button.
+Util.buildCupertinoButton('Send Partner Event',
+   () => Adjust.trackEvent(Util.buildPartnerEvent())),
+const Padding(padding: const EdgeInsets.all(7.0))
+```
+
+</CodeBlock>
+
+<CodeBlock title="Event log" highlight="{range: 4}">
+
+```txt
+Path:      /event
+ClientSdk: flutter$FLUTTER_VERSION
+Parameters:
+  partner_params  {"product_id":"29","user_id":"835"}
+  environment      sandbox
+  event_count      1
+  event_token      g3mfiw
+```
+
+</CodeBlock>
+
+## [Add a callback identifier](add-a-callback-identifier)
+
+<CodeBlock title="Property declaration">
+
+```dart
+String? callbackId;
+```
+
+</CodeBlock>
+
+You can add a custom string identifier to each event you want to measure. Adjust's servers can report on this identifier in event callbacks. This enables you to keep track of which events have been successfully measured.
+
+Set up this identifier by assigning your ID to the `callbackId` property on your event instance.
+
+```dart
+AdjustEvent myAdjustEvent = new AdjustEvent('abc123');
+//...
+myAdjustEvent.callbackId = '{your_callback_id}';
+//...
+Adjust.trackEvent(myAdjustEvent);
+```
+
+### [Example](example-5)
+
+This example shows how to record an event with the token `g3mfiw` whenever a user interacts with a button. In this example, the `callbackId` is set to `f2e728d8-271b-49ab-80ea-27830a215147`.
+
+<CodeBlock title="util.dart">
+
+<CodeBlock title="util.dart">
+
+```dart
+import 'package:adjust_sdk/adjust_event.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class Util {
+   static const String EVENT_TOKEN_SIMPLE = 'g3mfiw';
+   static const String CALLBACK_ID = "f2e728d8-271b-49ab-80ea-27830a215147"
+
+   static Widget buildCupertinoButton(String text, Function action) {
+      return new CupertinoButton(
+         child: Text(text),
+         color: CupertinoColors.activeBlue,
+         padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 30.0),
+         onPressed: action as void Function()?,
+      );
+   }
+
+   static AdjustEvent myAdjustEvent() {
+      AdjustEvent event = new AdjustEvent(EVENT_TOKEN_SIMPLE);
+      event.callbackId = CALLBACK_ID;
+      return event;
+}
+
+// main.dart
+import 'util.dart';
+
+Util.buildCupertinoButton('Send Callback Event',
+   () => Adjust.trackEvent(Util.myAdjustEvent())),
+const Padding(padding: const EdgeInsets.all(7.0))
+
+```
+
+</CodeBlock>
+
+</CodeBlock>
+
+<CodeBlock title="Event log" highlight="{range: 7}">
+
+```txt
+Path:      /event
+ClientSdk: flutter$FLUTTER_VERSION
+Parameters:
+  environment      sandbox
+  event_count      3
+  event_token      g3mfiw
+  callback_id      f2e728d8-271b-49ab-80ea-27830a215147
+```
+
+</CodeBlock>
+
+</SdkVersion>

--- a/src/content/docs/sdk/flutter/features/events.mdx
+++ b/src/content/docs/sdk/flutter/features/events.mdx
@@ -11,7 +11,7 @@ The Adjust SDK provides an `AdjustEvent` object which can be used to structure a
 <CodeBlock title="Method signature">
 
 ```dart
-AdjustEvent(string eventToken)
+AdjustEvent(String eventToken)
 ```
 
 </CodeBlock>
@@ -35,57 +35,6 @@ Adjust.trackEvent(myAdjustEvent);
 ```dart
 static void trackEvent(AdjustEvent event)
 ```
-
-</CodeBlock>
-
-You can associate your [Adjust event tokens](https://help.adjust.com/en/article/add-events#add-event) to actions in your app to record them. To record an event:
-
--  Create a new Adjust event instance and pass your event token as a string argument.
--  Call the `trackEvent` method with your event instance as an argument.
-
-```dart
-AdjustEvent myAdjustEvent = new AdjustEvent('abc123');
-//...
-Adjust.trackEvent(myAdjustEvent);
-```
-
-### [Example](example)
-
-This example shows how to record an event with the token `g3mfiw` whenever a user interacts with a button.
-
-<CodeBlock title="util.dart">
-
-```dart
-import 'package:adjust_sdk/adjust_event.dart';
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
-
-class Util {
-   static const String EVENT_TOKEN_SIMPLE = 'g3mfiw';
-
-   static Widget buildCupertinoButton(String text, Function action) {
-      return new CupertinoButton(
-         child: Text(text),
-         color: CupertinoColors.activeBlue,
-         padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 30.0),
-         onPressed: action as void Function()?,
-      );
-   }
-
-   static AdjustEvent myAdjustEvent() {
-      return new AdjustEvent(EVENT_TOKEN_SIMPLE);
-   }
-}
-
-// main.dart
-import 'util.dart';
-
-Util.buildCupertinoButton('Track Simple Event',
-   () => Adjust.trackEvent(Util.myAdjustEvent())),
-const Padding(padding: const EdgeInsets.all(7.0))
-```
-
-</CodeBlock>
 
 <CodeBlock title="Event log" collapse="6-46">
 
@@ -112,7 +61,7 @@ Parameters:
   environment      sandbox
   event_buffering_enabled 0
   event_count      3
-  event_token      g3mfiw
+  event_token      abc123
   gps_adid         5962dfc1-3a53-4692-850b-22c4bf4311a5
   gps_adid_attempt 2
   gps_adid_src     service
@@ -145,7 +94,7 @@ Parameters:
 <CodeBlock title="Method signature">
 
 ```dart
-void setRevenue(Num revenue, String currency)
+void setRevenue(num revenue, String currency)
 ```
 
 </CodeBlock>
@@ -171,49 +120,6 @@ adjustEvent.setRevenue(0.01, 'EUR');
 Adjust.trackEvent(myAdjustEvent);
 ```
 
-### [Example](example-1)
-
-This example shows how to record an event with the token `g3mfiw` whenever a user interacts with a button. The function sets the `revenue` property of this event to _`0.25`_ and the `currency` property to _`EUR`_.
-
-<CodeBlock title="util.dart">
-
-```dart
-import 'package:adjust_sdk/adjust_event.dart';
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
-
-class Util {
-   static const String EVENT_TOKEN_REVENUE = 'g3mfiw';
-
-   static Widget buildCupertinoButton(String text, Function action) {
-      return new CupertinoButton(
-         child: Text(text),
-         color: CupertinoColors.activeBlue,
-         padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 30.0),
-         onPressed: action as void Function()?,
-      );
-   }
-
-   static AdjustEvent myAdjustEvent() {
-      AdjustEvent event = new AdjustEvent(EVENT_TOKEN_REVENUE);
-      event.setRevenue(0.25, 'EUR');
-      return event;
-   }
-
-}
-
-// main.dart
-import 'util.dart';
-
-// Send revenue event button.
-Util.buildCupertinoButton('Send Revenue Event',
-   () => Adjust.trackEvent(Util.myAdjustEvent())),
-const Padding(padding: const EdgeInsets.all(7.0))
-
-```
-
-</CodeBlock>
-
 <CodeBlock title="Event log" highlight="{range: 7-8}">
 
 ```txt
@@ -223,7 +129,7 @@ Parameters:
   environment      sandbox
   event_count      3
   event_token      abc123
-  revenue          0.25
+  revenue          0.01
   currency         EUR
 ```
 
@@ -234,66 +140,25 @@ Parameters:
 <CodeBlock title="Property declaration">
 
 ```dart
-String? transactionId;
+String? deduplicationId;
 ```
 
 </CodeBlock>
 
-You can pass an optional identifier to avoid recording duplicate events. The SDK stores the last ten identifiers and skips revenue events with duplicate transaction IDs.
+You can pass an optional identifier to avoid recording duplicate events. By default, the SDK stores the last ten identifiers and skips revenue events with duplicate transaction IDs. In case you would like the SDK to store more than 10 identifiers, you can set the desired number of identifiers by assigning the value to `eventDeduplicationIdsMaxSize` of the `AdjustConfig` instance.
 
-To set the identifier, assign your transaction ID to the `setTransactionId` property of your event instance.
+To set the identifier, assign your deduplcation ID to the `deduplicationId` property of your event instance.
 
 ```dart
+adjustConfig.eventDeduplicationIdsMaxSize = 20;
+Adjust.initSdk(config);
+
+// ...
+
 AdjustEvent myAdjustEvent = new AdjustEvent('abc123');
-//...
-myAdjustEvent.transactionId = '{TransactionId}';
-//...
+myAdjustEvent.deduplicationId = 'deduplication-id';
 Adjust.trackEvent(myAdjustEvent);
 ```
-
-### [Example](example-2)
-
-This example shows how to record an event with the token `g3mfiw` whenever a user interacts with a button. The function sets the `uniqueId` to `5e85484b-1ebc-4141-aab7-25b869e54c49` using the `setTransactionId` method.
-
-<CodeBlock title="util.dart">
-
-```dart
-import 'package:adjust_sdk/adjust_event.dart';
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
-
-class Util {
-   static const String EVENT_TOKEN_REVENUE = 'g3mfiw';
-   static const String UNIQUE_ID = '5e85484b-1ebc-4141-aab7-25b869e54c49';
-
-   static Widget buildCupertinoButton(String text, Function action) {
-      return new CupertinoButton(
-         child: Text(text),
-         color: CupertinoColors.activeBlue,
-         padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 30.0),
-         onPressed: action as void Function()?,
-      );
-   }
-
-   static AdjustEvent myAdjustEvent() {
-      AdjustEvent event = new AdjustEvent(EVENT_TOKEN_REVENUE);
-      event.transactionId = UNIQUE_ID;
-      return event;
-   }
-
-}
-
-// main.dart
-import 'util.dart';
-
-// Send revenue event button.
-Util.buildCupertinoButton('Send Revenue Event',
-   () => Adjust.trackEvent(Util.myAdjustEvent())),
-const Padding(padding: const EdgeInsets.all(7.0))
-
-```
-
-</CodeBlock>
 
 <CodeBlock title="Event log" highlight="{range: 7}">
 
@@ -304,7 +169,7 @@ Parameters:
   environment      sandbox
   event_count      3
   event_token      abc123
-  transaction_id   5e85484b-1ebc-4141-aab7-25b869e54c49
+  transaction_id   deduplication-id
 ```
 
 </CodeBlock>
@@ -327,11 +192,23 @@ Add callback parameters to your event by calling the `addCallbackParameter` meth
 
 ```dart
 AdjustEvent myAdjustEvent = new AdjustEvent('abc123');
-//...
 adjustEvent.addCallbackParameter('key', 'value');
-//...
 Adjust.trackEvent(myAdjustEvent);
 ```
+
+<CodeBlock title="Event log" highlight="{range: 4}">
+
+```txt
+Path:      /event
+ClientSdk: flutter$FLUTTER_VERSION
+Parameters:
+  callback_params  {"key":"value"}
+  environment      sandbox
+  event_count      1
+  event_token      abc123
+```
+
+</CodeBlock>
 
 The Adjust SDK measures the event and sends a request to your URL with the callback parameters. For example, if you register the URL `https://www.mydomain.com/callback`, your callback looks like this:
 
@@ -354,76 +231,6 @@ Adjust supports many placeholders which you can use to pass information from the
 You can read more about using URL callbacks, including a full list of available values, in the [callbacks guide](https://help.adjust.com/en/article/callbacks).
 
 </Callout>
-
-### [Example](example-3)
-
-This example shows how to record an event with the token `g3mfiw` whenever a user interacts with a button. The following callback parameters are added:
-
--  The `event_token`
--  The `revenue_amount` generated by the event
-
-The resulting callback URL looks like this:
-
-<CodeBlock highlight="event_token=g3mfiw, revenue_amount=0.05">
-
-```http
-http://www.mydomain.com/callback?event_token=g3mfiw&revenue_amount=0.05
-```
-
-</CodeBlock>
-
-<CodeBlock title="util.dart">
-
-```dart
-import 'package:adjust_sdk/adjust_event.dart';
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
-
-class Util {
-   static const String EVENT_TOKEN_CALLBACK = 'g3mfiw';
-
-   static Widget buildCupertinoButton(String text, Function action) {
-      return new CupertinoButton(
-         child: Text(text),
-         color: CupertinoColors.activeBlue,
-         padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 30.0),
-         onPressed: action as void Function()?,
-      );
-   }
-
-   static AdjustEvent buildCallbackEvent() {
-      AdjustEvent event = new AdjustEvent(EVENT_TOKEN_CALLBACK);
-         event.addCallbackParameter('event_token', EVENT_TOKEN_CALLBACK);
-         event.addCallbackParameter('revenue_amount', '0.05');
-   return event;
-   }
-
-}
-
-// main.dart
-import 'util.dart';
-
-// Send callback event button.
-Util.buildCupertinoButton('Send Callback Event',
-   () => Adjust.trackEvent(Util.buildCallbackEvent())),
-const Padding(padding: const EdgeInsets.all(7.0))
-```
-
-</CodeBlock>
-
-<CodeBlock title="Event log" highlight="{range: 4}">
-
-```txt
-Path:      /event
-ClientSdk: flutter$FLUTTER_VERSION
-Parameters:
-  callback_params  {"event_token":"g3mfiw","revenue_amount":"0.05"}
-  environment      sandbox
-  event_count      1
-  event_token      g3mfiw
-```
-
-</CodeBlock>
 
 ## [Add partner parameters](add-partner-parameters)
 
@@ -449,57 +256,9 @@ Add partner parameters to your event by calling the `addPartnerParameter` method
 
 ```dart
 AdjustEvent myAdjustEvent = new AdjustEvent('abc123');
-//...
 adjustEvent.addPartnerParameter('key', 'value');
-//...
 Adjust.trackEvent(myAdjustEvent);
 ```
-
-### [Example](example-4)
-
-This example shows how to record an event with the token `g3mfiw` whenever a user interacts with a button. The following partner parameters are added:
-
--  The `product_id` of the associated product
--  The `user_id` of the user who triggered the event
-
-<CodeBlock title="util.dart">
-
-```dart
-import 'package:adjust_sdk/adjust_event.dart';
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
-
-class Util {
-   static const String EVENT_TOKEN_PARTNER = 'g3mfiw';
-
-   static Widget buildCupertinoButton(String text, Function action) {
-      return new CupertinoButton(
-         child: Text(text),
-         color: CupertinoColors.activeBlue,
-         padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 30.0),
-         onPressed: action as void Function()?,
-      );
-   }
-
-   static AdjustEvent buildPartnerEvent() {
-      AdjustEvent event = new AdjustEvent(EVENT_TOKEN_PARTNER);
-      event.addPartnerParameter('product_id', '29');
-      event.addPartnerParameter('user_id', '835');
-      return event;
-   }
-
-}
-
-// main.dart
-import 'util.dart';
-
-// Send partner event button.
-Util.buildCupertinoButton('Send Partner Event',
-   () => Adjust.trackEvent(Util.buildPartnerEvent())),
-const Padding(padding: const EdgeInsets.all(7.0))
-```
-
-</CodeBlock>
 
 <CodeBlock title="Event log" highlight="{range: 4}">
 
@@ -507,13 +266,11 @@ const Padding(padding: const EdgeInsets.all(7.0))
 Path:      /event
 ClientSdk: flutter$FLUTTER_VERSION
 Parameters:
-  partner_params  {"product_id":"29","user_id":"835"}
+  partner_params  {"key":"value"}
   environment      sandbox
   event_count      1
-  event_token      g3mfiw
+  event_token      abc123
 ```
-
-</CodeBlock>
 
 ## [Add a callback identifier](add-a-callback-identifier)
 
@@ -531,56 +288,9 @@ Set up this identifier by assigning your ID to the `callbackId` property on your
 
 ```dart
 AdjustEvent myAdjustEvent = new AdjustEvent('abc123');
-//...
-myAdjustEvent.callbackId = '{your_callback_id}';
-//...
+myAdjustEvent.callbackId = 'your-callback-id';
 Adjust.trackEvent(myAdjustEvent);
 ```
-
-### [Example](example-5)
-
-This example shows how to record an event with the token `g3mfiw` whenever a user interacts with a button. In this example, the `callbackId` is set to `f2e728d8-271b-49ab-80ea-27830a215147`.
-
-<CodeBlock title="util.dart">
-
-<CodeBlock title="util.dart">
-
-```dart
-import 'package:adjust_sdk/adjust_event.dart';
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
-
-class Util {
-   static const String EVENT_TOKEN_SIMPLE = 'g3mfiw';
-   static const String CALLBACK_ID = "f2e728d8-271b-49ab-80ea-27830a215147"
-
-   static Widget buildCupertinoButton(String text, Function action) {
-      return new CupertinoButton(
-         child: Text(text),
-         color: CupertinoColors.activeBlue,
-         padding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 30.0),
-         onPressed: action as void Function()?,
-      );
-   }
-
-   static AdjustEvent myAdjustEvent() {
-      AdjustEvent event = new AdjustEvent(EVENT_TOKEN_SIMPLE);
-      event.callbackId = CALLBACK_ID;
-      return event;
-}
-
-// main.dart
-import 'util.dart';
-
-Util.buildCupertinoButton('Send Callback Event',
-   () => Adjust.trackEvent(Util.myAdjustEvent())),
-const Padding(padding: const EdgeInsets.all(7.0))
-
-```
-
-</CodeBlock>
-
-</CodeBlock>
 
 <CodeBlock title="Event log" highlight="{range: 7}">
 
@@ -590,8 +300,9 @@ ClientSdk: flutter$FLUTTER_VERSION
 Parameters:
   environment      sandbox
   event_count      3
-  event_token      g3mfiw
-  callback_id      f2e728d8-271b-49ab-80ea-27830a215147
+  event_token      abc123
+  callback_id      your-callback-id
 ```
 
 </CodeBlock>
+

--- a/src/content/docs/sdk/flutter/features/events.mdx
+++ b/src/content/docs/sdk/flutter/features/events.mdx
@@ -170,10 +170,10 @@ Adjust.trackEvent(myAdjustEvent);
 Path:      /event
 ClientSdk: flutter$FLUTTER_VERSION
 Parameters:
-  environment      sandbox
-  event_count      3
-  event_token      abc123
-  transaction_id   deduplication-id
+  environment        sandbox
+  event_count        3
+  event_token        abc123
+  deduplication_id   deduplication-id
 ```
 
 </CodeBlock>


### PR DESCRIPTION
I have tried to clean up the event section for Flutter SDK v5. Things to keep in mind:

- I have updated the syntax to match Flutter SDK v5.
- I don't know how to create v4/v5 toggles, so you guys need to do that.
- I have also went with removal of bigger example code snippets which to me personally looked like too cumbersome -> too many clutter code from Flutter app which is not that important for the logic itself. So what I did was just to use log output (which I think is nice to have!) and just added it below most basic code snippet which is showcasing the usage of the certain API.

In case you are not fancying these changes (that are not related to the SDK v5 API itself), feel free to alter them as you wish.