### PR TITLE
Nonexistent locale redirect

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Page Not Found</title>
     <script>
-      // Redirect to the appropriate 404 page based on browser language
       const supportedLanguages = {
         ja: "/ja/404",
         ko: "/ko/404",
@@ -13,17 +12,29 @@
         en: "/en/404",
       };
 
-      const userLanguages = navigator.languages || [navigator.language];
-      const matchedLang = userLanguages.find((lang) =>
-        supportedLanguages.hasOwnProperty(lang.split("-")[0]),
-      );
+      const pathLang = window.location.pathname.split("/")[1];
+      const isSupportedLang =
+        Object.keys(supportedLanguages).includes(pathLang);
 
-      if (matchedLang) {
-        const langPrefix = matchedLang.split("-")[0];
-        window.location.replace(supportedLanguages[langPrefix]);
+      // If the locale in the URL is unsupported, redirect to English
+      if (!isSupportedLang) {
+        const urlSegments = window.location.pathname.split("/");
+        urlSegments[1] = "en"; // Change locale to "en"
+        window.location.replace(urlSegments.join("/"));
       } else {
-        // Default to English if no match
-        window.location.replace(supportedLanguages["en"]);
+        // If the locale is supported but still hitting 404, redirect based on browser language
+        const userLanguages = navigator.languages || [navigator.language];
+        const matchedLang = userLanguages.find((lang) =>
+          supportedLanguages.hasOwnProperty(lang.split("-")[0]),
+        );
+
+        if (matchedLang) {
+          const langPrefix = matchedLang.split("-")[0];
+          window.location.replace(supportedLanguages[langPrefix]);
+        } else {
+          // Default to English if no match
+          window.location.replace(supportedLanguages["en"]);
+        }
       }
     </script>
   </head>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,8 +1,19 @@
-import { defineMiddleware } from "astro/middleware";
+import { defineMiddleware, sequence } from "astro/middleware";
 
 const languages = ["en", "ja", "ko", "zh"]
 
-export const onRequest = defineMiddleware(async (context, next) => {
+const noLocale = defineMiddleware(async (context, next) => {
+   const response = await next();
+   const pathLang = context.url.pathname.split("/")[1]
+   if (!languages.includes(pathLang)) {
+      let newUrl = context.url.pathname.split("/");
+      newUrl.splice(1, 1, "en");
+      return context.redirect(newUrl.join("/"))
+   }
+   return response;
+})
+
+const notFound = defineMiddleware(async (context, next) => {
    const response = await next();
    const pathLang = context.url.pathname.split("/")[1]
    if (response.status === 404) {
@@ -11,3 +22,5 @@ export const onRequest = defineMiddleware(async (context, next) => {
    }
    return response;
 })
+
+export const onRequest = sequence(noLocale, notFound)


### PR DESCRIPTION
Currently, if you hit a nonexistent locale such as `fr` or `es`, you will get a 404. Instead, we should initially try to push users to the `en` root. If that doesn't exist, then a 404 can be shown.