### PR TITLE
[FECORE-628] s2s-api/sessions fixed headers links for the localized docs

### DIFF
--- a/src/content/docs/ja/api/s2s-api/sessions.mdx
+++ b/src/content/docs/ja/api/s2s-api/sessions.mdx
@@ -14,13 +14,13 @@ sidebar-label: S2Sセッション
 
 </Callout>
 
-## 事前準備 \{\#before\-you\-begin\}
+## 事前準備 {#before-you-begin}
 
 ### 認証 {#authentication}
 
 [サーバー間（S2S）セキュリティを設定](/ja/api/s2s-api/security)して、サーバー間 \(S2S\) セッションの計測を不正から守ります。そのためには、受信するリクエストごとに、Adjust管理画面で生成されたトークンが付与されている必要があります。トークンが付与されていないリクエスト、または不正なトークンが付与されたリクエストは、Adjustのサーバーによって拒否されます。
 
-## セッションを記録する \{\#record\-sessions\}
+## セッションを記録する {#record-sessions}
 
 Adjustはセッションをグループ化することでリソースを節約します。つまり、Adjustサーバーが新しいセッションをトリガーされたものとして受け取る前に、1つのセッション後に最低30分間の間隔がなければなりません。
 
@@ -81,7 +81,7 @@ https://s2s.adjust.com/session
 | `install_receipt`     | App Store、暗号化により署名されたインストールの受領証、iOSのみ。                                                                                                                    | `Super long string representation of the receipt` |
 | `ip_address`          | デバイスのIPアドレス。<br/>`ip_address`パラメーターではIPv4アドレスのみを受け付けます。IPv6は現在サポートされていません。                                                           | `ip_address=192.0.0.1`                            |
 
-## Googleに同意データを提供する（デジタル市情法へのコンプライアンス） \{\#provide\-consent\-data\-to\-google\-digital\-markets\-act\-compliance\}
+## Googleに同意データを提供する（デジタル市情法へのコンプライアンス） {#provide-consent-data-to-google-digital-markets-act-compliance}
 
 [EUのデジタル市場法（DMA）に準拠するため、](https://help.adjust.com/ja/article/google-compliancy-with-the-dma)Google 広告およびGoogle マーケティング プラットフォームは、AdjustからAPIへのアトリビューションリクエストを受信することに明示的な同意を必要とします。
 
@@ -102,7 +102,7 @@ Google 広告を使用している場合は`ad_personalization`パラメータ�
 | `ad_user_data`       | <ul><li>`1`: ユーザーが同意</li><li>`0`: ユーザーが同意しなかった</li></ul>                                                   | Googleに、ユーザーが個人データが計測目的で共有されることに同意したかどうかを通知します。<br/>この同意は、Google 広告およびGoogle マーケティング プラットフォームのUIで指定した全てのコアプラットフォームサービスCPSの広告主に適用されます。 |
 | `npa`                | <ul><li>`1`: ユーザーが同意</li><li>`0`: ユーザーが同意しなかった</li></ul>                                                   | アプリのインストール後に、Google マーケティング プラットフォームを介してパーソナライズされた広告を配信することにユーザーが同意したかどうかを通知します。                                                                                    |
 
-## 例 \{\#example\}
+## 例 {#example}
 
 <CodeBlock title="リクエスト">
 

--- a/src/content/docs/ko/api/s2s-api/sessions.mdx
+++ b/src/content/docs/ko/api/s2s-api/sessions.mdx
@@ -14,13 +14,13 @@ Adjust는 다음의 기능을 활성화해야 합니다. 자세한 정보는 담
 
 </Callout>
 
-## 시작에 앞서 \{\#before\-you\-begin\}
+## 시작에 앞서 {#before-you-begin}
 
 ### 인증 {#authentication}
 
 [S2S 보안을 설정](/ko/api/s2s-api/security)하여 S2S 세션의 보안을 보장하고, 스푸핑된 요청으로부터 보호할 수 있습니다. 이를 위해서는 수신되는 모든 요청에 Adjust 대시보드에서 생성된 인증 토큰이 포함되어야 합니다. 토큰이 포함되어 있지 않거나 올바르지 않은 토큰을 포함한 요청은 Adjust 서버에서 거부됩니다.
 
-## 세션 기록 \{\#record\-sessions\}
+## 세션 기록 {#record-sessions}
 
 Adjust는 리소스를 저장하기 위해 세션을 그룹화합니다. Adjust 서버가 새로운 세션이 트리거된 것으로 간주하려면, 세션 간 최소 30분의 간격이 있어야 합니다.
 
@@ -81,7 +81,7 @@ https://s2s.adjust.com/session
 | `install_receipt`     | 앱 스토어의 암호화 서명된 설치 영수증, iOS만 해당                                                                                                              | `Super long string representation of the receipt` |
 | `ip_address`          | 디바이스의 IP 주소.<br/>`ip_address` 파라미터는 IPv4 주소만 허용하며, IPv6은 현재 지원되지 않습니다.                                                           | `ip_address=192.0.0.1`                            |
 
-## Google에 동의 데이터 제공\(디지털 시장법 준수\) \{\#provide\-consent\-data\-to\-google\-digital\-markets\-act\-compliance\}
+## Google에 동의 데이터 제공(디지털 시장법 준수) {#provide-consent-data-to-google-digital-markets-act-compliance}
 
 [EU의 디지털 시장법\(DMA\)](https://help.adjust.com/ko/article/google-compliancy-with-the-dma)에 따라 Google Ads와 Google Marketing Platform은 API에 대한 Adjust의 어트리뷰션 요청을 수신하기 위해 명시적인 동의를 받아야 합니다.
 
@@ -102,7 +102,7 @@ Google Ads를 사용하는 경우 `ad_personalization` 파라미터를 전송하
 | `ad_user_data`       | <ul><li>`1`: 사용자가 동의함</li><li>`0`: 사용자가 동의하지 않음</li></ul>                                                  | 사용자가 측정 목적의 개인 정보 공유에 동의했는지 여부를 Google에 알려줍니다.<br/>해당 동의 정보는 광고주들이 Google Ads와 Google Marketing Platform UI에서 명시한 모든 Core Platform Services\(CPS\)에 적용됩니다. |
 | `npa`                | <ul><li>`1`: 사용자가 동의함</li><li>`0`: 사용자가 동의하지 않음</li></ul>                                                  | 사용자가 앱을 설치한 후 Google Marketing Platform을 통해 맞춤형 광고를 제공받는 데 동의했는지 여부를 알려줍니다.                                                                                                   |
 
-## 예 \{\#example\}
+## 예 {#example}
 
 <CodeBlock title="요청">
 

--- a/src/content/docs/zh/api/s2s-api/sessions.mdx
+++ b/src/content/docs/zh/api/s2s-api/sessions.mdx
@@ -14,13 +14,13 @@ Adjust 需要为您启用该功能。请联系您的技术客户经理或发送�
 
 </Callout>
 
-## 操作前须知 \{\#before\-you\-begin\}
+## 操作前须知 {#before-you-begin}
 
 ### 认证{#authentication}
 
 [设置 S2S 安全](/zh/api/s2s-api/security)来保护 S2S 会话的安全，抵御欺诈请求的侵害。设置认证后，每个传入的请求都必须带有您在 Adjust 控制面板中生成的认证识别码。缺失识别码或识别码不正确的请求会被 Adjust 服务器拒绝。
 
-## 记录会话\{\#record\-sessions\}
+## 记录会话{#record-sessions}
 
 Adjust 将会话归为组，以节省资源。也就是说，在一次会话后，必须有至少 30 分钟的间隔，Adjust 服务器才会将下一次触发的会话计为新会话。
 
@@ -81,7 +81,7 @@ https://s2s.adjust.com/session
 | `install_receipt`     | 来自 App Store 的加密签名安装收据，仅限 iOS                                                                     | `Super long string representation of the receipt` |
 | `ip_address`          | 设备 IP 地址`ip_address`参数仅接受 IPv4 地址。当前不支持 IPv6。                                                 | `ip_address=192.0.0.1`                            |
 
-## 向 Google 提供许可数据 \(《数字市场法案》合规\)\{\#provide\-consent\-data\-to\-google\-digital\-markets\-act\-compliance\}
+## 向 Google 提供许可数据 (《数字市场法案》合规){#provide-consent-data-to-google-digital-markets-act-compliance}
 
 要[符合欧盟的《数字市场法案》\(Digital Markets Act，简称 DMA\)](https://help.adjust.com/zh/article/google-compliancy-with-the-dma)，Google Ads 和 Google Marketing Platform 需要获得明确的用户许可，才能接收 Adjust 向其 API 发送的归因请求。
 
@@ -102,7 +102,7 @@ https://s2s.adjust.com/session
 | `ad_user_data`       | <ul><li>`1`: 用户已授权</li><li>`0`: 用户未授权</li></ul>                                 | 告知 Google 用户是否同意分享个人数据用于监测目的。该许可适用于广告主在 Google Ads 和 Google Marketing Platform 用户界面中指定的所有核心平台服务 \(CPS\)。 |
 | `npa`                | <ul><li>`1`: 用户已授权</li><li>`0`: 用户未授权</li></ul>                                 | 表明用户是否同意在安装应用后通过 Google Marketing Platform 被投放个性化广告。                                                                             |
 
-## 示例 \{\#example\}
+## 示例 {#example}
 
 <CodeBlock title="请求">
 


### PR DESCRIPTION
## Related issues

- Jira issue link: https://adjustcom.atlassian.net/browse/FECORE-628

## Changes

Fix for the localized versions of https://dev.adjust.com/en/api/s2s-api/sessions doc, to hide anchor links after headers
![image](https://github.com/user-attachments/assets/edaac57d-9bf3-43fc-8ff6-c240c5dbd672)
![image](https://github.com/user-attachments/assets/94a677e5-05d8-4064-af75-de8ba7cc2fde)
![image](https://github.com/user-attachments/assets/d5383c57-0fb6-4728-ac13-1e5ceebc8d4e)


