### PR TITLE
Reformat iOS & Android instructions Tabs as standard sections

### DIFF
--- a/src/content/docs/en/sdk/unity/v4/index.mdoc
+++ b/src/content/docs/en/sdk/unity/v4/index.mdoc
@@ -16,13 +16,11 @@ redirects:
 
 The Adjust Unity SDK enables you to record attribution, events, and more in your Unity app. Follow the steps in this guide to set up your app to work with the Adjust SDK.
 
-<Callout type="note">
-
+{% callout type="note" %}
 The Adjust SDK supports iOS 9 or later and Android API level 9 (Gingerbread) or later.
+{% /callout %}
 
-</Callout>
-
-## 1. Get the Adjust SDK {#get-the-adjust-sdk}
+## 1. Get the Adjust SDK  {% #get-the-adjust-sdk %}
 
 To use the Adjust SDK in your Unity app, you need to add it to your project. You can download the latest version from the [GitHub releases page](https://github.com/adjust/adjust_unity_sdk/releases/latest).
 
@@ -32,7 +30,7 @@ To import the Adjust SDK to your Unity project:
 2. Select **Assets --> Import Package --> Custom Package**.
 3. Select the downloaded SDK package.
 
-## 2. Integrate the SDK {#integrate-the-sdk}
+## 2. Integrate the SDK {% #integrate-the-sdk %}
 
 The Adjust SDK contains a Unity [prefab](https://docs.unity3d.com/Manual/Prefabs.html) that includes a template game object and an Adjust script. You can use this script to configure the SDK. To open the prefab in the Unity editor:
 
@@ -58,15 +56,14 @@ AdjustConfig adjustConfig = new AdjustConfig("{YourAppToken}", AdjustEnvironment
 Adjust.start(adjustConfig);
 ```
 
-## 3. Set up Android devices {#set-up-android-devices}
+## 3. Set up Android devices {% #set-up-android-devices %}
 
-### Add Google Play Services {#add-google-play-services}
+### Add Google Play Services {% #add-google-play-services %}
 
 Apps that target the Google Play Store must use the gps_adid (Google Advertising ID) to identify devices. You need to add the `play-services-ads-identifier` AAR to your project to access the `gps_adid`.
 
-<Tabs>
-<Tab title="External Dependency Manager" sync="google">
-
+{% tabs %}
+{% tab title="External Dependency Manager" sync="edm4u" %}
 If you are using the [External Dependency Manager plugin](https://developers.google.com/unity/archive#external_dependency_manager_for_unity), add the following to your `Dependencies.xml` file:
 
 ```xml
@@ -74,22 +71,19 @@ If you are using the [External Dependency Manager plugin](https://developers.goo
    <androidPackage spec="com.google.android.gms:play-services-ads-identifier:18.0.1" />
 </androidPackages>
 ```
+{% /tab %}
 
-</Tab>
-<Tab title="Manual installation" sync="manual">
-
+{% tab title="Manual installation" sync="manual" %}
 To install the ARR (Android Archive) manually, [download it from Maven](https://maven.google.com/web/index.html#com.google.android.gms:play-services-ads-identifier:18.0.1 "A link to the AAR artifact on Maven.") and add it to the `Assets/Plugins/Android` directory.
+{% /tab %}
+{% /tabs %}
 
-</Tab>
-</Tabs>
-
-### Collect App Set Identifier {#collect-app-set-identifier}
+### Collect App Set Identifier {% #collect-app-set-identifier %}
 
 The [App Set Identifier](https://developer.android.com/design-for-safety/privacy-sandbox/reference/adservices/appsetid/AppSetId) is a unique identifier that enables you to measure information from any of your apps that a user has installed on their device. All apps by the same developer share the same App Set ID, meaning you can gather meaningful insights from users across all your apps.
 
-<Tabs>
-<Tab title="External Dependency Manager" sync="google">
-
+{% tabs %}
+{% tab title="External Dependency Manager" sync="edm4u" %}
 To record a device's App Set ID, you need to add the following dependency to your `Dependencies.xml` file:
 
 ```xml
@@ -97,16 +91,14 @@ To record a device's App Set ID, you need to add the following dependency to you
    <androidPackage spec="com.google.android.gms:play-services-appset:16.0.2" />
 </androidPackages>
 ```
+{% /tab %}
 
-</Tab>
-<Tab title="Manual installation" sync="manual">
-
+{% tab title="Manual installation" sync="manual" %}
 To install the ARR (Android Archive) manually, [download it from Maven](https://maven.google.com/web/index.html#com.google.android.gms:play-services-appset:16.0.2 "A link to the AAR artifact on Maven.") and add it to the `Assets/Plugins/Android` directory.
+{% /tab %}
+{% /tabs %}
 
-</Tab>
-</Tabs>
-
-### Set up Proguard {#set-up-proguard}
+### Set up Proguard {% #set-up-proguard %}
 
 If you are using Proguard, add the following rules to your [custom Proguard file](https://docs.unity3d.com/Manual/class-PlayerSettingsAndroid.html#build).
 
@@ -125,55 +117,57 @@ If you are using Proguard, add the following rules to your [custom Proguard file
 -keep public class com.android.installreferrer.** { *; }
 ```
 
-### Set up install referrer {#set-up-install-referrer}
+### Set up install referrer {% #set-up-install-referrer %}
 
 The install referrer is a unique identifier which you can use to attribute an app install to a source. The Adjust SDK requires this information to perform attribution. There are two methods you can use to gather this information depending on which stores you target:
 
 -  Use the [Google Play Referrer API](https://developer.android.com/google/play/installreferrer).
 -  Use the Huawei Referrer API.
 
-#### Google Play Referrer API {#google-play-referrer-api}
+#### Google Play Referrer API {% #google-play-referrer-api %}
 
 There are 2 ways to add support for the Google Play Referrer API:
 
-1. Add the install referrer library as a dependency in a [custom `build.gradle` file](https://docs.unity3d.com/2023.1/Documentation/Manual/android-gradle-overview.html)
+{% tabs %}
+{% tab title="External Dependency Manager" sync="edm4u" %}
+Add the install referrer library as a dependency in a [custom `build.gradle` file](https://docs.unity3d.com/2023.1/Documentation/Manual/android-gradle-overview.html)
 
 ```groovy
 dependencies {
    implementation 'com.android.installreferrer:installreferrer:2.2'
 }
 ```
+{% /tab %}
 
-2. Download the install referrer library from [Maven](https://maven.google.com/web/index.html?q=install#com.android.installreferrer:installreferrer) and put the ARR (Android Archive) file in your `Plugins/Android` folder.
+{% tab title="Manual installation" sync="manual" %}
+Download the install referrer library from [Maven](https://maven.google.com/web/index.html?q=install#com.android.installreferrer:installreferrer) and put the ARR (Android Archive) file in your `Plugins/Android` folder.
+{% /tab %}
+{% /tabs %}
 
-#### Huawei Referrer API {#huawei-referrer-api}
+#### Huawei Referrer API {% #huawei-referrer-api %}
 
 As of v4.21.1, the Adjust SDK supports install measurement on Huawei devices using Huawei App Gallery v10.4 and later. You don't need to make any changes to start using the Huawei Referrer API.
 
-#### Meta referrer integration {#meta-referrer-integration}
+#### Meta referrer integration {% #meta-referrer-integration %}
 
-<MinorVersion added="v4.36.0">
-
+{% minorversion added="v4.36.0" %}
 The Adjust SDK supports the [Meta Install Referrer](https://developers.facebook.com/docs/app-ads/meta-install-referrer) in v4.36.0 and above. To enable this feature:
-
-</MinorVersion>
+{% /minorversion %}
 
 1. Find your Meta app ID in your [App Dashboard](https://developers.facebook.com/apps). See Meta's [App Dashboard documentation](https://developers.facebook.com/docs/development/create-an-app/app-dashboard) for more information.
 2. [Add the Meta apps to your `AndroidManifest.xml` file](https://developers.facebook.com/docs/app-ads/meta-install-referrer#step-1--add-the-meta-apps).
 
-<CodeBlock title="AndroidManifest.xml">
+   {% codeblock title="AndroidManifest.xml" %}
+   ```xml
+   <queries>
+      <package android:name="com.facebook.katana" />
+   </queries>
 
-```xml
-<queries>
-   <package android:name="com.facebook.katana" />
-</queries>
-
-<queries>
-   <package android:name="com.instagram.android" />
-</queries>
-```
-
-</CodeBlock>
+   <queries>
+      <package android:name="com.instagram.android" />
+   </queries>
+   ```
+   {% /codeblock %}
 
 3. Pass your App ID as a `string` argument to the `AdjustConfig.setFbAppId` method.
 
@@ -185,13 +179,11 @@ The Adjust SDK supports the [Meta Install Referrer](https://developers.facebook.
    Adjust.start(config);
    ```
 
-## 4. Add the iOS privacy manifest {#add-the-ios-privacy-manifest}
+## 4. Add the iOS privacy manifest {% #add-the-ios-privacy-manifest %}
 
-<MinorVersion added="v4.38.0">
-
+{% minorversion added="v4.38.0" %}
 iOS 17 introduced [Privacy manifests](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files), a mechanism that informs the App Store of your app's privacy requirements. The Adjust Unity SDK doesn't bundle this Privacy manifest file, so you need to ensure the contents of the Adjust iOS SDK Privacy manifest file are present in your app's Privacy manifest if your app targets devices running iOS 17 or later.
-
-</MinorVersion>
+{% /minorversion %}
 
 To add the Adjust Privacy manifest:
 
@@ -202,7 +194,7 @@ To add the Adjust Privacy manifest:
 
 When you submit your app to the App Store, Adjust's privacy declarations are included with your app.
 
-## 5. Build your app {#build-your-app}
+## 5. Build your app {% #build-your-app %}
 
 To complete the app build process, the Adjust Unity package performs custom post-build actions to ensure the Adjust SDK works in your app.
 
@@ -210,13 +202,11 @@ This process is performed by the `OnPostprocessBuild` method in `AdjustEditor.cs
 
 ![A screenshot of the Adjust SDK post-build configuration script in the Unity editor.](@images/unity/2-postbuild.png)
 
-### iOS {#ios}
+### iOS {% #ios %}
 
-<Callout type="important">
-
+{% callout type="important" %}
 To run the iOS post-build process, make sure that you have **iOS build support** installed in the Unity Editor.
-
-</Callout>
+{% /callout %}
 
 The iOS post-build process makes the following changes to your generated Xcode project:
 
@@ -245,7 +235,7 @@ To enable deep linking, add the following information:
 -  **iOS URL Identifier**: Your app's bundle ID.
 -  **iOS URL Schemes**: The URL scheme associated with your app.
 
-### Android {#android}
+### Android {% #android %}
 
 The Android post-build process checks for an `AndroidManifest.xml` file in `Assets/Plugins/Android/`. If this file isn't present, it creates a copy from [`AdjustAndroidManifest.xml`](https://github.com/adjust/unity_sdk/blob/master/Assets/Adjust/Native/Android/AdjustAndroidManifest.xml "A link to the AdjustAndroidManifest file on GitHub").
 
@@ -264,19 +254,17 @@ To enable deep linking, add the following information:
 
 **Android URI Schemes**: The destination of your deep link.
 
-## 6. Add the Adjust SDK signature {#add-the-adjust-sdk-signature}
+## 6. Add the Adjust SDK signature {% #add-the-adjust-sdk-signature %}
 
 You can use the Adjust SDK signature to sign all communications sent by the Adjust SDK. This enables Adjust’s servers to detect and reject any install activity that's not legitimate.
 
 To get started with the Adjust SDK signature, contact your Technical Account Manager or support@adjust.com.
 
-## 7. Test your integration {#test-your-integration}
+## 7. Test your integration {% #test-your-integration %}
 
-<Callout type="tip">
-
+{% callout type="tip" %}
 If you encounter any issues, email support@adjust.com with all details and logs.
-
-</Callout>
+{% /callout %}
 
 The Adjust SDK provides tools for testing and troubleshooting issues with your integration. To test your setup:
 
@@ -284,7 +272,7 @@ The Adjust SDK provides tools for testing and troubleshooting issues with your i
 -  Add a sandbox filter to your Adjust dashboard results.
 -  Set your [log level](/en/sdk/unity/configuration#set-your-logging-level) to `AdjustLogLevel.Verbose`.
 
-### Test Google Play Services integration {#test-google-play-services-integration}
+### Test Google Play Services integration {% #test-google-play-services-integration %}
 
 To test that the Adjust SDK can receive a device's Google Advertising ID, set the [log level](/en/sdk/unity/configuration#set-your-logging-level) to `AdjustLogLevel.Verbose` and the environment to `AdjustEnvironment.sandbox`. Start your app and measure a `session` or an event. The SDK logs the gps_adid (Google Play Services Advertiser ID) parameter if it has read the advertising ID.
 

--- a/src/content/docs/en/sdk/unity/v4/index.mdx
+++ b/src/content/docs/en/sdk/unity/v4/index.mdx
@@ -210,8 +210,7 @@ This process is performed by the `OnPostprocessBuild` method in `AdjustEditor.cs
 
 ![A screenshot of the Adjust SDK post-build configuration script in the Unity editor.](@images/unity/2-postbuild.png)
 
-<Tabs>
-<Tab title="iOS" icon="PlatformIos">
+### iOS {#ios}
 
 <Callout type="important">
 
@@ -224,7 +223,7 @@ The iOS post-build process makes the following changes to your generated Xcode p
 -  Adds the other linker flag `-ObjC`: required to recognize Adjust Objective-C categories at build time.
 -  Enables Objective-C exceptions.
 
-#### Frameworks {#frameworks}
+#### Frameworks
 
 You can enable the following frameworks to access iOS features:
 
@@ -234,11 +233,11 @@ You can enable the following frameworks to access iOS features:
 -  `StoreKit.framework`: Required to communicate with the SKAdNetwork framework.
 -  `iAd.framework` **Deprecated**: Use `AdServices.framework`
 
-#### App Tracking Transparency consent dialog {#app-tracking-transparency-consent-dialog}
+#### App Tracking Transparency consent dialog
 
 If you are using the ATT (App Tracking Transparency) wrapper, enter a **User Tracking Description** message. This displays when you present the ATT consent dialog to your user.
 
-#### Deep linking {#deep-linking}
+#### Deep linking
 
 To enable deep linking, add the following information:
 
@@ -246,12 +245,11 @@ To enable deep linking, add the following information:
 -  **iOS URL Identifier**: Your app's bundle ID.
 -  **iOS URL Schemes**: The URL scheme associated with your app.
 
-</Tab>
-<Tab title="Android" icon="PlatformAndroid">
+### Android {#android}
 
 The Android post-build process checks for an `AndroidManifest.xml` file in `Assets/Plugins/Android/`. If this file isn't present, it creates a copy from [`AdjustAndroidManifest.xml`](https://github.com/adjust/unity_sdk/blob/master/Assets/Adjust/Native/Android/AdjustAndroidManifest.xml "A link to the AdjustAndroidManifest file on GitHub").
 
-#### Permissions {#permissions}
+#### Permissions
 
 You can enable the following permissions to access Android features:
 
@@ -260,14 +258,11 @@ You can enable the following permissions to access Android features:
 -  `com.android.finsky.permission.BIND_GET_INSTALL_REFERRER_SERVICE` **Deprecated**: Required to fetch install referrer information via Google Play Store intent.
 -  `com.google.android.gms.permission.AD_ID`: Required to read the device advertising ID on Android 12 (API level 31) and above. See [Google's `AdvertisingIdClient.info` documentation](https://developers.google.com/android/reference/com/google/android/gms/ads/identifier/AdvertisingIdClient.Info#public-string-getid) for more information.
 
-#### Deep linking {#deep-linking-1}
+#### Deep linking
 
 To enable deep linking, add the following information:
 
 **Android URI Schemes**: The destination of your deep link.
-
-</Tab>
-</Tabs>
 
 ## 6. Add the Adjust SDK signature {#add-the-adjust-sdk-signature}
 

--- a/src/content/docs/en/sdk/unity/v5/index.mdoc
+++ b/src/content/docs/en/sdk/unity/v5/index.mdoc
@@ -158,8 +158,8 @@ You can configure post-build options to customize your app build.
 
 ![A screenshot of the Adjust SDK post-build configuration script in the Unity editor.](@images/unity/2-postbuild.png)
 
-{% tabs %}
-{% tab title="iOS" icon="PlatformIos" %}
+### iOS {% #ios %}
+
 {% callout type="important" %}
 To run the iOS post-build process, make sure that you have **iOS build support** installed in the Unity Editor.
 {% /callout %}
@@ -168,7 +168,7 @@ The iOS post-build process makes the following changes to your generated Xcode p
 
 - Enables Objective-C exceptions.
 
-#### Frameworks {% #frameworks %}
+#### Frameworks
 
 You can enable the following frameworks to access iOS features:
 
@@ -177,23 +177,23 @@ You can enable the following frameworks to access iOS features:
 - `AppTrackingTransparency.framework`: Required to ask for user's consent to be measured and obtain consent status
 - `StoreKit.framework`: Required to communicate with the SKAdNetwork framework.
 
-#### App Tracking Transparency consent dialog {% #app-tracking-transparency-consent-dialog %}
+#### App Tracking Transparency consent dialog
 
 If you are using the ATT (App Tracking Transparency) wrapper, enter a **User Tracking Description** message. This displays when you present the ATT consent dialog to your user.
 
-#### Deep linking {% #deep-linking %}
+#### Deep linking
 
 To enable deep linking, add the following information:
 
 - **iOS Universal Links Domain**: The associated domain used for universal links.
 - **iOS URL Identifier**: Your app's bundle ID.
 - **iOS URL Schemes**: The URL scheme associated with your app.
-{% /tab %}
 
-{% tab title="Android" icon="PlatformAndroid" %}
+### Android {%#android%}
+
 The Android post-build process checks for an `AndroidManifest.xml` file in `Assets/Plugins/Android/`. If this file isn't present, it creates a copy from [`AdjustAndroidManifest.xml`](https://github.com/adjust/unity_sdk/blob/master/Assets/Adjust/Native/Android/AdjustAndroidManifest.xml "A link to the AdjustAndroidManifest file on GitHub").
 
-#### Permissions {% #permissions %}
+#### Permissions
 
 You can enable the following permissions to access Android features:
 
@@ -202,13 +202,11 @@ You can enable the following permissions to access Android features:
 - `com.android.finsky.permission.BIND_GET_INSTALL_REFERRER_SERVICE` **Deprecated**: Required to fetch install referrer information via Google Play Store intent.
 - `com.google.android.gms.permission.AD_ID`: Required to read the device advertising ID on Android 12 (API level 31) and above. See [Google's `AdvertisingIdClient.info` documentation](https://developers.google.com/android/reference/com/google/android/gms/ads/identifier/AdvertisingIdClient.Info#public-string-getid) for more information.
 
-#### Deep linking {% #deep-linking-1 %}
+#### Deep linking
 
 To enable deep linking, add the following information:
 
 **Android URI Schemes**: The destination of your deep link.
-{% /tab %}
-{% /tabs %}
 
 The output of the process is shown in the Unity IDE console window.
 

--- a/src/content/docs/en/sdk/unity/v5/index.mdoc
+++ b/src/content/docs/en/sdk/unity/v5/index.mdoc
@@ -189,7 +189,7 @@ To enable deep linking, add the following information:
 - **iOS URL Identifier**: Your app's bundle ID.
 - **iOS URL Schemes**: The URL scheme associated with your app.
 
-### Android {%#android%}
+### Android {% #android %}
 
 The Android post-build process checks for an `AndroidManifest.xml` file in `Assets/Plugins/Android/`. If this file isn't present, it creates a copy from [`AdjustAndroidManifest.xml`](https://github.com/adjust/unity_sdk/blob/master/Assets/Adjust/Native/Android/AdjustAndroidManifest.xml "A link to the AdjustAndroidManifest file on GitHub").
 


### PR DESCRIPTION
## Related issues

<!-- What issue does this pull request resolve? Add a link to a Jira or GitHub issue. -->

- Jira issue link: [ADAPP-18952](https://adjustcom.atlassian.net/browse/ADAPP-18952)

## Changes

<!-- What does this PR change? Give a short summary. -->
In the Unity integration app, under Build your app, there were tabs for iOS and Android. Both have internal headings with the same “names” and anchor links, creating a weird duplication/broken links in the internal ToC (the one on the right).

Extracted the iOS & Android instructions into standard sections in the document, and deleted the `tabs` component.

## Required translations

<!-- If your change affects SDK documentation, make sure you group your changes by localization requirement. For example, if you need to change iOS, Android, Unity, and React Native, you need to put the React Native changes in their own PR to split up the localization job. -->

No text changed.

[ADAPP-18952]: https://adjustcom.atlassian.net/browse/ADAPP-18952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ