### PR TITLE
THC 1084 double slash in footer links

### DIFF
--- a/src/components/HeadSEO.astro
+++ b/src/components/HeadSEO.astro
@@ -4,10 +4,14 @@ import { SITE, OPEN_GRAPH } from "../consts";
 import { useTranslations } from "@i18n/utils";
 import type { Locales } from "@i18n/locales";
 
-type Props = Partial<{ canonicalUrl: URL } & CollectionEntry<"docs">["data"]>;
+type Props = Partial<
+  { canonicalUrl: URL; pageTitle: string } & CollectionEntry<"docs">["data"]
+>;
 
-const { ogLocale, image, title, description, canonicalUrl } = Astro.props;
-const formattedContentTitle = `${title}`;
+const { ogLocale, image, title, description, canonicalUrl, pageTitle } =
+  Astro.props;
+
+const formattedContentTitle = `${title ?? pageTitle}`;
 const imageSrc = image?.src ?? OPEN_GRAPH.image.src;
 const canonicalImageSrc = new URL(imageSrc, Astro.site);
 const imageAlt = image?.alt ?? OPEN_GRAPH.image.alt;

--- a/src/components/Layout/Footer/static.ts
+++ b/src/components/Layout/Footer/static.ts
@@ -3,20 +3,26 @@ import { ui } from "@i18n/ui";
 
 interface FooterLinks {
   id: keyof (typeof ui)[typeof defaultLang];
-  url: string
+  url: string;
 }
 
 export const footerLinks = (language: string): FooterLinks[] => {
-  let lang = "";
+  let langPath = "";
   if (language !== "en") {
-    lang = language
+    langPath = `/${language}`;
   }
   return [
-    { id: "footer.about-us", url: `https://www.adjust.com/${lang}/company/` },
-    { id: "footer.security", url: `https://www.adjust.com/${lang}/security/` },
+    {
+      id: "footer.about-us",
+      url: `https://www.adjust.com${langPath}/company/`,
+    },
+    {
+      id: "footer.security",
+      url: `https://www.adjust.com${langPath}/security/`,
+    },
     {
       id: "footer.privacy-policy",
-      url: `https://www.adjust.com/${lang}/terms/privacy-policy/`,
+      url: `https://www.adjust.com${langPath}/terms/privacy-policy/`,
     },
     {
       id: "footer.terms",
@@ -25,10 +31,10 @@ export const footerLinks = (language: string): FooterLinks[] => {
     { id: "footer.ccpa-gdpr", url: `https://www.adjust.com/terms/ccpa/` },
     {
       id: "footer.legal-notice",
-      url: `https://www.adjust.com/${lang}/terms/impressum/`,
+      url: `https://www.adjust.com${langPath}/terms/impressum/`,
     },
   ];
-}
+};
 
 export const footerIcons = [
   {
@@ -36,9 +42,21 @@ export const footerIcons = [
     readableName: "WeChat",
     link: "https://mp.weixin.qq.com/mp/profile_ext?action=home&__biz=MzIzODg5ODQwMg==",
   },
-  { name: "facebook-icon", readableName: "Facebook", link: "https://www.facebook.com/adjustcom" },
-  { name: "twitter-icon", readableName: "Twitter", link: "https://twitter.com/adjustcom" },
-  { name: "instagram-icon", readableName: "Instagram", link: "https://www.instagram.com/adjustcom/" },
+  {
+    name: "facebook-icon",
+    readableName: "Facebook",
+    link: "https://www.facebook.com/adjustcom",
+  },
+  {
+    name: "twitter-icon",
+    readableName: "Twitter",
+    link: "https://twitter.com/adjustcom",
+  },
+  {
+    name: "instagram-icon",
+    readableName: "Instagram",
+    link: "https://www.instagram.com/adjustcom/",
+  },
   {
     name: "linkedin-icon",
     readableName: "LinkedIn",

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -34,14 +34,15 @@ const topCategories = [
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const t = useTranslations(lang as keyof Locales);
+const pageTitle = t("site.title");
 ---
 
 <html dir={`/${lang}`} lang={lang} class="initial">
   <head>
     <HeadCommon />
-    <HeadSEO canonicalUrl={canonicalURL} />
+    <HeadSEO pageTitle={pageTitle} canonicalUrl={canonicalURL} />
     <title>
-      {t("site.title")}
+      {pageTitle}
     </title>
   </head>
   <body class="font-body xs:w-full xxl:w-[1600px] mx-auto bg-body-main">

--- a/src/pages/[lang]/search.astro
+++ b/src/pages/[lang]/search.astro
@@ -38,14 +38,15 @@ const helpCenterTypesenseKeys = {
 };
 
 const t = useTranslations(currentLang as keyof Locales);
+const pageTitle = `Search | ${t("site.title")}`;
 ---
 
 <html dir={`/${lang}`} lang={lang} class="initial">
   <head>
     <HeadCommon />
-    <HeadSEO canonicalUrl={canonicalURL} />
+    <HeadSEO pageTitle={pageTitle} canonicalUrl={canonicalURL} />
     <title>
-      {`Search | ${t("site.title")}`}
+      {pageTitle}
     </title>
   </head>
   <body class="font-body xs:w-full xxl:w-[1600px] mx-auto bg-body-main">


### PR DESCRIPTION
## Related issues

- Jira issue link: https://adjustcom.atlassian.net/browse/THC-1084
- GitHub issue link:

## Changes

- Fixed double slash for the Adjust links in the Footer
- Fixed error when "undefined" is shown instead of the page title for the Main and Search pages
![image](https://github.com/user-attachments/assets/d865e521-8103-445c-87f4-ca7019460ae5)

