### PR TITLE
Make version fetch markup-independent

### DIFF
--- a/src/integrations/fetchSdkVersions.ts
+++ b/src/integrations/fetchSdkVersions.ts
@@ -28,15 +28,15 @@ type GraphQLResponse = {
 };
 
 let versionReplacements: VersionMap = {
-  android: { v4: "vx.x.x", v5: "vx.x.x" },
-  ios: { v4: "vx.x.x", v5: "vx.x.x" },
-  unity: { v4: "vx.x.x", v5: "vx.x.x" },
-  react_native: { v4: "vx.x.x", v5: "vx.x.x" },
-  cordova: { v4: "vx.x.x", v5: "vx.x.x" },
-  flutter: { v4: "vx.x.x", v5: "vx.x.x" },
-  cocos2dx: { v4: "vx.x.x", v5: "vx.x.x" },
-  web: "vx.x.x",
-  windows: "vx.x.x",
+  android: { v4: "x.x.x", v5: "x.x.x" },
+  ios: { v4: "x.x.x", v5: "x.x.x" },
+  unity: { v4: "x.x.x", v5: "x.x.x" },
+  react_native: { v4: "x.x.x", v5: "x.x.x" },
+  cordova: { v4: "x.x.x", v5: "x.x.x" },
+  flutter: { v4: "x.x.x", v5: "x.x.x" },
+  cocos2dx: { v4: "x.x.x", v5: "x.x.x" },
+  web: "x.x.x",
+  windows: "x.x.x",
 };
 
 /**
@@ -86,8 +86,8 @@ export async function fetchVersions() {
             const response = await octokit.graphql<GraphQLResponse>(query);
 
             // Extract the first v4 and v5 tag names
-            const firstV4Tag = response.v4Tags.refs.edges[0]?.node.name || "Not found";
-            const firstV5Tag = response.v5Tags.refs.edges[0]?.node.name || "Not found";
+            const firstV4Tag = response.v4Tags.refs.edges[0]?.node.name.replace("v", "") || "Not found";
+            const firstV5Tag = response.v5Tags.refs.edges[0]?.node.name.replace("v", "") || "Not found";
 
             currentPlatform.v4 = firstV4Tag;
             currentPlatform.v5 = firstV5Tag;
@@ -112,7 +112,7 @@ export async function fetchVersions() {
             `;
 
             const response = await octokit.graphql<GraphQLResponse>(query);
-            versionReplacements[platform] = response.latestTag?.refs.edges[0]?.node.name || "Not found";
+            versionReplacements[platform] = response.latestTag?.refs.edges[0]?.node.name.replace("v", "") || "Not found";
           }
         }
       );

--- a/src/integrations/remarkReplaceVersions.ts
+++ b/src/integrations/remarkReplaceVersions.ts
@@ -17,12 +17,11 @@ const replaceTemplateStringsPlugin: Plugin<[VersionMap]> = (options) => {
 
          for (const [platform, currentPlatform] of Object.entries(versions)) {
             if (typeof currentPlatform === 'string') {
-               const replacementValue = currentPlatform.substring(1); // Remove leading "v"
                const oldValue = new RegExp(`\\$${platform.toUpperCase()}_VERSION`, 'g');
-               newValue = newValue.replace(oldValue, replacementValue);
+               newValue = newValue.replace(oldValue, currentPlatform);
             } else {
-               const v4ReplacementValue = currentPlatform.v4.substring(1); // Remove leading "v"
-               const v5ReplacementValue = currentPlatform.v5.substring(1); // Remove leading "v"
+               const v4ReplacementValue = currentPlatform.v4;
+               const v5ReplacementValue = currentPlatform.v5;
                const v4OldValue = new RegExp(`\\$${platform.toUpperCase()}_V4_VERSION`, 'g');
                const v5OldValue = new RegExp(`\\$${platform.toUpperCase()}_V5_VERSION`, 'g');
                newValue = newValue.replace(v4OldValue, v4ReplacementValue);


### PR DESCRIPTION
Currently, the version fetch logic has an extra step to strip the leading "v" in the remark plugin. For Markdoc, this needs to be stripped before it's written to a file. To make this step work for both MDX and Markdoc, this PR:

- [x] Adds a step to remove the "v" during the fetch process
- [x] Removes the "v" stripping step from the remark plugin

With this setup, the following markup works for MDX:

````mdx
```js
var foo = "$ANDROID_V5_VERSION";
```
````

And the following for Mdoc:

````md
```js
var foo = "{% $versions.android.v5 %}";
```
````