### PR TITLE
Added ability to disable AppTrackingTransparency.framework uage

### DIFF
--- a/src/content/docs/en/sdk/ios/v5/features/att.mdx
+++ b/src/content/docs/en/sdk/ios/v5/features/att.mdx
@@ -256,6 +256,7 @@ setupWebViewJavascriptBridge(function (bridge) {
    var environment = AdjustConfig.EnvironmentSandbox;
    var adjustConfig = new AdjustConfig(yourAppToken, environment);
    adjustConfig.disableAppTrackingTransparencyUsage();
+   Adjust.initSdk(adjustConfig)
 });
 ```
 

--- a/src/content/docs/en/sdk/ios/v5/features/att.mdx
+++ b/src/content/docs/en/sdk/ios/v5/features/att.mdx
@@ -240,6 +240,7 @@ NSString *environment = ADJEnvironmentSandbox;
 ADJConfig *adjustConfig = [[ADJConfig alloc] initWithAppToken:appToken
                                                 environment:environment];
 [adjustConfig disableAppTrackingTransparencyUsage];
+[Adjust initSdk:adjustConfig];
 ```
 
 </CodeBlock>

--- a/src/content/docs/en/sdk/ios/v5/features/att.mdx
+++ b/src/content/docs/en/sdk/ios/v5/features/att.mdx
@@ -200,7 +200,7 @@ Both of these endpoints are available for all [URL strategies](/en/sdk/ios/featu
 | India URL strategy      | `analytics.adjust.net.in` | `consent.adjust.net.in` |
 
 
-## Disable Apple's AppTrackingTransparency.framework Usage {#disable-att-framework}
+## Disable the usage of App Tracking Transparency {#disable-att-framework}
 
 <CodeBlock title="Method signature">
 

--- a/src/content/docs/en/sdk/ios/v5/features/att.mdx
+++ b/src/content/docs/en/sdk/ios/v5/features/att.mdx
@@ -239,7 +239,6 @@ NSString *yourAppToken = @"{YourAppToken}";
 NSString *environment = ADJEnvironmentSandbox;
 ADJConfig *adjustConfig = [[ADJConfig alloc] initWithAppToken:appToken
                                                 environment:environment];
-// ...
 [adjustConfig disableAppTrackingTransparencyUsage];
 ```
 

--- a/src/content/docs/en/sdk/ios/v5/features/att.mdx
+++ b/src/content/docs/en/sdk/ios/v5/features/att.mdx
@@ -238,7 +238,7 @@ adjustConfig?.disableAppTrackingTransparencyUsage()
 NSString *yourAppToken = @"{YourAppToken}";
 NSString *environment = ADJEnvironmentSandbox;
 ADJConfig *adjustConfig = [[ADJConfig alloc] initWithAppToken:appToken
-                                                environment:environment];
+                                                  environment:environment];
 [adjustConfig disableAppTrackingTransparencyUsage];
 [Adjust initSdk:adjustConfig];
 ```

--- a/src/content/docs/en/sdk/ios/v5/features/att.mdx
+++ b/src/content/docs/en/sdk/ios/v5/features/att.mdx
@@ -198,3 +198,68 @@ Both of these endpoints are available for all [URL strategies](/en/sdk/ios/featu
 | China URL strategy      | `analytics.adjust.world`  | `consent.adjust.world`  |
 | China only URL strategy | `analytics.adjust.cn`     | `consent.adjust.cn`     |
 | India URL strategy      | `analytics.adjust.net.in` | `consent.adjust.net.in` |
+
+
+## Disabling SDK's interaction with Apple's AppTrackingTransparency.framework API {#disable_att_framework}
+
+<CodeBlock title="Method signature">
+
+```objc
+- (void)disableAppTrackingTransparencyUsage;
+```
+
+</CodeBlock>
+
+In case you want to completely disable Adjust SDK's interaction with `AppTrackingTransparency.framework` you can configure the SDK accordingly by calling the `[ADJConfig disableAppTrackingTransparencyUsage]` method.
+
+<Tabs>
+<Tab title="Swift" sync="swift">
+
+<CodeBlock highlight="{range: 7}">
+
+```swift
+let yourAppToken = "{YourAppToken}"
+let environment = ADJEnvironmentSandbox
+let adjustConfig = ADJConfig(
+   appToken: yourAppToken,
+   environment: environment)
+// ...
+adjustConfig?.disableAppTrackingTransparencyUsage()
+```
+
+</CodeBlock>
+
+</Tab>
+<Tab title="Objective-C" sync="objc">
+
+<CodeBlock highlight="{range: 6}">
+
+```objc
+NSString *yourAppToken = @"{YourAppToken}";
+NSString *environment = ADJEnvironmentSandbox;
+ADJConfig *adjustConfig = [[ADJConfig alloc] initWithAppToken:appToken
+                                                environment:environment];
+// ...
+[adjustConfig disableAppTrackingTransparencyUsage];
+```
+
+</CodeBlock>
+
+</Tab>
+<Tab title="Javascript" sync="js">
+
+<CodeBlock highlight="{range: 5}">
+
+```js
+setupWebViewJavascriptBridge(function (bridge) {
+   var yourAppToken = yourAppToken;
+   var environment = AdjustConfig.EnvironmentSandbox;
+   var adjustConfig = new AdjustConfig(yourAppToken, environment);
+   adjustConfig.disableAppTrackingTransparencyUsage();
+});
+```
+
+</CodeBlock>
+
+</Tab>
+</Tabs>

--- a/src/content/docs/en/sdk/ios/v5/features/att.mdx
+++ b/src/content/docs/en/sdk/ios/v5/features/att.mdx
@@ -200,7 +200,7 @@ Both of these endpoints are available for all [URL strategies](/en/sdk/ios/featu
 | India URL strategy      | `analytics.adjust.net.in` | `consent.adjust.net.in` |
 
 
-## Disabling SDK's interaction with Apple's AppTrackingTransparency.framework API {#disable_att_framework}
+## Disable Apple's AppTrackingTransparency.framework Usage {#disable-att-framework}
 
 <CodeBlock title="Method signature">
 

--- a/src/content/docs/en/sdk/ios/v5/features/att.mdx
+++ b/src/content/docs/en/sdk/ios/v5/features/att.mdx
@@ -210,7 +210,7 @@ Both of these endpoints are available for all [URL strategies](/en/sdk/ios/featu
 
 </CodeBlock>
 
-In case you want to completely disable Adjust SDK's interaction with `AppTrackingTransparency.framework` you can configure the SDK accordingly by calling the `[ADJConfig disableAppTrackingTransparencyUsage]` method.
+In case you want to completely disable Adjust SDK's interaction with `AppTrackingTransparency.framework` call the `disableAppTrackingTransparencyUsage` method on your `ADJConfig` instance before SDK initialization.
 
 <Tabs>
 <Tab title="Swift" sync="swift">


### PR DESCRIPTION
## Related issues

- Jira issue link: https://adjustcom.atlassian.net/browse/SDK-2211

## Changes

Added ability to disable SDK's interaction with AppTrackingTransparency.framework API.

## Required translations

<!-- If your change affects SDK documentation, make sure you group your changes by localization requirement. For example, if you need to change iOS, Android, Unity, and React Native, you need to put the React Native changes in their own PR to split up the localization job. -->

| Platform                | ZH                 | JA                 | KO                 | EN
| ----------------------- | ------------------ | ------------------ | ------------------ | -----------------|
| iOS                     | :x: | :x: | :x: |✅ 
